### PR TITLE
Issue #46 - Update Nomenclature using non-trademarked wordings where possible

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -15,7 +15,7 @@ Editor: Michael B. Jones, Microsoft, mbj@microsoft.com
 Editor: Rolf Lindemann, Nok Nok Labs, rolf@noknok.com
 group: webauthn
 Ignored Vars: op, current.algorithm, alg
-Abstract: This specification defines an API that enables web pages to access WebAuth compliant strong cryptographic credentials through browser script. Conceptually, credentials are stored on a WebAuth authenticator, and each credential is bound to a single Relying Party. Authenticators are responsible for ensuring that no operation is performed without the user's consent. The user agent mediates access to credentials in order to preserve user privacy. Web Authentication uses the concept of attestation to provide a cryptographic proof of the authenticator model to the relying party.  The relying party can derive the authenticator security characteristics from this proof.
+Abstract: This specification defines an API that enables web pages to access WebAuthn compliant strong cryptographic credentials through browser script. Conceptually, credentials are stored on an authenticator, and each credential is bound to a single Relying Party. Authenticators are responsible for ensuring that no operation is performed without the user's consent. The user agent mediates access to credentials in order to preserve user privacy. Web Authentication uses the concept of attestation to provide a cryptographic proof of the authenticator model to the relying party.  The relying party can derive the authenticator security characteristics from this proof.
 Boilerplate: omit conformance, omit feedback-header
 Markup Shorthands: css off, markdown on
 </pre>
@@ -24,7 +24,7 @@ Markup Shorthands: css off, markdown on
 
   <em>This section is not normative.</em>
 
-  <p>This specification defines an API for web pages to access scoped credentials through JavaScript, for the purpose of strongly authenticating a user. Scoped credentials are always scoped to a single Relying Party, and the API respects this requirement. Credentials created by a Relying Party can only be accessed by web origins belonging to that Relying Party. Additionally, privacy across Relying Parties must be maintained; scripts must not be able to detect any properties, or even the existence, of credentials belonging to other Relying Parties.</p>
+  <p>This specification defines an API for web pages to access scoped credentials through JavaScript, for the purpose of strongly authenticating a user. Scoped credentials are always scoped to a single WebAuthn Relying Party, and the API respects this requirement. Credentials created by a Relying Party can only be accessed by web origins belonging to that Relying Party. Additionally, privacy across Relying Parties must be maintained; scripts must not be able to detect any properties, or even the existence, of credentials belonging to other Relying Parties.</p>
 
   <p>Scoped credentials are located on authenticators, which can use them to perform operations subject to user consent. Broadly, authenticators are of two types:</p>
 
@@ -42,7 +42,7 @@ Markup Shorthands: css off, markdown on
       <li>
         On the phone:
         <ul>
-          <li>User goes to example.com in the browser, and signs in using whatever method they have been using (possibly a pre-WebAuth method such as a password).</li>
+          <li>User goes to example.com in the browser, and signs in using whatever method they have been using (possibly a legacy method such as a password).</li>
           <li>The phone prompts, &quot;Do you want to register this device with example.com?&quot;</li>
           <li>User agrees.</li>
           <li>The phone prompts the user for a previously configured authorization gesture (PIN, biometric, etc.); the user provides this.</li>
@@ -95,7 +95,7 @@ Markup Shorthands: css off, markdown on
 
 # Conformance # {#conformance}
 
-  <p>This specification defines criteria for a <dfn>conforming user agent</dfn>. A user agent MUST behave as described in this specification in order to be considered conformant. User agents MAY implement algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's algorithms. A conforming Scoped Credential API user agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the “Web IDL” specification. [[!WebIDL-1]]</p>
+  <p>This specification defines criteria for a <dfn>conforming user agent</dfn>. A user agent MUST behave as described in this specification in order to be considered conformant. User agents MAY implement algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's algorithms. A conforming Web Authentication API user agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the “Web IDL” specification. [[!WebIDL-1]]</p>
   
 <!-- begin from signature-format -->
 <p> The term <b>Base64url Encoding</b> refers to the base64 encoding using the URL- and filename-safe character set defined in Section 5 of [[RFC4648]], with all trailing '=' characters omitted (as permitted by Section 3.2) and without the inclusion of any line breaks, whitespace, or other additional characters. This is the same encoding as used by JSON Web Signature (JWS) [[RFC7515]].</p>
@@ -122,13 +122,13 @@ Markup Shorthands: css off, markdown on
 
 
 
-# WebAuth Authenticator model # {#authenticator-model}
+# WebAuthn Authenticator model # {#authenticator-model}
   
-  <p>The API defined in this specification implies a specific abstract functional model for a WebAuth authenticator. This section describes the WebAuth authenticator model. Client platforms may implement and expose this abstract model in any way desired. However, the behavior of the client's Scoped Credential API implementation, when operating on the embedded and external authenticators supported by that platform, MUST be indistinguishable from the behavior specified in the <a href="#api">Scoped Credential API</a> section.</p>
+  <p>The API defined in this specification implies a specific abstract functional model for an authenticator. This section describes the authenticator model. Client platforms may implement and expose this abstract model in any way desired. However, the behavior of the client's Web Authentication API implementation, when operating on the embedded and external authenticators supported by that platform, MUST be indistinguishable from the behavior specified in the <a href="#api">Web Authentication API</a> section.</p>
   
-  <p>In this abstract model, each WebAuth authenticator stores some number of scoped credentials. Each scoped credential has an identifier which is unique (or extremely unlikely to be duplicated) among all scoped credentials. Each credential is also associated with a Relying Party, whose identity is represented by a Relying Party Identifier (RP ID).</p>
+  <p>In this abstract model, each authenticator stores some number of scoped credentials. Each scoped credential has an identifier which is unique (or extremely unlikely to be duplicated) among all scoped credentials. Each credential is also associated with a WebAuthn Relying Party, whose identity is represented by a Relying Party Identifier (RP ID).</p>
   
-  <p>A client must connect to a WebAuth authenticator in order to invoke any of the operations of that authenticator. This connection defines an authenticator session. A WebAuth authenticator must maintain isolation between sessions. It may do this by only allowing one session to exist at any particular time, or by providing more complicated session management.</p>
+  <p>A client must connect to an authenticator in order to invoke any of the operations of that authenticator. This connection defines an authenticator session. An authenticator must maintain isolation between sessions. It may do this by only allowing one session to exist at any particular time, or by providing more complicated session management.</p>
   
   <p>The following operations can be invoked by the client in an authenticator session.</p>
   
@@ -174,7 +174,7 @@ Markup Shorthands: css off, markdown on
 
 
 
-# Scoped Credential API # {#api}
+# Web Authentication API # {#api}
 
   <p>This section normatively specifies the API for creating and using scoped credentials. Support for deleting credentials is deliberately omitted; this is expected to be done through platform-specific user interfaces rather than from a script. The basic idea is that the credentials belong to the user and are managed by the browser and underlying platform. Scripts can (with the user&apos;s consent) request the browser to create a new credential for future use by the script's origin. Scripts can also request the user’s permission to perform authentication operations with an existing credential held by the platform. However, all such operations are mediated by the browser and/or platform on the user&apos;s behalf. At no point does the script get access to the credentials themselves; it only gets information about the credentials in the form of objects.</p>
 
@@ -184,7 +184,7 @@ Markup Shorthands: css off, markdown on
 
   <pre class="idl">
   partial interface Window {
-      readonly attribute WebAuthentication webauth;
+      readonly attribute WebAuthentication webauthn;
   };
 
   interface WebAuthentication {
@@ -194,14 +194,14 @@ Markup Shorthands: css off, markdown on
           DOMString                               attestationChallenge,
           optional unsigned long                  credentialTimeoutSeconds,
           optional sequence < Credential >        blacklist,
-          optional WebAuthExtensions              credentialExtensions
+          optional WebAuthnExtensions             credentialExtensions
       );
 
-      Promise < WebAuthAssertion > getAssertion (
+      Promise < WebAuthnAssertion > getAssertion (
           DOMString                        assertionChallenge,
           optional unsigned long           assertionTimeoutSeconds,
           optional sequence < Credential > whitelist,
-          optional WebAuthExtensions       assertionExtensions
+          optional WebAuthnExtensions      assertionExtensions
       );
   };
 
@@ -225,7 +225,7 @@ Markup Shorthands: css off, markdown on
   };
 
   enum CredentialType {
-      "ScopedUserCredential"
+      "ScopedCred"
   };
 
   interface Credential {
@@ -233,7 +233,7 @@ Markup Shorthands: css off, markdown on
       readonly attribute DOMString      id;
   };
 
-  dictionary WebAuthExtensions {
+  dictionary WebAuthnExtensions {
   };
   </pre>
 
@@ -372,7 +372,7 @@ Markup Shorthands: css off, markdown on
 
             <li>If any authenticator returns an error status, delete the corresponding entry from <var>issuedRequests</var>.</li>
 
-            <li>If any authenticator returns success, create a new {{WebAuthAssertion}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <code>value</code> and terminate this algorithm.</li>
+            <li>If any authenticator returns success, create a new {{WebAuthnAssertion}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <code>value</code> and terminate this algorithm.</li>
           </ol>
         </li>
 
@@ -386,7 +386,7 @@ Markup Shorthands: css off, markdown on
 ## <dfn interface>ScopedCredentialInfo</dfn> Interface ## {#iface-credentialInfo}
 
     <div dfn-for="ScopedCredentialInfo">
-      <p>This interface represents a newly-created scoped credential. It contains information about the credential that can be used to locate it later for use, and also contains metadata that can be used by the Relying Party to assess the strength of the credential during registration.</p>
+      <p>This interface represents a newly-created scoped credential. It contains information about the credential that can be used to locate it later for use, and also contains metadata that can be used by the WebAuthn Relying Party to assess the strength of the credential during registration.</p>
 
       <p>The <dfn>credential</dfn> attribute contains a unique identifier for the credential represented by this object.</p>
 
@@ -432,9 +432,9 @@ Markup Shorthands: css off, markdown on
 ### Credential Type enumeration (enum <dfn enum>CredentialType</dfn>) ### {#credentialType}
 
       <div dfn-for="CredentialType">
-        <p>This enumeration defines the valid credential types. It is an extension point; values may be added to it in the future, as more credential types are defined. The values of this enumeration are used for versioning the WebAuth assertion and attestation statement according to the type of the authenticator.</p>
+        <p>This enumeration defines the valid credential types. It is an extension point; values may be added to it in the future, as more credential types are defined. The values of this enumeration are used for versioning the WebAuthn assertion and attestation statement according to the type of the authenticator.</p>
 
-        <p>Currently one credential type is defined, namely &quot;<dfn>ScopedUserCredential</dfn>&quot;.</p>
+        <p>Currently one credential type is defined, namely &quot;<dfn>ScopedCred</dfn>&quot;.</p>
       </div>
 
 
@@ -454,12 +454,12 @@ Markup Shorthands: css off, markdown on
       <p>A string or dictionary identifying a cryptographic algorithm and optionally a set of parameters for that algorithm. This type is defined in [[!WebCryptoAPI]].</p>
 
 
-### WebAuth Assertion (interface {{WebAuthAssertion}}) ### {#iface-assertion}
+### WebAuthn Assertion (interface {{WebAuthnAssertion}}) ### {#iface-assertion}
 
-      <p>Scoped credentials produce a cryptographic signature that provides proof of possession of a private key as well as evidence of user consent to a specific transaction. The structure of these signatures is defined in [[#webauth-assertion]].</p>
+      <p>Scoped credentials produce a cryptographic signature that provides proof of possession of a private key as well as evidence of user consent to a specific transaction. The structure of these signatures is defined in [[#webauthn-assertion]].</p>
 
 
-### WebAuth Assertion Extensions (dictionary <dfn>WebAuthExtensions</dfn>) ### {#iface-assertion-extensions}
+### WebAuthn Assertion Extensions (dictionary <dfn>WebAuthExtensions</dfn>) ### {#iface-assertion-extensions}
 
       <p>This is a dictionary containing zero or more extensions as defined in [[#extensions]]. An extension is an additional parameter that can be passed to the <a>getAssertion()</a> method and triggers some additional processing by the client platform and/or the authenticator.</p>
 
@@ -473,7 +473,7 @@ Markup Shorthands: css off, markdown on
 
 ### Key Attestation Statement (interface <dfn>AttestationStatement</dfn>) ### {#iface-attestation-statement}
 
-      <p>WebAuth authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each credential public key, attestation information that can be verified by a Relying Party. Typically this information contains a signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information providing provenance information for the attesting key, enabling a trust decision to be made. The structure of these attestation statements is defined in [[#attestation]].</p>
+      <p>Authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each credential public key, attestation information that can be verified by a WebAuthn Relying Party. Typically this information contains a signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information providing provenance information for the attesting key, enabling a trust decision to be made. The structure of these attestation statements is defined in [[#attestation]].</p>
 
 
 <!-- Included from signature-format.html -->
@@ -481,14 +481,14 @@ Markup Shorthands: css off, markdown on
 # Signature Format # {#signature-format}
 
 
-<p>WebAuth signatures are bound to various contextual data. These data are
+<p>WebAuthn signatures are bound to various contextual data. These data are
 observed, and added at different levels of the stack as a signature request
 passes from the server to the authenticator. In verifying a signature, the
 server checks these bindings against expected values.</p>
 
-<p>The components of a system using WebAuth can be divided into three layers:</p>
+<p>The components of a system using WebAuthn can be divided into three layers:</p>
 <ol>
-  <li>The relying party (RP), which uses the WebAuth services.
+  <li>The relying party (RP), which uses the WebAuthn services.
   The relying party may, for
   example, be a web-application running in a browser, or a native application
   that runs directly on the OS platform.</li>
@@ -500,7 +500,7 @@ server checks these bindings against expected values.</p>
 </ol>
 
 <p>When the RP client-side application is a web-application, the interface between 1 and 2
-is the <a href="#api">Scoped Credential API</a>, but is platform specific for native applications.
+is the <a href="#api">Web Authentication API</a>, but is platform specific for native applications.
 In cases where the authenticator is not tightly integrated with the platform, the interface
 between 2 and 3 is a separately-defined protocol.
 This specification defines the common signature format
@@ -564,7 +564,7 @@ of this hash, and its own authenticator data.</p>
     <dt>JsonWebKey <dfn>tokenBinding</dfn></dt>
     <dd>
       A JsonWebKey object [[JWK]] describing the public key that this client uses for
-      the Token Binding protocol when communicating with the Relying Party.
+      the Token Binding protocol when communicating with the WebAuthn Relying Party.
       This can be omitted if no Token Binding has been negotiated between the
       client and the Relying Party.
     </dd>
@@ -596,7 +596,7 @@ of this hash, and its own authenticator data.</p>
   </ol>
 
   <p>The <var>clientDataHash</var> value is incorporated into a signature
-  by a WebAuth authenticator (see <a href="#authenticator-signature"></a>).
+  by an authenticator (see <a href="#authenticator-signature"></a>).
   It is delivered to integrated authenticators
   in platform specific manners, and to external authenticators as a part of
   a signature request.
@@ -697,13 +697,13 @@ of this hash, and its own authenticator data.</p>
     the raw signature back to the client.
   </p>
 
-## Client encoding of assertions ## {#webauth-assertion}
+## Client encoding of assertions ## {#webauthn-assertion}
 
   <p>The client platform uses an authenticator assertion to construct
-  the final {{WebAuth assertion}} object returned to the RP as follows.</p>
+  the final {{WebAuthn assertion}} object returned to the RP as follows.</p>
 
   <pre class="idl">
-  interface WebAuthAssertion {
+  interface WebAuthnAssertion {
 	  attribute Credential credential;
 	  attribute DOMString  clientData;
 	  attribute DOMString  authenticatorData;
@@ -711,7 +711,7 @@ of this hash, and its own authenticator data.</p>
   };
   </pre>
   
-  <div dfn-for="WebAuthAssertion">
+  <div dfn-for="WebAuthnAssertion">
   <dl>
     <dt>attribute Credential <dfn>credential</dfn></dt>
     <dd>
@@ -735,7 +735,7 @@ of this hash, and its own authenticator data.</p>
   </dl>
 
   <p>This assertion is delivered to the RP in either a platform specific manner, or
-  in the case of web applications, according to the Scoped Credential API ([[#api]]).
+  in the case of web applications, according to the Web Authentication API ([[#api]]).
   It contains all the information that the RP's server requires to
   reconstruct the signature base string, as well as to decode and validate
   the bindings of both the client- and authenticator data.</p>
@@ -747,7 +747,7 @@ of this hash, and its own authenticator data.</p>
 # Key Attestation Format # {#attestation}
 
     This specification defines generic data structures that cover the
-	semantics of WebAuth Authenticator attestation. This specification also 
+	semantics of authenticator attestation. This specification also 
 	provides a profile of these structures when a TPM [[TPM]] acts as a crypto kernel. 
 	More profiles are expected to be added as the specification
 	evolves.
@@ -756,7 +756,7 @@ of this hash, and its own authenticator data.</p>
 
 ### Attestation Models ### {#attestation-models}
       
-	<p>WebAuth specifies multiple attestation models:</p>
+	<p>WebAuthn supports multiple attestation models:</p>
 	<dl>
 	  <dt>Full Basic Attestation</dt>
 	  <dd>In the case of full basic attestation [[UAFProtocol]], the Authenticator's attestation private key is
@@ -789,7 +789,7 @@ of this hash, and its own authenticator data.</p>
 	  <dd>In this case, the Authenticator receives DAA credentials from a single DAA-Issuer.
 	    These DAA credentials are used along with blinding to sign the attestation data.
 	    The concept of blinding avoids the DAA credentials being misused as global correlation handle.
-	    <p>WebAuth supports DAA using elliptic curve cryptography and bilinear pairings, 
+	    <p>WebAuthn supports DAA using elliptic curve cryptography and bilinear pairings, 
 	      called ECDAA (see [[FIDOEcdaaAlgorithm]]) in this specification.</p>
 	  </dd>
 	</dl>
@@ -801,14 +801,14 @@ of this hash, and its own authenticator data.</p>
 
 ### Contextual Data ### {#attestation-contextual-data}
 
-	<p>WebAuth attestation statements are bound to various contextual data. These data are
+	<p>WebAuthn attestation statements are bound to various contextual data. These data are
 	  observed, and added at different levels of the stack as a signature request
 	  passes from the server to the authenticator. In verifying a signature, the
 	  server checks these bindings against expected values.</p>
 	
 	<p>These components can be divided into three layers:</p>
 	<ol>
-	  <li>The relying party (RP) consists of two subcomponents: an online
+	  <li>The WebAuthn relying party (RP) consists of two subcomponents: an online
 	    service and a client-side application. The client-side app may, for
 	    example, be a web application running in a browser, or a native application
 	    that runs directly on the OS platform.</li>
@@ -852,7 +852,7 @@ of this hash, and its own authenticator data.</p>
 ### Attestation Raw Data Types ### {#attestation-raw-data-types}
 
 	<p>
-	  WebAuth specifies pluggable attestation raw data types, i.e., 
+	  WebAuthn supports pluggable attestation raw data types, i.e., 
 	  ways to serialize the data being attested to by the authenticator.
 	  The reason is to be able to support existing devices like TPMs and other
 	  platform-specific formats.
@@ -990,7 +990,7 @@ interface AttestationHeader {
 	<dl dfn-for="AttestationHeader">
 	  <dt>readonly attribute DOMString <dfn>claimedAAGUID</dfn></dt>
 	  <dd>The claimed Authenticator Attestation GUID (a version 4 GUID, see [[RFC4122]]).  
-	    This value is used by the server to 
+	    This value is used by the WebAuthn Relying Party to 
 	    lookup the trust anchor for verifying this AttestationCore object.  
 	    If the verification succeeds, 
 	    the AAGUID related to the trust anchor is trusted.  This field MUST be present, if either no
@@ -1010,9 +1010,9 @@ interface AttestationHeader {
 ## Defined Attestation Raw Data Types ## {#defined-attestation-raw-data-types}
 	<p>
 	  Attestation Raw Data (<code>rawData</code>) is the to-be-signed object of
-	  the attestation statement. WebAuth supports pluggable attestation data types.
+	  the attestation statement. WebAuthn supports pluggable attestation data types.
 	  This allows support of TPM generated attestation data as well as support of
-	  other WebAuth authenticators.
+	  other WebAuthn authenticators.
 	</p>
 	<p>
 	  The contents of the attestation data must be controlled (i.e., generated or
@@ -1021,7 +1021,7 @@ interface AttestationHeader {
 
 ### Packed Attestation ### {#packed-attestation}
 
-	  Packed attestation is a WebAuth optimized format of attestation data.  It uses a very compact but 
+	  Packed attestation is a WebAuthn optimized format of attestation data.  It uses a very compact but 
 	  still extensible encoding method.  Encoding this format can even be implemented by authenticators
 	  with very limited resources (e.g., secure elements).
 
@@ -1150,7 +1150,7 @@ interface AttestationHeader {
 
 	  <dl>
 		<dt>Extension identifier</dt>
-		<dd><code>webauth.aaguid</code></dd>
+		<dd><code>webauthn.aaguid</code></dd>
 		
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
@@ -1193,7 +1193,7 @@ interface AttestationHeader {
 ##### SupportedExtensions Extension ##### {#supported-extensions-extension}
 	  <dl>
 		<dt>Extension identifier</dt>
-		<dd><code>webauth.exts</code></dd>		
+		<dd><code>webauthn.exts</code></dd>		
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
 		
@@ -1216,7 +1216,7 @@ interface AttestationHeader {
 ##### User Verification Index (UVI) Extension ##### {#uvi-extension}
 	  <dl>
 		<dt>Extension identifier</dt>
-		<dd><code>webauth.uvi</code></dd>
+		<dd><code>webauthn.uvi</code></dd>
 		
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
@@ -1254,15 +1254,15 @@ interface AttestationHeader {
 		    </p>
 		    <p>Example for rawData containing one UVI extension</p>
   <pre>
-  F1 D0                                -- This is a WebAuth packed rawData object
-  81                                   -- TUP and ED set
-  00 00 00 01                          -- (initial) signature counter
-  ...                                  -- all public key alg etc.
-  A1                                   -- extension: CBOR map of one element
-    6B                                 -- Key 1: CBOR text string of 11 bytes
-      77 65 62 61 75 74 68 2E 75 76 69 -- "webauth.uvi" UTF-8 string
-    58 20                              -- Value 1: CBOR byte string with 0x20 bytes
-    00 43 B8 E3 BE 27 95 8C            -- the UVI value itself
+  F1 D0                                   -- This is a WebAuthn packed rawData object
+  81                                      -- TUP and ED set
+  00 00 00 01                             -- (initial) signature counter
+  ...                                     -- all public key alg etc.
+  A1                                      -- extension: CBOR map of one element
+    6C                                    -- Key 1: CBOR text string of 12 bytes
+      77 65 62 61 75 74 68 6E 2E 75 76 69 -- "webauthn.uvi" UTF-8 string
+    58 20                                 -- Value 1: CBOR byte string with 0x20 bytes
+    00 43 B8 E3 BE 27 95 8C               -- the UVI value itself
     28 D5 74 BF 46 8A 85 CF
     46 9A 14 F0 E5 16 69 31
     DA 4B CF FF C1 BB 11 32
@@ -1350,12 +1350,12 @@ interface AttestationHeader {
 	    <p>
               If <code>attestationStatement.core.version</code> equals 1, (i.e., for
               TPM 1.2), RSASSA-PKCS1-v1_5 signature algorithm (section 8.2 of
-              [[RFC3447]]) can be used by WebAuth Authenticators (i.e.
+              [[RFC3447]]) can be used by WebAuthn Authenticators (i.e.
               <code>attestationStatement.header.alg</code>="RS256").
 	    </p>
 	    <p>
               If <code>attestationStatement.core.version</code> equals 2, the
-              following algorithms can be used by WebAuth Authenticators:
+              following algorithms can be used by WebAuthn Authenticators:
 	    </p>
 		
 	    <ol>
@@ -1598,7 +1598,7 @@ dictionary AndroidAttestationClientData : ClientData {
 		chains up to a trusted root (following [[RFC5280]]).
 	      </li>
 	      <li>Verify that the attestation certificate has the right Extended Key Usage (EKU) based
-		on the WebAuth Authenticator type (as denoted by the <code>header.type</code> member). In case of a
+		on the WebAuthn Authenticator type (as denoted by the <code>header.type</code> member). In case of a
 		type="tpm", this EKU shall be OID "2.23.133.8.3".
 	      </li>
 	      <li>If the attestation type is "android", verify that the attestation certificate is issued 
@@ -1689,19 +1689,19 @@ dictionary AndroidAttestationClientData : ClientData {
 	  be mitigated in several ways, including:
 	</p>
 	<ul>
-	  <li>A WebAuth Authenticator manufacturer may choose to ship all of their devices with
+	  <li>A WebAuthn Authenticator manufacturer may choose to ship all of their devices with
 	    the same (or a fixed number of) attestation key(s) (called Full Basic Attestation). This will
 	    anonymize the user at the risk of not being able to revoke a
-	    particular attestation key should its WebAuth Authenticator be compromised.
+	    particular attestation key should its WebAuthn Authenticator be compromised.
 	  </li>
-	  <li>A WebAuth Authenticator may be capable of dynamically generating different attestation keys
+	  <li>A WebAuthn Authenticator may be capable of dynamically generating different attestation keys
 	    (and requesting related certificates) per origin (following the Privacy CA model). 
-	    For example, a WebAuth Authenticator can ship with a master 
+	    For example, a WebAuthn Authenticator can ship with a master 
 	    attestation key (and certificate), and
 	    combined with a cloud operated privacy CA, can dynamically generate per origin
 	    attestation keys and attestation certificates.
 	  </li>
-	  <li>A WebAuth Authenticator can implement direct anonymous 
+	  <li>A WebAuthn Authenticator can implement direct anonymous 
 	    attestation (see [[FIDOEcdaaAlgorithm]]).  Using this scheme the authenticator
 	    generates a blinded attestation signature.  This allows the relying party to verify 
 	    the signature using the DAA root key, but the attestation signature doesn't 
@@ -1712,23 +1712,23 @@ dictionary AndroidAttestationClientData : ClientData {
 ### Attestation Certificate and Attestation Certificate CA Compromise ### {#ca-compromise}
 
 	<p>When an intermediate CA or a root CA used for issuing attestation
-	  certificates is compromised, WebAuth Authenticator attestation keys are still
+	  certificates is compromised, WebAuthn Authenticator attestation keys are still
 	  safe although their certificates can no longer be trusted. A
-	  WebAuth Authenticator manufacturer that has recorded the public attestation keys
+	  WebAuthn Authenticator manufacturer that has recorded the public attestation keys
 	  for their devices can issue new attestation certificates for
 	  these keys from a new intermediate CA or from a new root CA.
 	  If the root CA changes, the relying parties must update their trusted 
 	  root certificates accordingly.
 	</p>
-	<p>A WebAuth Authenticator attestation certificate must be revoked by the issuing CA
-	  if its key has been compromised. A WebAuth Authenticator manufacturer may need to
+	<p>A WebAuthn Authenticator attestation certificate must be revoked by the issuing CA
+	  if its key has been compromised. A WebAuthn Authenticator manufacturer may need to
 	  ship a firmware update and inject new attestation keys and
-	  certificates into already manufactured WebAuth Authenticators, if
+	  certificates into already manufactured WebAuthn Authenticators, if
 	  the exposure was due to a firmware flaw.
 	  (The process by which this happens is out of scope for this specification.)
 	  No further valid
-	  attestation statements can be made by the affected WebAuth Authenticators unless
-	  the WebAuth Authenticator manufacturer has this capability.
+	  attestation statements can be made by the affected WebAuthn Authenticators unless
+	  the WebAuthn Authenticator manufacturer has this capability.
 	</p>
 	<p>If attestation certificate validation fails due to a revoked
 	  intermediate attestation CA certificate, and relying party policy requires rejecting
@@ -1754,21 +1754,21 @@ dictionary AndroidAttestationClientData : ClientData {
 	<p>A 3 tier hierarchy for attestation certificates is recommended 
 	  (i.e., Attestation Root, Attestation Issuing CA, Attestation Certificate). 
 	  It is also recommended that
-	  for each WebAuth Authenticator device line (i.e., model), a separate issuing CA is used to help
+	  for each WebAuthn Authenticator device line (i.e., model), a separate issuing CA is used to help
 	  facilitate isolating problems with a specific version of a device.
 	</p>
 	<p>If the attestation root certificate is <em>not</em> dedicated 
-	  to a single WebAuth Authenticator device line (i.e., AAGUID),
+	  to a single WebAuthn Authenticator device line (i.e., AAGUID),
 	  the AAGUID must be specified either in the attestation certificate itself or 
 	  as an extension in the <code>core.rawData</code>.
 	</p>
 
 <!-- End of include from key-attestation.html -->
 
-# WebAuth Extensions # {#extensions}
+# WebAuthn Extensions # {#extensions}
 <p>
   The mechanism for generating scoped credentials, as well as requesting and
-  generating WebAuth assertions, as defined in [[#api]],
+  generating WebAuthn assertions, as defined in [[#api]],
   can be extended to suit particular use cases. Each case is
   addressed by defining a <em>registration extension</em> and/or a
   <em>signature extension</em>. Extensions can define additions to the
@@ -1821,7 +1821,7 @@ dictionary AndroidAttestationClientData : ClientData {
   <p>
   Extensions are identified by a string, chosen by the extension author. Extension identifiers
   should aim to be globally unique, e.g., by using reverse domain-name of the defining entity such
-  as <code>com.example.webauth.myextension</code>.
+  as <code>com.example.webauthn.myextension</code>.
   </p>
 
   <p>
@@ -1830,7 +1830,7 @@ dictionary AndroidAttestationClientData : ClientData {
   </p>
 
   <p>
-  Standard extensions defined in this specification use a fixed prefix of <code>webauth.</code>
+  Standard extensions defined in this specification use a fixed prefix of <code>webauthn.</code>
   for the extension identifiers. This prefix should not be used for 3rd party extensions.
   </p>
 
@@ -1881,7 +1881,7 @@ dictionary AndroidAttestationClientData : ClientData {
 
   <pre class="example highlight">
   var assertionPromise = credentials.getAssertion(..., /* extensions */ {
-    "com.example.webauth.foobar": 42
+    "com.example.webauthn.foobar": 42
   });
   </pre>
 
@@ -1966,7 +1966,7 @@ dictionary AndroidAttestationClientData : ClientData {
   </p>
 
   <p>
-    The extension identifier is chosen as <code>com.example.webauth.geo</code>.
+    The extension identifier is chosen as <code>com.example.webauthn.geo</code>.
     The client argument is the constant value <code>true</code>, since the
     extension does not require the RP to pass any particular information to the
     client, other than that it requests the use of the extension. The RP sets
@@ -1976,7 +1976,7 @@ dictionary AndroidAttestationClientData : ClientData {
   var assertionPromise =
       credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
           {}, /* Empty filter */
-          { 'com.example.webauth.geo': true });
+          { 'com.example.webauthn.geo': true });
   </pre>
 
   <p>
@@ -1987,7 +1987,7 @@ dictionary AndroidAttestationClientData : ClientData {
   {
      ...,
      'extensions': {
-         'com.example.webauth.geo': {
+         'com.example.webauthn.geo': {
              'type': 'Point',
              'coordinates': [65.059962, -13.993041]
          }
@@ -2009,14 +2009,14 @@ dictionary AndroidAttestationClientData : ClientData {
   </p>
 
   <pre>
-  81 (hex)                             -- Flags, ED and TUP both set.
-  20 05 58 1F                          -- Signature counter
-  A1                                   -- CBOR map of one element
-    6B                                 -- Key 1: CBOR text string of 11 bytes
-      77 65 62 61 75 74 68 2e 67 65 6f -- "webauth.geo" UTF-8 string
-    82                                 -- Value 1: CBOR array of two elements
-      FA 42 82 1E B3                   -- Element 1: Latitude as CBOR encoded float
-      FA C1 5F E3 7F                   -- Element 2: Longitude as CBOR encoded float
+  81 (hex)                                -- Flags, ED and TUP both set.
+  20 05 58 1F                             -- Signature counter
+  A1                                      -- CBOR map of one element
+    6C                                    -- Key 1: CBOR text string of 12 bytes
+      77 65 62 61 75 74 68 6E 2E 67 65 6F -- "webauthn.geo" UTF-8 string
+    82                                    -- Value 1: CBOR array of two elements
+      FA 42 82 1E B3                      -- Element 1: Latitude as CBOR encoded float
+      FA C1 5F E3 7F                      -- Element 2: Longitude as CBOR encoded float
   </pre>
 
 
@@ -2037,7 +2037,7 @@ dictionary AndroidAttestationClientData : ClientData {
   <dl>
     <dt>Extension identifier</dt>
     <dd>
-      <code>webauth.txauth.simple</code> 
+      <code>webauthn.txauth.simple</code> 
     </dd>
     <dt>Client argument</dt>
     <dd>A single UTF-8 encoded string <em>prompt</em></dd>
@@ -2062,7 +2062,7 @@ dictionary AndroidAttestationClientData : ClientData {
   <dl>
     <dt>Extension identifier</dt>
     <dd>
-      <code>webauth.txauth.generic</code>
+      <code>webauthn.txauth.generic</code>
     </dd>
 
     <dt>Client argument</dt>
@@ -2106,7 +2106,7 @@ dictionary AndroidAttestationClientData : ClientData {
   <dl>
     <dt>Extension identifier</dt>
     <dd>
-      <code>webauth.authn-sel</code> (only used during {{makeCredential()}})
+      <code>webauthn.authn-sel</code> (only used during {{makeCredential()}})
     </dd>
     <dt>Client argument</dt>
     <dd>
@@ -2299,9 +2299,9 @@ typedef DOMString AAGUID;
 
 
     <pre class="example highlight">
-    var webauthAPI = window.webauth;
+    var webauthnAPI = window.webauthn;
 
-    if (!webauthAPI) { /* Platform not capable. Handle error. */ }
+    if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
     var userAccountInformation = {
       rpDisplayName: "Acme",
@@ -2315,23 +2315,22 @@ typedef DOMString AAGUID;
     // prefers an ES256 credential.
     var cryptoParams = [
       {
-        type: "ScopedUserCredential",
+        type: "ScopedCred",
         algorithm: "ES256"
       },
       {
-        type: "ScopedUserCredential",
+        type: "ScopedCred",
         algorithm: "RS256"
       }
     ];
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
     var blacklist = [];  // No blacklist
-    var extensions = {"webauth.location": true};  // Include location information
-                                                  // in attestation
-
+    var extensions = {"webauthn.location": true};  // Include location information
+                                                   // in attestation
 
     // Note: The following call will cause the authenticator to display UI.
-    webauthAPI.makeCredential(userAccountInformation, cryptoParams, challenge,
+    webauthnAPI.makeCredential(userAccountInformation, cryptoParams, challenge,
                            timeoutSeconds, blacklist, extensions)
       .then(function (newCredentialInfo) {
         // Send new credential info to server for verification and registration.
@@ -2346,7 +2345,7 @@ typedef DOMString AAGUID;
 
     <ol type ="1">
       <li>The user visits example.com, which serves up a script.</li>
-      <li>The script asks the client platform for a WebAuth identity assertion, providing as much information as possible to narrow the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after registration, or by other means such as prompting the user for a username.</li>
+      <li>The script asks the client platform for a WebAuthn identity assertion, providing as much information as possible to narrow the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after registration, or by other means such as prompting the user for a username.</li>
       <li>The Relying Party script runs one of the code snippets below.</li>
       <li>The client platform searches for and locates the external authenticator.</li>
       <li>The client platform connects to the external authenticator, performing any pairing actions if necessary.</li>
@@ -2366,15 +2365,15 @@ typedef DOMString AAGUID;
     <p>If the Relying Party script does not have any hints available (e.g., from locally stored data) to help it narrow the list of credentials, then the sample code for performing such an authentication might look like this:</p>
 
     <pre class="example highlight">
-    var webauthAPI = window.webauth;
+    var webauthnAPI = window.webauthn;
 
-    if (!webauthAPI) { /* Platform not capable. Handle error. */ }
+    if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
-    var whitelist = [{ type: "ScopedUserCredential" }];
+    var whitelist = [{ type: "ScopedCred" }];
 
-    webauthAPI.getAssertion(challenge, timeoutSeconds, whitelist)
+    webauthnAPI.getAssertion(challenge, timeoutSeconds, whitelist)
       .then(function (assertion) {
         // Send assertion to server for verification
     }).catch(function (err) {
@@ -2385,25 +2384,25 @@ typedef DOMString AAGUID;
     <p>On the other hand, if the Relying Party script has some hints to help it narrow the list of credentials, then the sample code for performing such an authentication might look like the following. Note that this sample also demonstrates how to use the extension for transaction authorization.</p>
 
     <pre class="example highlight">
-    var webauthAPI = window.webauth;
+    var webauthnAPI = window.webauthn;
 
-    if (!webauthAPI) { /* Platform not capable. Handle error. */ }
+    if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
     var acceptableCredential1 = {
-      type: "ScopedUserCredential",
+      type: "ScopedCred",
       id: "ISEhISEhIWhpIHRoZXJlISEhISEhIQo="
     };
     var acceptableCredential2 = {
-      type: "ScopedUserCredential",
+      type: "ScopedCred",
       id: "cm9zZXMgYXJlIHJlZCwgdmlvbGV0cyBhcmUgYmx1ZQo="
     };
     var whitelist = [acceptableCredential1, acceptableCredential2];
-    var extensions = { 'webauth.txauth.simple':
+    var extensions = { 'webauthn.txauth.simple':
                        "Wave your hands in the air like you just don't care" };
 
-    webauthAPI.getAssertion(challenge, timeoutSeconds, whitelist, extensions)
+    webauthnAPI.getAssertion(challenge, timeoutSeconds, whitelist, extensions)
       .then(function (assertion) {
         // Send assertion to server for verification
     }).catch(function (err) {

--- a/index.src.html
+++ b/index.src.html
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: FIDO 2.0: Web API for accessing FIDO 2.0 credentials
+Title: Web Authentication: A Web API for accessing scoped credentials
 Status: ED
 TR: http://www.w3.org/TR/webauthn/
 ED: http://w3c.github.io/webauthn/
@@ -15,7 +15,7 @@ Editor: Michael B. Jones, Microsoft, mbj@microsoft.com
 Editor: Rolf Lindemann, Nok Nok Labs, rolf@noknok.com
 group: webauthn
 Ignored Vars: op, current.algorithm, alg
-Abstract: This specification defines an API that enables web pages to access FIDO 2.0 compliant strong cryptographic credentials through browser script. Conceptually, credentials are stored on a FIDO 2.0 authenticator, and each credential is bound to a single Relying Party. Authenticators are responsible for ensuring that no operation is performed without the user's consent. The user agent mediates access to credentials in order to preserve user privacy. FIDO uses the concept of attestation to provide a cryptographic proof of the authenticator model to the relying party.  The relying party can derive the authenticator security characteristics from this proof.
+Abstract: This specification defines an API that enables web pages to access WebAuth compliant strong cryptographic credentials through browser script. Conceptually, credentials are stored on a WebAuth authenticator, and each credential is bound to a single Relying Party. Authenticators are responsible for ensuring that no operation is performed without the user's consent. The user agent mediates access to credentials in order to preserve user privacy. Web Authentication uses the concept of attestation to provide a cryptographic proof of the authenticator model to the relying party.  The relying party can derive the authenticator security characteristics from this proof.
 Boilerplate: omit conformance, omit feedback-header
 Markup Shorthands: css off, markdown on
 </pre>
@@ -24,16 +24,16 @@ Markup Shorthands: css off, markdown on
 
   <em>This section is not normative.</em>
 
-  <p>This specification defines an API for web pages to access FIDO 2.0 credentials through JavaScript, for the purpose of strongly authenticating a user. FIDO 2.0 credentials are always bound to a single FIDO Relying Party, and the API respects this requirement. Credentials created by a Relying Party can only be accessed by web origins belonging to that Relying Party. Additionally, privacy across Relying Parties must be maintained; scripts must not be able to detect any properties, or even the existence, of credentials belonging to other Relying Parties.</p>
+  <p>This specification defines an API for web pages to access scoped credentials through JavaScript, for the purpose of strongly authenticating a user. Scoped credentials are always scoped to a single Relying Party, and the API respects this requirement. Credentials created by a Relying Party can only be accessed by web origins belonging to that Relying Party. Additionally, privacy across Relying Parties must be maintained; scripts must not be able to detect any properties, or even the existence, of credentials belonging to other Relying Parties.</p>
 
-  <p>FIDO 2.0 credentials are located on authenticators, which can use them to perform operations subject to user consent. Broadly, authenticators are of two types:</p>
+  <p>Scoped credentials are located on authenticators, which can use them to perform operations subject to user consent. Broadly, authenticators are of two types:</p>
 
   <ol>
     <li><dfn>Embedded authenticators</dfn> have their operation managed by the same computing device (e.g., smart phone, tablet, desktop PC) as the user agent is running on. For instance, such an authenticator might consist of a Trusted Platform Module (TPM) or Secure Element (SE) integrated into the computing device, along with appropriate platform software to mediate access to this device's functionality.</li>
     <li><dfn>External authenticators</dfn> operate autonomously from the device running the user agent, and accessed over a transport such as Universal Serial Bus (USB), Bluetooth Low Energy (BLE) or Near Field Communications (NFC).</li>
   </ol>
 
-  <p>Note that an external authenticator may itself contain an embedded authenticator. For example, consider a smart phone that contains a FIDO 2.0 credential. The credential may be accessed by a web browser running on the phone itself. In this case the module containing the credential is functioning as an embedded authenticator. However, the credential may also be accessed over BLE by a user agent on a nearby laptop. In this latter case, the phone is functioning as an external authenticator. These modes may even be used in a single end-to-end user scenario. One such scenario is described in the remainder of this section.</p>
+  <p>Note that an external authenticator may itself contain an embedded authenticator. For example, consider a smart phone that contains a scoped credential. The credential may be accessed by a web browser running on the phone itself. In this case the module containing the credential is functioning as an embedded authenticator. However, the credential may also be accessed over BLE by a user agent on a nearby laptop. In this latter case, the phone is functioning as an external authenticator. These modes may even be used in a single end-to-end user scenario. One such scenario is described in the remainder of this section.</p>
 
 
 ## Registration (embedded authenticator mode) ## {#registration-embedded}
@@ -42,7 +42,7 @@ Markup Shorthands: css off, markdown on
       <li>
         On the phone:
         <ul>
-          <li>User goes to example.com in the browser, and signs in using whatever method they have been using (possibly a pre-FIDO method such as a password).</li>
+          <li>User goes to example.com in the browser, and signs in using whatever method they have been using (possibly a pre-WebAuth method such as a password).</li>
           <li>The phone prompts, &quot;Do you want to register this device with example.com?&quot;</li>
           <li>User agrees.</li>
           <li>The phone prompts the user for a previously configured authorization gesture (PIN, biometric, etc.); the user provides this.</li>
@@ -89,13 +89,13 @@ Markup Shorthands: css off, markdown on
 
     <ul>
       <li>User goes to example.com on their laptop, is guided through a flow to create and register a credential on their phone.</li>
-      <li>User employs a FIDO 2.0 credential as described above to authorize a single transaction, such as a payment or other financial transaction.</li>
+      <li>User employs a scoped credential as described above to authorize a single transaction, such as a payment or other financial transaction.</li>
     </ul>
 
 
 # Conformance # {#conformance}
 
-  <p>This specification defines criteria for a <dfn>conforming user agent</dfn>. A user agent MUST behave as described in this specification in order to be considered conformant. User agents MAY implement algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's algorithms. A conforming FIDO Credential API user agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the “Web IDL” specification. [[!WebIDL-1]]</p>
+  <p>This specification defines criteria for a <dfn>conforming user agent</dfn>. A user agent MUST behave as described in this specification in order to be considered conformant. User agents MAY implement algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's algorithms. A conforming Scoped Credential API user agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the “Web IDL” specification. [[!WebIDL-1]]</p>
   
 <!-- begin from signature-format -->
 <p> The term <b>Base64url Encoding</b> refers to the base64 encoding using the URL- and filename-safe character set defined in Section 5 of [[RFC4648]], with all trailing '=' characters omitted (as permitted by Section 3.2) and without the inclusion of any line breaks, whitespace, or other additional characters. This is the same encoding as used by JSON Web Signature (JWS) [[RFC7515]].</p>
@@ -122,13 +122,13 @@ Markup Shorthands: css off, markdown on
 
 
 
-# FIDO Authenticator model # {#authenticator-model}
+# WebAuth Authenticator model # {#authenticator-model}
   
-  <p>The API defined in this specification implies a specific abstract functional model for a FIDO authenticator. This section describes the FIDO authenticator model. Client platforms may implement and expose this abstract model in any way desired. However, the behavior of the client's FIDO Credential API implementation, when operating on the embedded and external authenticators supported by that platform, MUST be indistinguishable from the behavior specified in the <a href="#api">FIDO Credential API</a> section.</p>
+  <p>The API defined in this specification implies a specific abstract functional model for a WebAuth authenticator. This section describes the WebAuth authenticator model. Client platforms may implement and expose this abstract model in any way desired. However, the behavior of the client's Scoped Credential API implementation, when operating on the embedded and external authenticators supported by that platform, MUST be indistinguishable from the behavior specified in the <a href="#api">Scoped Credential API</a> section.</p>
   
-  <p>In this abstract model, each FIDO authenticator stores some number of FIDO credentials. Each FIDO credential has an identifier which is unique (or extremely unlikely to be duplicated) among all FIDO credentials. Each credential is also associated with a FIDO Relying Party, whose identity is represented by a Relying Party Identifier (RP ID).</p>
+  <p>In this abstract model, each WebAuth authenticator stores some number of scoped credentials. Each scoped credential has an identifier which is unique (or extremely unlikely to be duplicated) among all scoped credentials. Each credential is also associated with a Relying Party, whose identity is represented by a Relying Party Identifier (RP ID).</p>
   
-  <p>A client must connect to a FIDO authenticator in order to invoke any of the operations of that authenticator. This connection defines an authenticator session. A FIDO authenticator must maintain isolation between sessions. It may do this by only allowing one session to exist at any particular time, or by providing more complicated session management.</p>
+  <p>A client must connect to a WebAuth authenticator in order to invoke any of the operations of that authenticator. This connection defines an authenticator session. A WebAuth authenticator must maintain isolation between sessions. It may do this by only allowing one session to exist at any particular time, or by providing more complicated session management.</p>
   
   <p>The following operations can be invoked by the client in an authenticator session.</p>
   
@@ -146,7 +146,7 @@ Markup Shorthands: css off, markdown on
     
     <p>On successful completion of this operation, the authenticator returns the type and unique identifier of this new credential to the user agent.</p>
 
-    <p>If the user refuses consent, the authenticator returns an  appropriate error status to the client.</p>
+    <p>If the user refuses consent, the authenticator returns an appropriate error status to the client.</p>
 
 ## The <dfn>authenticatorGetAssertion</dfn> operation ## {#op-get-assertion}
 
@@ -174,78 +174,76 @@ Markup Shorthands: css off, markdown on
 
 
 
-# FIDO Credential API # {#api}
+# Scoped Credential API # {#api}
 
-  <p>This section normatively specifies the API for creating and using FIDO 2.0 credentials. Support for deleting credentials is deliberately omitted; this is expected to be done through platform-specific user interfaces rather than from a script. The basic idea is that the credentials belong to the user and are managed by the browser and underlying platform. Scripts can (with the user&apos;s consent) request the browser to create a new credential for future use by the script's origin. Scripts can also request the user’s permission to perform authentication operations with an existing credential held by the platform. However, all such operations are mediated by the browser and/or platform on the user&apos;s behalf. At no point does the script get access to the credentials themselves; it only gets information about the credentials in the form of objects.</p>
+  <p>This section normatively specifies the API for creating and using scoped credentials. Support for deleting credentials is deliberately omitted; this is expected to be done through platform-specific user interfaces rather than from a script. The basic idea is that the credentials belong to the user and are managed by the browser and underlying platform. Scripts can (with the user&apos;s consent) request the browser to create a new credential for future use by the script's origin. Scripts can also request the user’s permission to perform authentication operations with an existing credential held by the platform. However, all such operations are mediated by the browser and/or platform on the user&apos;s behalf. At no point does the script get access to the credentials themselves; it only gets information about the credentials in the form of objects.</p>
 
   <p>User agents SHOULD only expose this API to callers in <dfn>secure contexts</dfn>, as defined in [[powerful-features]].</p>
-
-  <p>In the future, this API may be integrated into a more general Web API framework for credential management, which is being worked on in the W3C. Such integration will, most likely, create intermediate interface and dictionary types, from which the types in this specification will then inherit. However the experience of the FIDO developer and end user will not be substantially changed by this. In the meantime, this specification is maintained in a more minimal form for ease of review.</p>
 
   <p>The API is defined by the following Web IDL fragment.</p>
 
   <pre class="idl">
-  partial interface Window { 
-      readonly attribute FIDOCredentials fido; 
-  }; 
-   
-  interface FIDOCredentials { 
-      Promise < FIDOCredentialInfo > makeCredential ( 
-          Account                               accountInformation, 
-          sequence < FIDOCredentialParameters > cryptoParameters, 
-          DOMString                             attestationChallenge,
-          optional unsigned long                credentialTimeoutSeconds,
-          optional sequence < Credential >      blacklist,
-          optional FIDOExtensions               credentialExtensions
-      ); 
-   
-      Promise < FIDOAssertion > getAssertion ( 
+  partial interface Window {
+      readonly attribute WebAuthentication webauth;
+  };
+
+  interface WebAuthentication {
+      Promise < ScopedCredentialInfo > makeCredential (
+          Account                                 accountInformation,
+          sequence < ScopedCredentialParameters > cryptoParameters,
+          DOMString                               attestationChallenge,
+          optional unsigned long                  credentialTimeoutSeconds,
+          optional sequence < Credential >        blacklist,
+          optional WebAuthExtensions              credentialExtensions
+      );
+
+      Promise < WebAuthAssertion > getAssertion (
           DOMString                        assertionChallenge,
           optional unsigned long           assertionTimeoutSeconds,
-          optional sequence < Credential > whitelist, 
-          optional FIDOExtensions          assertionExtensions 
-      ); 
-  }; 
-   
-  interface FIDOCredentialInfo { 
-      readonly attribute Credential           credential; 
-      readonly attribute any                  publicKey; 
-      readonly attribute AttestationStatement attestation; 
-  }; 
-
-  dictionary Account { 
-      required DOMString rpDisplayName; 
-      required DOMString displayName; 
-      DOMString          name; 
-      DOMString          id; 
-      DOMString          imageUri; 
+          optional sequence < Credential > whitelist,
+          optional WebAuthExtensions       assertionExtensions
+      );
   };
-   
-  dictionary FIDOCredentialParameters { 
-      required CredentialType        type; 
-      required AlgorithmIdentifier   algorithm; 
-  }; 
 
-  enum CredentialType { 
-      "FIDO" 
-  }; 
-
-  interface Credential { 
-      readonly attribute CredentialType type; 
-      readonly attribute DOMString      id; 
+  interface ScopedCredentialInfo {
+      readonly attribute Credential           credential;
+      readonly attribute any                  publicKey;
+      readonly attribute AttestationStatement attestation;
   };
-  
-  dictionary FIDOExtensions {
+
+  dictionary Account {
+      required DOMString rpDisplayName;
+      required DOMString displayName;
+      DOMString          name;
+      DOMString          id;
+      DOMString          imageUri;
+  };
+
+  dictionary ScopedCredentialParameters {
+      required CredentialType        type;
+      required AlgorithmIdentifier   algorithm;
+  };
+
+  enum CredentialType {
+      "ScopedUserCredential"
+  };
+
+  interface Credential {
+      readonly attribute CredentialType type;
+      readonly attribute DOMString      id;
+  };
+
+  dictionary WebAuthExtensions {
   };
   </pre>
 
-## <dfn interface>FIDOCredentials</dfn> Interface ## {#iface-credential}
+## <dfn interface>WebAuthentication</dfn> Interface ## {#iface-credential}
 
     <p>This interface consists of the following methods.</p>
 
-### Create a new credential (<dfn method for="FIDOCredentials">makeCredential()</dfn> method) ### {#makeCredential}
+### Create a new credential (<dfn method for="WebAuthentication">makeCredential()</dfn> method) ### {#makeCredential}
 
-      <p>With this method, a script can request the user agent to create a new credential of a given type and persist it to the underlying platform, which may involve data storage managed by the browser or the OS. The user agent will prompt the user to approve this operation. On success, the promise will be resolved with a {{FIDOCredentialInfo}} object describing the newly created credential.</p>
+      <p>With this method, a script can request the user agent to create a new credential of a given type and persist it to the underlying platform, which may involve data storage managed by the browser or the OS. The user agent will prompt the user to approve this operation. On success, the promise will be resolved with a {{ScopedCredentialInfo}} object describing the newly created credential.</p>
 
       <p>This method takes the following parameters:</p>
 
@@ -305,7 +303,7 @@ Markup Shorthands: css off, markdown on
             <li>If any authenticator returns a status indicating that the user cancelled the operation, delete that authenticator's entry from <var>issuedRequests</var>. For each remaining entry in <var>issuedRequests</var> invoke the <a><code>authenticatorCancel</code></a> operation on that authenticator and remove its entry from the list.</li>
 
             <li>If any authenticator returns an error status, delete the corresponding entry from <var>issuedRequests</var>.</li>
-            <li>If any authenticator indicates success, create a new {{FIDOCredentialInfo}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <var>value</var> and terminate this algorithm.</li>
+            <li>If any authenticator indicates success, create a new {{ScopedCredentialInfo}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <var>value</var> and terminate this algorithm.</li>
           </ol>
         </li>
 
@@ -318,9 +316,9 @@ Markup Shorthands: css off, markdown on
 
 
 
-### Use an existing credential (<dfn method for="FIDOCredentials">getAssertion()</dfn> method) ### {#getAssertion}
+### Use an existing credential (<dfn method for="WebAuthentication">getAssertion()</dfn> method) ### {#getAssertion}
 
-      <p>This method is used to discover and use an existing FIDO 2.0 credential, with the user's consent. The script optionally specifies some criteria to indicate what credentials are acceptable to it. The user agent and/or platform locates credentials matching the specified criteria, and guides the user to pick one that the script should be allowed to use. The user may choose not to provide a credential even if one is present, for example to maintain privacy.</p>
+      <p>This method is used to discover and use an existing scoped credential, with the user's consent. The script optionally specifies some criteria to indicate what credentials are acceptable to it. The user agent and/or platform locates credentials matching the specified criteria, and guides the user to pick one that the script should be allowed to use. The user may choose not to provide a credential even if one is present, for example to maintain privacy.</p>
 
       <p>This method takes the following parameters:</p>
 
@@ -374,7 +372,7 @@ Markup Shorthands: css off, markdown on
 
             <li>If any authenticator returns an error status, delete the corresponding entry from <var>issuedRequests</var>.</li>
 
-            <li>If any authenticator returns success, create a new {{FIDOAssertion}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <code>value</code> and terminate this algorithm.</li>
+            <li>If any authenticator returns success, create a new {{WebAuthAssertion}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <code>value</code> and terminate this algorithm.</li>
           </ol>
         </li>
 
@@ -385,10 +383,10 @@ Markup Shorthands: css off, markdown on
       <p>During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and authorizing an authenticator with which to complete the operation.</p>
 
 
-## <dfn interface>FIDOCredentialInfo</dfn> Interface ## {#iface-credentialInfo}
+## <dfn interface>ScopedCredentialInfo</dfn> Interface ## {#iface-credentialInfo}
 
-    <div dfn-for="FIDOCredentialInfo">
-      <p>This interface represents a newly-created FIDO credential. It contains information about the credential that can be used to locate it later for use, and also contains metadata that can be used by the FIDO Relying Party to assess the strength of the credential during registration.</p>
+    <div dfn-for="ScopedCredentialInfo">
+      <p>This interface represents a newly-created scoped credential. It contains information about the credential that can be used to locate it later for use, and also contains metadata that can be used by the Relying Party to assess the strength of the credential during registration.</p>
 
       <p>The <dfn>credential</dfn> attribute contains a unique identifier for the credential represented by this object.</p>
 
@@ -416,9 +414,9 @@ Markup Shorthands: css off, markdown on
     </div>
 
 
-## Parameters for Credential Generation (dictionary <dfn dictionary>FIDOCredentialParameters</dfn>) ## {#credential-params}
+## Parameters for Credential Generation (dictionary <dfn dictionary>ScopedCredentialParameters</dfn>) ## {#credential-params}
 
-    <div dfn-for="FIDOCredentialParameters">
+    <div dfn-for="ScopedCredentialParameters">
       <p>This dictionary is used to supply additional parameters when creating a new credential.</p>
 
       <p>The <dfn>type</dfn> member specifies the type of credential to be created.</p>
@@ -429,14 +427,14 @@ Markup Shorthands: css off, markdown on
 
 ## Supporting Data Structures ## {#supporting-data-structures}
   
-    The FIDO credential type uses certain data structures that are specified in supporting specifications. These are as follows.
+    The scoped credential type uses certain data structures that are specified in supporting specifications. These are as follows.
 
 ### Credential Type enumeration (enum <dfn enum>CredentialType</dfn>) ### {#credentialType}
 
       <div dfn-for="CredentialType">
-        <p>This enumeration defines the valid credential types. It is an extension point; values may be added to it in the future, as more credential types are defined. The values of this enumeration are used for versioning the FIDO assertion and attestation statement according to the type of the authenticator.</p>
+        <p>This enumeration defines the valid credential types. It is an extension point; values may be added to it in the future, as more credential types are defined. The values of this enumeration are used for versioning the WebAuth assertion and attestation statement according to the type of the authenticator.</p>
 
-        <p>Currently one credential type is defined, namely &quot;<dfn>FIDO</dfn>&quot;, the FIDO 2.0 credential type.</p>
+        <p>Currently one credential type is defined, namely &quot;<dfn>ScopedUserCredential</dfn>&quot;.</p>
       </div>
 
 
@@ -456,41 +454,41 @@ Markup Shorthands: css off, markdown on
       <p>A string or dictionary identifying a cryptographic algorithm and optionally a set of parameters for that algorithm. This type is defined in [[!WebCryptoAPI]].</p>
 
 
-### FIDO Assertion (interface {{FIDOAssertion}}) ### {#iface-assertion}
+### WebAuth Assertion (interface {{WebAuthAssertion}}) ### {#iface-assertion}
 
-      <p>FIDO 2.0 credentials produce a cryptographic signature that provides proof of possession of a private key as well as evidence of user consent to a specific transaction. The structure of these signatures is defined in [[#fido-assertion]].</p>
+      <p>Scoped credentials produce a cryptographic signature that provides proof of possession of a private key as well as evidence of user consent to a specific transaction. The structure of these signatures is defined in [[#webauth-assertion]].</p>
 
 
-### FIDO Assertion Extensions (dictionary <dfn>FIDOExtensions</dfn>) ### {#iface-assertion-extensions}
+### WebAuth Assertion Extensions (dictionary <dfn>WebAuthExtensions</dfn>) ### {#iface-assertion-extensions}
 
       <p>This is a dictionary containing zero or more extensions as defined in [[#extensions]]. An extension is an additional parameter that can be passed to the <a>getAssertion()</a> method and triggers some additional processing by the client platform and/or the authenticator.</p>
 
       <p>
         If the caller wants to pass extensions to the platform, it SHOULD do so by adding one
-        entry per extension to this <code>FIDOExtensions</code> dictionary with 
+        entry per extension to this <code>WebAuthExtensions</code> dictionary with
         the extension identifier as the key, and the extension's value as the value
-        (see [[#signature-format]] for details).  
+        (see [[#signature-format]] for details).
       </p>
 
 
 ### Key Attestation Statement (interface <dfn>AttestationStatement</dfn>) ### {#iface-attestation-statement}
 
-      <p>FIDO 2.0 authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each credential public key, attestation information that can be verified by a Relying Party. Typically this information contains a signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information providing provenance information for the attesting key, enabling a trust decision to be made. The structure of these attestation statements is defined in [[#attestation]].</p>
+      <p>WebAuth authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each credential public key, attestation information that can be verified by a Relying Party. Typically this information contains a signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information providing provenance information for the attesting key, enabling a trust decision to be made. The structure of these attestation statements is defined in [[#attestation]].</p>
 
 
 <!-- Included from signature-format.html -->
 
 # Signature Format # {#signature-format}
-	  
 
-<p>FIDO 2.0 signatures are bound to various contextual data. These data are
+
+<p>WebAuth signatures are bound to various contextual data. These data are
 observed, and added at different levels of the stack as a signature request
 passes from the server to the authenticator. In verifying a signature, the
 server checks these bindings against expected values.</p>
 
-<p>The components of a system using FIDO 2.0 can be divided into three layers:</p>
+<p>The components of a system using WebAuth can be divided into three layers:</p>
 <ol>
-  <li>The relying party (RP), which uses the FIDO 2.0 services.
+  <li>The relying party (RP), which uses the WebAuth services.
   The relying party may, for
   example, be a web-application running in a browser, or a native application
   that runs directly on the OS platform.</li>
@@ -502,7 +500,7 @@ server checks these bindings against expected values.</p>
 </ol>
 
 <p>When the RP client-side application is a web-application, the interface between 1 and 2
-is the <a href="#api">FIDO Credential API</a>, but is platform specific for native applications.
+is the <a href="#api">Scoped Credential API</a>, but is platform specific for native applications.
 In cases where the authenticator is not tightly integrated with the platform, the interface
 between 2 and 3 is a separately-defined protocol.
 This specification defines the common signature format
@@ -598,7 +596,7 @@ of this hash, and its own authenticator data.</p>
   </ol>
 
   <p>The <var>clientDataHash</var> value is incorporated into a signature
-  by a FIDO authenticator (see <a href="#authenticator-signature"></a>).
+  by a WebAuth authenticator (see <a href="#authenticator-signature"></a>).
   It is delivered to integrated authenticators
   in platform specific manners, and to external authenticators as a part of
   a signature request.
@@ -699,13 +697,13 @@ of this hash, and its own authenticator data.</p>
     the raw signature back to the client.
   </p>
 
-## Client encoding of assertions ## {#fido-assertion}
+## Client encoding of assertions ## {#webauth-assertion}
 
   <p>The client platform uses an authenticator assertion to construct
-  the final {{FIDO assertion}} object returned to the RP as follows.</p>
+  the final {{WebAuth assertion}} object returned to the RP as follows.</p>
 
   <pre class="idl">
-  interface FIDOAssertion {
+  interface WebAuthAssertion {
 	  attribute Credential credential;
 	  attribute DOMString  clientData;
 	  attribute DOMString  authenticatorData;
@@ -713,7 +711,7 @@ of this hash, and its own authenticator data.</p>
   };
   </pre>
   
-  <div dfn-for="FIDOAssertion">
+  <div dfn-for="WebAuthAssertion">
   <dl>
     <dt>attribute Credential <dfn>credential</dfn></dt>
     <dd>
@@ -737,8 +735,8 @@ of this hash, and its own authenticator data.</p>
   </dl>
 
   <p>This assertion is delivered to the RP in either a platform specific manner, or
-  in the case of web applications, according to the FIDO Web API ([[#api]]).
-  It contains all the information that the RP's FIDO server requires to
+  in the case of web applications, according to the Scoped Credential API ([[#api]]).
+  It contains all the information that the RP's server requires to
   reconstruct the signature base string, as well as to decode and validate
   the bindings of both the client- and authenticator data.</p>
 <!-- End of include from signature-format.html -->
@@ -749,7 +747,7 @@ of this hash, and its own authenticator data.</p>
 # Key Attestation Format # {#attestation}
 
     This specification defines generic data structures that cover the
-	semantics of FIDO Authenticator attestation. This specification also 
+	semantics of WebAuth Authenticator attestation. This specification also 
 	provides a profile of these structures when a TPM [[TPM]] acts as a crypto kernel. 
 	More profiles are expected to be added as the specification
 	evolves.
@@ -758,7 +756,7 @@ of this hash, and its own authenticator data.</p>
 
 ### Attestation Models ### {#attestation-models}
       
-	<p>FIDO 2.0 specifies multiple attestation models:</p>
+	<p>WebAuth specifies multiple attestation models:</p>
 	<dl>
 	  <dt>Full Basic Attestation</dt>
 	  <dd>In the case of full basic attestation [[UAFProtocol]], the Authenticator's attestation private key is
@@ -781,7 +779,7 @@ of this hash, and its own authenticator data.</p>
 	    attestation certificate for it. 
 	    <p>Using this approach, the Authenticator can limit the exposure of the 
 	      endorsement key (which is a global correlation handle) to Privacy CA(s).
-	      Attestation keys can be requested for each FIDO credential individually.
+	      Attestation keys can be requested for each scoped credential individually.
 	    </p>
 	    <p class="note">This concept typically leads to multiple attestation certificates.
 	      The attestation certificate requested most recently is called "active".
@@ -791,11 +789,11 @@ of this hash, and its own authenticator data.</p>
 	  <dd>In this case, the Authenticator receives DAA credentials from a single DAA-Issuer.
 	    These DAA credentials are used along with blinding to sign the attestation data.
 	    The concept of blinding avoids the DAA credentials being misused as global correlation handle.
-	    <p>FIDO 2.0 supports DAA using elliptic curve cryptography and bilinear pairings, 
+	    <p>WebAuth supports DAA using elliptic curve cryptography and bilinear pairings, 
 	      called ECDAA (see [[FIDOEcdaaAlgorithm]]) in this specification.</p>
 	  </dd>
 	</dl>
-	<p>Compliant FIDO Servers MUST support all attestation models.  
+	<p>Compliant servers MUST support all attestation models.  
 	  Authenticators can choose what attestation model to implement.
 	</p>
 	<p class="note">Relying parties can always decide what attestation models are acceptable by policy.
@@ -803,7 +801,7 @@ of this hash, and its own authenticator data.</p>
 
 ### Contextual Data ### {#attestation-contextual-data}
 
-	<p>FIDO 2.0 attestation statements are bound to various contextual data. These data are
+	<p>WebAuth attestation statements are bound to various contextual data. These data are
 	  observed, and added at different levels of the stack as a signature request
 	  passes from the server to the authenticator. In verifying a signature, the
 	  server checks these bindings against expected values.</p>
@@ -854,7 +852,7 @@ of this hash, and its own authenticator data.</p>
 ### Attestation Raw Data Types ### {#attestation-raw-data-types}
 
 	<p>
-	  FIDO specifies pluggable attestation raw data types, i.e., 
+	  WebAuth specifies pluggable attestation raw data types, i.e., 
 	  ways to serialize the data being attested to by the authenticator.
 	  The reason is to be able to support existing devices like TPMs and other
 	  platform-specific formats.
@@ -924,7 +922,7 @@ interface AttestationStatement {
 	</dl>
 	
 	<p>This attestation statement is delivered to the RP according to the Client API.
-	  It contains all the information that the RP's FIDO server requires to
+	  It contains all the information that the RP's server requires to
 	  reconstruct the signature base string, as well as to decode and validate
 	  the bindings of both the client- and authenticator data.
 	</p>
@@ -992,7 +990,7 @@ interface AttestationHeader {
 	<dl dfn-for="AttestationHeader">
 	  <dt>readonly attribute DOMString <dfn>claimedAAGUID</dfn></dt>
 	  <dd>The claimed Authenticator Attestation GUID (a version 4 GUID, see [[RFC4122]]).  
-	    This value is used by the FIDO Server to 
+	    This value is used by the server to 
 	    lookup the trust anchor for verifying this AttestationCore object.  
 	    If the verification succeeds, 
 	    the AAGUID related to the trust anchor is trusted.  This field MUST be present, if either no
@@ -1005,16 +1003,16 @@ interface AttestationHeader {
 	  <dt>readonly attribute DOMString <dfn>alg</dfn></dt>
 	  <dd>The name of the algorithm used to generate the attestation signature according to [[!RFC7518]].  
 	    <p>See [[#packed-attestation-signature]] for the signature algorithms 
-	      to be implemented by FIDO Servers.</p>
+	      to be implemented by servers.</p>
 	  </dd>
 	</dl>
 
 ## Defined Attestation Raw Data Types ## {#defined-attestation-raw-data-types}
 	<p>
 	  Attestation Raw Data (<code>rawData</code>) is the to-be-signed object of
-	  the attestation statement. FIDO supports pluggable attestation data types.
+	  the attestation statement. WebAuth supports pluggable attestation data types.
 	  This allows support of TPM generated attestation data as well as support of
-	  other FIDO authenticators.
+	  other WebAuth authenticators.
 	</p>
 	<p>
 	  The contents of the attestation data must be controlled (i.e., generated or
@@ -1023,7 +1021,7 @@ interface AttestationHeader {
 
 ### Packed Attestation ### {#packed-attestation}
 
-	  Packed attestation is a FIDO optimized format of attestation data.  It uses a very compact but 
+	  Packed attestation is a WebAuth optimized format of attestation data.  It uses a very compact but 
 	  still extensible encoding method.  Encoding this format can even be implemented by authenticators
 	  with very limited resources (e.g., secure elements).
 
@@ -1038,10 +1036,10 @@ interface AttestationHeader {
 	    <p>For this type, only version="1" is defined at this time.</p>
 
 	    <p>The field <code>rawData</code> is the <b>base64url encoding of the byte array</b>.
-	      The encoding of attestation data (for type "packed") is a byte array 
-	      of 45 bytes + length of public key + length of KeyHandle + potentially more extensions. 
+	      The encoding of attestation data (for type "packed") is a byte array
+	      of 45 bytes + length of public key + length of KeyHandle + potentially more extensions.
 	      The first bytes before the extensions have a fixed layout as follows:</p>
-		  
+
 	    <table class="complex data longlastcol">
 	      <tr>
 		<th>Length (in bytes)</th>
@@ -1050,7 +1048,7 @@ interface AttestationHeader {
 	      <tr>
 		<td>2</td>
 		<td>0xF1D0, fixed big-endian TAG to make sure this object won't be 
-		  confused with other (non-FIDO) binary objects.</td>
+		  confused with other (non-WebAuth) binary objects.</td>
 	      </tr>
 	      <tr>
 		<td>1</td>
@@ -1071,25 +1069,25 @@ interface AttestationHeader {
 		<td>2</td>
 		<td>
 		  Public key algorithm and encoding (16-bit big-endian value).
-		  Allowed values are: 
+		  Allowed values are:
 		  <ol>
 		    <li>0x0100. This is raw ANSI X9.62 formatted Elliptic Curve public key [[!SEC1]].
-		      <p>I.e., <code>[0x04, X (n bytes), Y (n bytes)]</code>.  Where the 
-			byte <code>0x04</code> denotes the uncompressed point compression method 
+		      <p>I.e., <code>[0x04, X (n bytes), Y (n bytes)]</code>.  Where the
+			byte <code>0x04</code> denotes the uncompressed point compression method
 			and n denotes the key length in bytes.</p>
-		    </li>	  
-		    <li>0x0102.  Raw encoded RSA PKCS1 or 
+		    </li>
+		    <li>0x0102.  Raw encoded RSA PKCS1 or
 		      RSASSA-PSS public key [[RFC3447]].
-		      <p>In the case of RSASSA-PSS, the default parameters according 
+		      <p>In the case of RSASSA-PSS, the default parameters according
 			to [[RFC4055]] MUST be assumed, i.e.,
 			<ul>
 			  <li>Mask Generation Algorithm MGF1 with SHA256</li>
 			  <li>Salt Length of 32 bytes, i.e., the length of a SHA256 hash value.</li>
-			  <li>Trailer Field value of 1, which represents the trailer field with 
+			  <li>Trailer Field value of 1, which represents the trailer field with
 			    hexadecimal value <code>0xBC</code>.
 			</ul>
 		      </p>
-		      <p>That is, <code>[modulus (256 bytes), e (m-n bytes)]</code>.  
+		      <p>That is, <code>[modulus (256 bytes), e (m-n bytes)]</code>.
 			Where <code>m</code> is the total length of the field.</p>
 		      <p>This total length should be taken from the object containing this key</p>
 		    </li>
@@ -1098,7 +1096,7 @@ interface AttestationHeader {
 	      </tr>
 	      <tr>
 		<td>2</td>
-		<td>Byte length m of following public key bytes (16 bit value 
+		<td>Byte length m of following public key bytes (16 bit value
 		  with most significant byte first).
 		</td>
 	      </tr>
@@ -1152,7 +1150,7 @@ interface AttestationHeader {
 
 	  <dl>
 		<dt>Extension identifier</dt>
-		<dd><code>fido.aaguid</code></dd>
+		<dd><code>webauth.aaguid</code></dd>
 		
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
@@ -1195,7 +1193,7 @@ interface AttestationHeader {
 ##### SupportedExtensions Extension ##### {#supported-extensions-extension}
 	  <dl>
 		<dt>Extension identifier</dt>
-		<dd><code>fido.exts</code></dd>		
+		<dd><code>webauth.exts</code></dd>		
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
 		
@@ -1218,7 +1216,7 @@ interface AttestationHeader {
 ##### User Verification Index (UVI) Extension ##### {#uvi-extension}
 	  <dl>
 		<dt>Extension identifier</dt>
-		<dd><code>fido.uvi</code></dd>
+		<dd><code>webauth.uvi</code></dd>
 		
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
@@ -1241,7 +1239,7 @@ interface AttestationHeader {
 		      It also must contain sufficient entropy that makes guessing impractical.  
 		      UVI values MUST NOT be reused by the Authenticator (for other biometric data or users).
 		    </p>
-		    <p>The UVI data can be used by FIDO Servers to understand whether an authentication
+		    <p>The UVI data can be used by servers to understand whether an authentication
 		      was authorized by the exact same biometric data as the initial key generation.
 		      This allows the detection and prevention of "friendly fraud".
 		    </p>
@@ -1251,23 +1249,23 @@ interface AttestationHeader {
 		      factory reset is performed for the device, e.g. 
 		      rawUVI = biometricReferenceData | OSLevelUserID | FactoryResetCounter.
 		    </p>
-		    <p>FIDO Servers supporting UVI extensions MUST support a length of up to 32 bytes
+		    <p>Servers supporting UVI extensions MUST support a length of up to 32 bytes
 		      for the UVI value.
 		    </p>
 		    <p>Example for rawData containing one UVI extension</p>
   <pre>
-  F1 D0                         -- This is a FIDO packed rawData object
-  81                            -- TUP and ED set
-  00 00 00 01                   -- (initial) signature counter
-  ...                           -- all public key alg etc.
-  A1                            -- extension: CBOR map of one element
-    68                          -- Key 1: CBOR text string of 8 bytes
-      66 69 64 6F 2E 75 76 69   -- "fido.uvi" UTF-8 string
-    58 20                       -- Value 1: CBOR byte string with 0x20 bytes
-    00 43 B8 E3 BE 27 95 8C     -- the UVI value itself
-    28 D5 74 BF 46 8A 85 CF 
-    46 9A 14 F0 E5 16 69 31 
-    DA 4B CF FF C1 BB 11 32 
+  F1 D0                                -- This is a WebAuth packed rawData object
+  81                                   -- TUP and ED set
+  00 00 00 01                          -- (initial) signature counter
+  ...                                  -- all public key alg etc.
+  A1                                   -- extension: CBOR map of one element
+    6B                                 -- Key 1: CBOR text string of 11 bytes
+      77 65 62 61 75 74 68 2E 75 76 69 -- "webauth.uvi" UTF-8 string
+    58 20                              -- Value 1: CBOR byte string with 0x20 bytes
+    00 43 B8 E3 BE 27 95 8C            -- the UVI value itself
+    28 D5 74 BF 46 8A 85 CF
+    46 9A 14 F0 E5 16 69 31
+    DA 4B CF FF C1 BB 11 32
     82
   </pre>
 		</dd>
@@ -1277,7 +1275,7 @@ interface AttestationHeader {
 
 	    <p>The <code>signature</code> is computed over the base64url-decoded <code>rawData</code> field.</p>
 	    The following 
-	    algorithms must be implemented by FIDO Servers: 
+	    algorithms must be implemented by servers: 
 	    <ol>
 	      <li>"ES256" [[!RFC7518]]</li>
 	      <li>"RS256" [[!RFC7518]]</li>
@@ -1328,9 +1326,9 @@ interface AttestationHeader {
 
 
 ### TPM Attestation ### {#tpm-attestation}
-	  
+
 #### Attestation rawData (type="tpm") #### {#sec-raw-data-tpm}
-	    
+
 	    <p>
               The value of <code>rawData</code> is the <b>base64url encoding of a binary object</b>.
 	      This binary object is either a
@@ -1352,12 +1350,12 @@ interface AttestationHeader {
 	    <p>
               If <code>attestationStatement.core.version</code> equals 1, (i.e., for
               TPM 1.2), RSASSA-PKCS1-v1_5 signature algorithm (section 8.2 of
-              [[RFC3447]]) can be used by FIDO Authenticators (i.e.
+              [[RFC3447]]) can be used by WebAuth Authenticators (i.e.
               <code>attestationStatement.header.alg</code>="RS256").
 	    </p>
 	    <p>
               If <code>attestationStatement.core.version</code> equals 2, the
-              following algorithms can be used by FIDO Authenticators:
+              following algorithms can be used by WebAuth Authenticators:
 	    </p>
 		
 	    <ol>
@@ -1371,7 +1369,7 @@ interface AttestationHeader {
 	      
 	    <p>The <code>signature</code> is computed over the base64url-decoded <code>rawData</code> field</p>
 	    <p>See [[#packed-attestation-signature]] for the signature algorithms 
-	      to be implemented by FIDO Servers.
+	      to be implemented by servers.
 	    </p>
 
 
@@ -1548,7 +1546,7 @@ dictionary AndroidAttestationClientData : ClientData {
               </li>
               <li>
 		Check that <code>AndroidAttestationClientData.publicKey</code> is the same key as the one
-		returned in the <code>FIDOCredentialInfo</code> by the
+		returned in the <code>ScopedCredentialInfo</code> by the
 		<code>makeCredential</code> call.
               </li>
               <li>
@@ -1600,7 +1598,7 @@ dictionary AndroidAttestationClientData : ClientData {
 		chains up to a trusted root (following [[RFC5280]]).
 	      </li>
 	      <li>Verify that the attestation certificate has the right Extended Key Usage (EKU) based
-		on the FIDO Authenticator type (as denoted by the <code>header.type</code> member). In case of a
+		on the WebAuth Authenticator type (as denoted by the <code>header.type</code> member). In case of a
 		type="tpm", this EKU shall be OID "2.23.133.8.3".
 	      </li>
 	      <li>If the attestation type is "android", verify that the attestation certificate is issued 
@@ -1624,23 +1622,23 @@ dictionary AndroidAttestationClientData : ClientData {
 		(id-fido-gen-ce-aaguid) verify that the value of this extension matches 
 		<code>header.claimedAAGUID</code>.  This identifies the Authenticator model.
 	      </li>
-	      <li>If such extension doesn't exist, 
+	      <li>If such extension doesn't exist,
 		the attestation root certificate is dedicated to a single Authenticator model.
 	      </li>
 	    </ol>
 	  </li>
 	  <li>If <code>attestationSignature.alg</code> is ECDAA (e.g., "ED256", "ED512"):
 	    <ol>
-	      <li>Lookup the DAA 
+	      <li>Lookup the DAA
 		root key from a trusted source.  The FIDO Metadata Service [[FIDOMetadataService]]
 		provides an easy way to access such information.
 		The <code>header.claimedAAGUID</code>
-		can be used for this lookup.	    
+		can be used for this lookup.
 	      </li>
-	      <li>Perform DAA-Verify on <code>signature</code> 
+	      <li>Perform DAA-Verify on <code>signature</code>
 		for <code>core.rawData</code> (see [[!FIDOEcdaaAlgorithm]]).</li>
 	      <li>
-		Verify <code>core.rawData</code> syntax and that it doesn't contradict the signing 
+		Verify <code>core.rawData</code> syntax and that it doesn't contradict the signing
 		algorithm specified in <code>header.alg</code>.
 	      </li>
 	      <li>The DAA root key is dedicated to a single Authenticator model.</li>
@@ -1666,9 +1664,9 @@ dictionary AndroidAttestationClientData : ClientData {
 	  </li>
 	  <li>
 	    Accept the request associated with the attestation statement but
-	    treat the attested FIDO Credential as one with surrogate basic 
+	    treat the attested Scoped Credential as one with surrogate basic 
 	    attestation (see [[#attestation-models]]), if policy allows it.
-	    If doing so, there is no cryptographic proof that the FIDO Credential 
+	    If doing so, there is no cryptographic proof that the Scoped Credential 
 	    has been generated by a particular Authenticator model.  
 	    See [[FIDOSecRef]] and [[UAFProtocol]] for more details on the relevance on attestation.
 	  </li>
@@ -1691,19 +1689,19 @@ dictionary AndroidAttestationClientData : ClientData {
 	  be mitigated in several ways, including:
 	</p>
 	<ul>
-	  <li>A FIDO Authenticator manufacturer may choose to ship all of their devices with
+	  <li>A WebAuth Authenticator manufacturer may choose to ship all of their devices with
 	    the same (or a fixed number of) attestation key(s) (called Full Basic Attestation). This will
 	    anonymize the user at the risk of not being able to revoke a
-	    particular attestation key should its FIDO Authenticator be compromised.
+	    particular attestation key should its WebAuth Authenticator be compromised.
 	  </li>
-	  <li>A FIDO Authenticator may be capable of dynamically generating different attestation keys
+	  <li>A WebAuth Authenticator may be capable of dynamically generating different attestation keys
 	    (and requesting related certificates) per origin (following the Privacy CA model). 
-	    For example, a FIDO Authenticator can ship with a master 
+	    For example, a WebAuth Authenticator can ship with a master 
 	    attestation key (and certificate), and
 	    combined with a cloud operated privacy CA, can dynamically generate per origin
 	    attestation keys and attestation certificates.
 	  </li>
-	  <li>A FIDO Authenticator can implement direct anonymous 
+	  <li>A WebAuth Authenticator can implement direct anonymous 
 	    attestation (see [[FIDOEcdaaAlgorithm]]).  Using this scheme the authenticator
 	    generates a blinded attestation signature.  This allows the relying party to verify 
 	    the signature using the DAA root key, but the attestation signature doesn't 
@@ -1714,33 +1712,33 @@ dictionary AndroidAttestationClientData : ClientData {
 ### Attestation Certificate and Attestation Certificate CA Compromise ### {#ca-compromise}
 
 	<p>When an intermediate CA or a root CA used for issuing attestation
-	  certificates is compromised, FIDO Authenticator attestation keys are still
+	  certificates is compromised, WebAuth Authenticator attestation keys are still
 	  safe although their certificates can no longer be trusted. A
-	  FIDO Authenticator manufacturer that has recorded the public attestation keys
+	  WebAuth Authenticator manufacturer that has recorded the public attestation keys
 	  for their devices can issue new attestation certificates for
 	  these keys from a new intermediate CA or from a new root CA.
 	  If the root CA changes, the relying parties must update their trusted 
 	  root certificates accordingly.
 	</p>
-	<p>A FIDO Authenticator attestation certificate must be revoked by the issuing CA
-	  if its key has been compromised. A FIDO Authenticator manufacturer may need to
+	<p>A WebAuth Authenticator attestation certificate must be revoked by the issuing CA
+	  if its key has been compromised. A WebAuth Authenticator manufacturer may need to
 	  ship a firmware update and inject new attestation keys and
-	  certificates into already manufactured FIDO Authenticators, if
+	  certificates into already manufactured WebAuth Authenticators, if
 	  the exposure was due to a firmware flaw.
 	  (The process by which this happens is out of scope for this specification.)
 	  No further valid
-	  attestation statements can be made by the affected FIDO Authenticators unless
-	  the FIDO Authenticator manufacturer has this capability.
+	  attestation statements can be made by the affected WebAuth Authenticators unless
+	  the WebAuth Authenticator manufacturer has this capability.
 	</p>
 	<p>If attestation certificate validation fails due to a revoked
 	  intermediate attestation CA certificate, and relying party policy requires rejecting
 	  the registration/authentication request in these situations,
 	  then it is recommended that the relying party also un-registers
 	  (or marks as "surrogate attestation" (see <a href='#attestation-models'></a>), policy permitting) 
-	  FIDO credentials that were registered post the CA compromise date using an attestation
+	  scoped credentials that were registered post the CA compromise date using an attestation
 	  certificate chaining up to the same intermediate CA. It is thus
 	  recommended that relying parties remember intermediate attestation CA certificates
-	  during Authenticator registration in order to un-register related FIDO Credentials if 
+	  during Authenticator registration in order to un-register related Scoped Credentials if 
 	  the registration was performed after revocation of such certificates.
 	</p>
 	
@@ -1756,22 +1754,21 @@ dictionary AndroidAttestationClientData : ClientData {
 	<p>A 3 tier hierarchy for attestation certificates is recommended 
 	  (i.e., Attestation Root, Attestation Issuing CA, Attestation Certificate). 
 	  It is also recommended that
-	  for each FIDO Authenticator device line (i.e., model), a separate issuing CA is used to help
+	  for each WebAuth Authenticator device line (i.e., model), a separate issuing CA is used to help
 	  facilitate isolating problems with a specific version of a device.
 	</p>
 	<p>If the attestation root certificate is <em>not</em> dedicated 
-	  to a single FIDO Authenticator device line (i.e., AAGUID),
+	  to a single WebAuth Authenticator device line (i.e., AAGUID),
 	  the AAGUID must be specified either in the attestation certificate itself or 
 	  as an extension in the <code>core.rawData</code>.
 	</p>
-  
-<!-- End of include from key-attestation.html -->  
-  
-  
-# FIDO Extensions # {#extensions}
+
+<!-- End of include from key-attestation.html -->
+
+# WebAuth Extensions # {#extensions}
 <p>
-  The mechanism for generating FIDO 2.0 credentials, as well as requesting and
-  generating FIDO 2.0 assertions, as defined in [[#api]],
+  The mechanism for generating scoped credentials, as well as requesting and
+  generating WebAuth assertions, as defined in [[#api]],
   can be extended to suit particular use cases. Each case is
   addressed by defining a <em>registration extension</em> and/or a
   <em>signature extension</em>. Extensions can define additions to the
@@ -1798,7 +1795,7 @@ dictionary AndroidAttestationClientData : ClientData {
 </ul>
 
 <p>
-  When requesting an assertion for a FIDO 2.0 credential, an RP can list a set
+  When requesting an assertion for a scoped credential, an RP can list a set
   of extensions to be used, if they are supported by the client and/or the
   authenticator. It sends the request parameters for each extension in the
   {{getAssertion()}} call (for signature extensions) or
@@ -1824,7 +1821,7 @@ dictionary AndroidAttestationClientData : ClientData {
   <p>
   Extensions are identified by a string, chosen by the extension author. Extension identifiers
   should aim to be globally unique, e.g., by using reverse domain-name of the defining entity such
-  as <code>com.example.fido.myextension</code>.
+  as <code>com.example.webauth.myextension</code>.
   </p>
 
   <p>
@@ -1833,7 +1830,7 @@ dictionary AndroidAttestationClientData : ClientData {
   </p>
 
   <p>
-  Standard extensions defined by FIDO in this specification use a fixed prefix of <code>fido.</code>
+  Standard extensions defined in this specification use a fixed prefix of <code>webauth.</code>
   for the extension identifiers. This prefix should not be used for 3rd party extensions.
   </p>
 
@@ -1884,7 +1881,7 @@ dictionary AndroidAttestationClientData : ClientData {
 
   <pre class="example highlight">
   var assertionPromise = credentials.getAssertion(..., /* extensions */ {
-    "com.example.fido.foobar": 42
+    "com.example.webauth.foobar": 42
   });
   </pre>
 
@@ -1969,7 +1966,7 @@ dictionary AndroidAttestationClientData : ClientData {
   </p>
 
   <p>
-    The extension identifier is chosen as <code>com.example.fido.geo</code>.
+    The extension identifier is chosen as <code>com.example.webauth.geo</code>.
     The client argument is the constant value <code>true</code>, since the
     extension does not require the RP to pass any particular information to the
     client, other than that it requests the use of the extension. The RP sets
@@ -1979,7 +1976,7 @@ dictionary AndroidAttestationClientData : ClientData {
   var assertionPromise =
       credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
           {}, /* Empty filter */
-          { 'com.example.fido.geo': true });
+          { 'com.example.webauth.geo': true });
   </pre>
 
   <p>
@@ -1990,7 +1987,7 @@ dictionary AndroidAttestationClientData : ClientData {
   {
      ...,
      'extensions': {
-         'com.example.fido.geo': {
+         'com.example.webauth.geo': {
              'type': 'Point',
              'coordinates': [65.059962, -13.993041]
          }
@@ -2012,21 +2009,21 @@ dictionary AndroidAttestationClientData : ClientData {
   </p>
 
   <pre>
-  81 (hex)                      -- Flags, ED and TUP both set.
-  20 05 58 1F                   -- Signature counter
-  A1                            -- CBOR map of one element
-    68                          -- Key 1: CBOR text string of 8 bytes
-      66 69 64 6F 2E 67 65 6F   -- "fido.geo" UTF-8 string
-    82                          -- Value 1: CBOR array of two elements
-      FA 42 82 1E B3            -- Element 1: Latitude as CBOR encoded float
-      FA C1 5F E3 7F            -- Element 2: Longitude as CBOR encoded float
+  81 (hex)                             -- Flags, ED and TUP both set.
+  20 05 58 1F                          -- Signature counter
+  A1                                   -- CBOR map of one element
+    6B                                 -- Key 1: CBOR text string of 11 bytes
+      77 65 62 61 75 74 68 2e 67 65 6f -- "webauth.geo" UTF-8 string
+    82                                 -- Value 1: CBOR array of two elements
+      FA 42 82 1E B3                   -- Element 1: Latitude as CBOR encoded float
+      FA C1 5F E3 7F                   -- Element 2: Longitude as CBOR encoded float
   </pre>
 
 
 # Standard Extensions # {#extension-standard}
 
   <p>
-  This section defines standard extensions defined by the FIDO Alliance.
+  This section defines standard extensions defined by the W3C.
   </p>
 
 ## Transaction authorization ## {#extension-txauth}
@@ -2040,8 +2037,8 @@ dictionary AndroidAttestationClientData : ClientData {
   <dl>
     <dt>Extension identifier</dt>
     <dd>
-      <code>fido.txauth.simple</code> 
-    </dd>    
+      <code>webauth.txauth.simple</code> 
+    </dd>
     <dt>Client argument</dt>
     <dd>A single UTF-8 encoded string <em>prompt</em></dd>
 
@@ -2054,7 +2051,7 @@ dictionary AndroidAttestationClientData : ClientData {
     <dt>Authenticator processing</dt>
     <dd>The authenticator MUST display the prompt to the user before performing
         the user verification / test of user presence. The authenticator may insert line breaks if needed.</dd>
-    
+
     <dt>Authenticator data</dt>
     <dd>A single UTF-8 string, representing the prompt <em>as displayed</em> (including any
         eventual line breaks).</dd>
@@ -2065,13 +2062,13 @@ dictionary AndroidAttestationClientData : ClientData {
   <dl>
     <dt>Extension identifier</dt>
     <dd>
-      <code>fido.txauth.generic</code> 
+      <code>webauth.txauth.generic</code>
     </dd>
-    
+
     <dt>Client argument</dt>
     <dd>A CBOR map with one pair of data items (CBOR tagged as 0xa1). The pair of data items consists of
       <ol>
-	<li>one UTF-8 encoded string <dfn>contentType</dfn>, containing 
+	<li>one UTF-8 encoded string <dfn>contentType</dfn>, containing
 	  the MIME-Type of the content, e.g. "image/png"</li>
 	<li>and the <dfn>content</dfn> itself, encoded as CBOR byte array.</li>
       </ol>
@@ -2088,10 +2085,10 @@ dictionary AndroidAttestationClientData : ClientData {
         the user verification / test of user presence. The authenticator may add other information below the <a>content</a>.
         No changes are allowed to the <a>content</a> itself, i.e. inside <a>content</a> boundary box.
     </dd>
-    
+
     <dt>Authenticator data</dt>
     <dd>
-      The hash value of the <a>content</a> which was displayed.  
+      The hash value of the <a>content</a> which was displayed.
       The authenticator MUST use the same hash algorithm as it uses for the signature itself.
     </dd>
   </dl>
@@ -2109,7 +2106,7 @@ dictionary AndroidAttestationClientData : ClientData {
   <dl>
     <dt>Extension identifier</dt>
     <dd>
-      <code>fido.authn-sel</code> (only used during {{makeCredential()}})
+      <code>webauth.authn-sel</code> (only used during {{makeCredential()}})
     </dd>
     <dt>Client argument</dt>
     <dd>
@@ -2120,12 +2117,12 @@ typedef sequence < AAGUID > AuthenticatorSelectionList;
       Each AAGUID corresponds to an authenticator attestation that is
       acceptable to the RP for this credential creation. The list is ordered by
       decreasing preference.<br>
-      
+
       An AAGUID is defined as a DOMString, and is the globally unique identifier
       of the authenticator attestation being sought.
       <pre class="idl highlight">
 typedef DOMString AAGUID;
-      </pre>      
+      </pre>
     </dd>
 
     <dt>Client processing</dt>
@@ -2148,11 +2145,11 @@ typedef DOMString AAGUID;
 
 # IANA Considerations # {#iana-considerations}
 
-  This specification registers the algorithm names "S256", "S384", "S512", and "SM3" 
-  with the IANA JSON Web Algorithms registry as defined in section 
-  "Cryptographic Algorithms for Digital Signatures and MACs" in [[RFC7518]]. 
+  This specification registers the algorithm names "S256", "S384", "S512", and "SM3"
+  with the IANA JSON Web Algorithms registry as defined in section
+  "Cryptographic Algorithms for Digital Signatures and MACs" in [[RFC7518]].
   <p>
-    These names follow the naming strategy in 
+    These names follow the naming strategy in
     <a href="https://tools.ietf.org/html/draft-ietf-oauth-spop-15">draft-ietf-oauth-spop-15</a>.
   </p>
 
@@ -2181,7 +2178,7 @@ typedef DOMString AAGUID;
 	       <td>[[SP800-107r1]]</td>
 	  </tr>
 	</tbody>
-      </table>	
+      </table>
     </p>
 
     <p>
@@ -2209,7 +2206,7 @@ typedef DOMString AAGUID;
 	       <td>[[SP800-107r1]]</td>
 	  </tr>
 	</tbody>
-      </table>	
+      </table>
     </p>
 
     <p>
@@ -2237,7 +2234,7 @@ typedef DOMString AAGUID;
 	       <td>[[SP800-107r1]]</td>
 	  </tr>
 	</tbody>
-      </table>	
+      </table>
     </p>
 
     <p>
@@ -2265,7 +2262,7 @@ typedef DOMString AAGUID;
 	       <td>N/A</td>
 	  </tr>
 	</tbody>
-      </table>	
+      </table>
     </p>
 
 
@@ -2273,7 +2270,7 @@ typedef DOMString AAGUID;
 
   <em>This section is not normative.</em>
 
-  <p>In this section, we walk through some events in the lifecycle of a FIDO 2.0 credential, along with the corresponding sample code for using this API. Note that this is an example flow, and does not limit the scope of how the API can be used.</p>
+  <p>In this section, we walk through some events in the lifecycle of a scoped credential, along with the corresponding sample code for using this API. Note that this is an example flow, and does not limit the scope of how the API can be used.</p>
 
   <p>As was the case in earlier sections, this flow focuses on a use case involving an external first-factor authenticator with its own display. One example of such an authenticator would be a smart phone. Other authenticator types are also supported by this API, subject to implementation by the platform. For instance, this flow also works without modification for the case of an authenticator that is embedded in the client platform. The flow also works for the case of an external authenticator without its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the client platform needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the client platform to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.</p>
 
@@ -2302,9 +2299,9 @@ typedef DOMString AAGUID;
 
 
     <pre class="example highlight">
-    var fidoAPI = window.fido;
+    var webauthAPI = window.webauth;
 
-    if (!fidoAPI) { /* Platform not capable. Handle error. */ }
+    if (!webauthAPI) { /* Platform not capable. Handle error. */ }
 
     var userAccountInformation = {
       rpDisplayName: "Acme",
@@ -2318,23 +2315,23 @@ typedef DOMString AAGUID;
     // prefers an ES256 credential.
     var cryptoParams = [
       {
-        type: "FIDO",
+        type: "ScopedUserCredential",
         algorithm: "ES256"
       },
       {
-        type: "FIDO",
+        type: "ScopedUserCredential",
         algorithm: "RS256"
       }
     ];
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
     var blacklist = [];  // No blacklist
-    var extensions = {"fido.location": true};  // Include location information
-                                               // in attestation
+    var extensions = {"webauth.location": true};  // Include location information
+                                                  // in attestation
 
 
     // Note: The following call will cause the authenticator to display UI.
-    fidoAPI.makeCredential(userAccountInformation, cryptoParams, challenge,
+    webauthAPI.makeCredential(userAccountInformation, cryptoParams, challenge,
                            timeoutSeconds, blacklist, extensions)
       .then(function (newCredentialInfo) {
         // Send new credential info to server for verification and registration.
@@ -2349,7 +2346,7 @@ typedef DOMString AAGUID;
 
     <ol type ="1">
       <li>The user visits example.com, which serves up a script.</li>
-      <li>The script asks the client platform for a FIDO identity assertion, providing as much information as possible to narrow the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after registration, or by other means such as prompting the user for a username.</li>
+      <li>The script asks the client platform for a WebAuth identity assertion, providing as much information as possible to narrow the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after registration, or by other means such as prompting the user for a username.</li>
       <li>The Relying Party script runs one of the code snippets below.</li>
       <li>The client platform searches for and locates the external authenticator.</li>
       <li>The client platform connects to the external authenticator, performing any pairing actions if necessary.</li>
@@ -2369,15 +2366,15 @@ typedef DOMString AAGUID;
     <p>If the Relying Party script does not have any hints available (e.g., from locally stored data) to help it narrow the list of credentials, then the sample code for performing such an authentication might look like this:</p>
 
     <pre class="example highlight">
-    var fidoAPI = window.fido;
+    var webauthAPI = window.webauth;
 
-    if (!fidoAPI) { /* Platform not capable. Handle error. */ }
+    if (!webauthAPI) { /* Platform not capable. Handle error. */ }
 
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
-    var whitelist = [{ type: "FIDO" }];
+    var whitelist = [{ type: "ScopedUserCredential" }];
 
-    fidoAPI.getAssertion(challenge, timeoutSeconds, whitelist)
+    webauthAPI.getAssertion(challenge, timeoutSeconds, whitelist)
       .then(function (assertion) {
         // Send assertion to server for verification
     }).catch(function (err) {
@@ -2388,25 +2385,25 @@ typedef DOMString AAGUID;
     <p>On the other hand, if the Relying Party script has some hints to help it narrow the list of credentials, then the sample code for performing such an authentication might look like the following. Note that this sample also demonstrates how to use the extension for transaction authorization.</p>
 
     <pre class="example highlight">
-    var fidoAPI = window.fido;
+    var webauthAPI = window.webauth;
 
-    if (!fidoAPI) { /* Platform not capable. Handle error. */ }
+    if (!webauthAPI) { /* Platform not capable. Handle error. */ }
 
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
     var acceptableCredential1 = {
-      type: "FIDO",
+      type: "ScopedUserCredential",
       id: "ISEhISEhIWhpIHRoZXJlISEhISEhIQo="
     };
     var acceptableCredential2 = {
-      type: "FIDO",
+      type: "ScopedUserCredential",
       id: "cm9zZXMgYXJlIHJlZCwgdmlvbGV0cyBhcmUgYmx1ZQo="
     };
     var whitelist = [acceptableCredential1, acceptableCredential2];
-    var extensions = { 'fido.txauth.simple':
+    var extensions = { 'webauth.txauth.simple':
                        "Wave your hands in the air like you just don't care" };
 
-    fidoAPI.getAssertion(challenge, timeoutSeconds, whitelist, extensions)
+    webauthAPI.getAssertion(challenge, timeoutSeconds, whitelist, extensions)
       .then(function (assertion) {
         // Send assertion to server for verification
     }).catch(function (err) {


### PR DESCRIPTION
Generally, the following substitutions were made:
- Extensions were renamed from "fido." to "webauth."
- CredentialType "FIDO" was renamed to "ScopedUserCredential"
- "FIDO Authenticators" are now "WebAuth Authenticators"
- "FIDO Credential" and similar are now "Scoped Credential"
- "FIDO method" and similar are now "WebAuth method"
- "FIDO Relying Party" and similar are now "WebAuthn Relying Party"
- The WebIDL DOM interface is now type "WebAuthentication" and named "webauth"

I did not attempt to change the OIDs, references to the ECDAA specification, or the FIDO Metadata Service (see Issue #47).

**NOTE to reviewers**: As a byproduct of editing, some of the extraneous end-of-line whitespace got cleaned up as well, but not all of it. You may want to append `?w=1` to your URL to instruct Github to ignore whitespace changes.