### PR TITLE
Issue #50: Add a Terminology Section

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -15,7 +15,7 @@ Editor: Michael B. Jones, Microsoft, mbj@microsoft.com
 Editor: Rolf Lindemann, Nok Nok Labs, rolf@noknok.com
 group: webauthn
 Ignored Vars: op, current.algorithm, alg
-Abstract: This specification defines an API that enables web pages to access WebAuthn compliant strong cryptographic credentials through browser script. Conceptually, credentials are stored on an authenticator, and each credential is bound to a single Relying Party. Authenticators are responsible for ensuring that no operation is performed without the user's consent. The user agent mediates access to credentials in order to preserve user privacy. Web Authentication uses the concept of attestation to provide a cryptographic proof of the authenticator model to the relying party.  The relying party can derive the authenticator security characteristics from this proof.
+Abstract: This specification defines an API that enables web pages to access WebAuthn compliant strong cryptographic credentials through browser script. Conceptually, credentials are stored on an authenticator, and each credential is bound to a single <a>Relying Party</a>. Authenticators are responsible for ensuring that no operation is performed without the user's consent. The user agent mediates access to credentials in order to preserve user privacy. Web Authentication uses the concept of attestation to provide a cryptographic proof of the authenticator model to the relying party.  The relying party can derive the authenticator security characteristics from this proof.
 Boilerplate: omit conformance, omit feedback-header
 Markup Shorthands: css off, markdown on
 </pre>
@@ -24,9 +24,9 @@ Markup Shorthands: css off, markdown on
 
   <em>This section is not normative.</em>
 
-  <p>This specification defines an API for web pages to access scoped credentials through JavaScript, for the purpose of strongly authenticating a user. Scoped credentials are always scoped to a single WebAuthn Relying Party, and the API respects this requirement. Credentials created by a Relying Party can only be accessed by web origins belonging to that Relying Party. Additionally, privacy across Relying Parties must be maintained; scripts must not be able to detect any properties, or even the existence, of credentials belonging to other Relying Parties.</p>
+  <p>This specification defines an API for web pages to access scoped credentials through JavaScript, for the purpose of strongly authenticating a user. Scoped credentials are always scoped to a single <a>WebAuthn Relying Party</a>, and the API respects this requirement. Credentials created by a Relying Party can only be accessed by web origins belonging to that Relying Party. Additionally, privacy across Relying Parties must be maintained; scripts must not be able to detect any properties, or even the existence, of credentials belonging to other Relying Parties.</p>
 
-  <p>Scoped credentials are located on authenticators, which can use them to perform operations subject to user consent. Broadly, authenticators are of two types:</p>
+  <p>Scoped credentials are located on <a>authenticators</a>, which can use them to perform operations subject to user consent. Broadly, authenticators are of two types:</p>
 
   <ol>
     <li><dfn>Embedded authenticators</dfn> have their operation managed by the same computing device (e.g., smart phone, tablet, desktop PC) as the user agent is running on. For instance, such an authenticator might consist of a Trusted Platform Module (TPM) or Secure Element (SE) integrated into the computing device, along with appropriate platform software to mediate access to this device's functionality.</li>
@@ -36,7 +36,7 @@ Markup Shorthands: css off, markdown on
   <p>Note that an external authenticator may itself contain an embedded authenticator. For example, consider a smart phone that contains a scoped credential. The credential may be accessed by a web browser running on the phone itself. In this case the module containing the credential is functioning as an embedded authenticator. However, the credential may also be accessed over BLE by a user agent on a nearby laptop. In this latter case, the phone is functioning as an external authenticator. These modes may even be used in a single end-to-end user scenario. One such scenario is described in the remainder of this section.</p>
 
 
-## Registration (embedded authenticator mode) ## {#registration-embedded}
+## Registration (<a>embedded authenticator</a> mode) ## {#registration-embedded}
 
     <ul>
       <li>
@@ -52,7 +52,7 @@ Markup Shorthands: css off, markdown on
     </ul>
 
 
-## Authentication (external authenticator mode) ## {#authentication-external}
+## Authentication (<a>external authenticator</a> mode) ## {#authentication-external}
 
     <ul>
       <li>
@@ -95,8 +95,8 @@ Markup Shorthands: css off, markdown on
 
 # Conformance # {#conformance}
 
-  <p>This specification defines criteria for a <dfn>conforming user agent</dfn>. A user agent MUST behave as described in this specification in order to be considered conformant. User agents MAY implement algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's algorithms. A conforming Web Authentication API user agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the “Web IDL” specification. [[!WebIDL-1]]</p>
-  
+  <p>This specification defines criteria for a <a>Conforming User Agent</a>. A User Agent MUST behave as described in this specification in order to be considered conformant. User Agents MAY implement algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's algorithms. A conforming Web Authentication API User Agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the “Web IDL” specification. [[!WebIDL-1]]</p>
+
 <!-- begin from signature-format -->
 <p> The term <b>Base64url Encoding</b> refers to the base64 encoding using the URL- and filename-safe character set defined in Section 5 of [[RFC4648]], with all trailing '=' characters omitted (as permitted by Section 3.2) and without the inclusion of any line breaks, whitespace, or other additional characters. This is the same encoding as used by JSON Web Signature (JWS) [[RFC7515]].</p>
 <!-- end from signature-format -->
@@ -121,21 +121,20 @@ Markup Shorthands: css off, markdown on
     </dl>
 
 
-
 # WebAuthn Authenticator model # {#authenticator-model}
-  
-  <p>The API defined in this specification implies a specific abstract functional model for an authenticator. This section describes the authenticator model. Client platforms may implement and expose this abstract model in any way desired. However, the behavior of the client's Web Authentication API implementation, when operating on the embedded and external authenticators supported by that platform, MUST be indistinguishable from the behavior specified in the <a href="#api">Web Authentication API</a> section.</p>
-  
-  <p>In this abstract model, each authenticator stores some number of scoped credentials. Each scoped credential has an identifier which is unique (or extremely unlikely to be duplicated) among all scoped credentials. Each credential is also associated with a WebAuthn Relying Party, whose identity is represented by a Relying Party Identifier (RP ID).</p>
-  
+
+  <p>The API defined in this specification implies a specific abstract functional model for an <a>authenticator</a>. This section describes the authenticator model. Client platforms may implement and expose this abstract model in any way desired. However, the behavior of the client's Web Authentication API implementation, when operating on the embedded and external authenticators supported by that platform, MUST be indistinguishable from the behavior specified in the <a href="#api">Web Authentication API</a> section.</p>
+
+  <p>In this abstract model, each authenticator stores some number of scoped credentials. Each scoped credential has an identifier which is unique (or extremely unlikely to be duplicated) among all scoped credentials. Each credential is also associated with a <a>WebAuthn Relying Party</a>, whose identity is represented by a <dfn>Relying Party Identifier</dfn> (RP ID).</p>
+
   <p>A client must connect to an authenticator in order to invoke any of the operations of that authenticator. This connection defines an authenticator session. An authenticator must maintain isolation between sessions. It may do this by only allowing one session to exist at any particular time, or by providing more complicated session management.</p>
-  
+
   <p>The following operations can be invoked by the client in an authenticator session.</p>
-  
+
 ## The <dfn>authenticatorMakeCredential</dfn> operation ## {#op-make-cred}
-    
+
     <p>This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following input parameters:</p>
-    
+
     <ul>
       <li>The web origin of the script on whose behalf the operation is being initiated, as determined by the user agent and the client.</li>
       <li>The RP ID corresponding to the above web origin, as determined by the user agent and the client.</li>
@@ -143,7 +142,7 @@ Markup Shorthands: css off, markdown on
     </ul>
 
     <p>When this operation is invoked, the authenticator obtains user consent for creating a new credential. The prompt for obtaining this consent is shown by the authenticator if it has its own output capability, or by the user agent otherwise. Once user consent is obtained, the authenticator generates the appropriate cryptographic keys and creates a new credential. It then associates the credential with the specified RP ID such that it will be able to retrieve the RP ID later, given the credential ID.</p>
-    
+
     <p>On successful completion of this operation, the authenticator returns the type and unique identifier of this new credential to the user agent.</p>
 
     <p>If the user refuses consent, the authenticator returns an appropriate error status to the client.</p>
@@ -151,7 +150,7 @@ Markup Shorthands: css off, markdown on
 ## The <dfn>authenticatorGetAssertion</dfn> operation ## {#op-get-assertion}
 
     <p>This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following input parameters:</p>
-    
+
     <ul>
       <li>The web origin of the script on whose behalf the operation is being initiated, as determined by the user agent and the client.</li>
       <li>The RP ID corresponding to the above web origin, as determined by the user agent and the client.</li>
@@ -165,11 +164,11 @@ Markup Shorthands: css off, markdown on
     <p>If the user refuses consent, the authenticator returns an appropriate error status to the client.</p>
 
 ## The <dfn>authenticatorCancel</dfn> operation ## {#op-cancel}
-    
+
     <p>This operation takes no input parameters and returns no result.</p>
 
     <p>When this operation is invoked by the client in an authenticator session, it has the effect of terminating any <a><code>authenticatorMakeCredential</code></a> or <a><code>authenticatorGetAssertion</code></a> operation currently in progress in that authenticator session. The authenticator stops prompting for, or accepting, any user input related to authorizing the canceled operation. The client ignores any further responses from the authenticator for the canceled operation.</p>
-    
+
     <p>This operation is ignored if it is invoked in an authenticator session which does not have an <a><code>authenticatorMakeCredential</code></a> or <a><code>authenticatorGetAssertion</code></a> operation currently in progress.</p>
 
 
@@ -243,7 +242,7 @@ Markup Shorthands: css off, markdown on
 
 ### Create a new credential (<dfn method for="WebAuthentication">makeCredential()</dfn> method) ### {#makeCredential}
 
-      <p>With this method, a script can request the user agent to create a new credential of a given type and persist it to the underlying platform, which may involve data storage managed by the browser or the OS. The user agent will prompt the user to approve this operation. On success, the promise will be resolved with a {{ScopedCredentialInfo}} object describing the newly created credential.</p>
+      <p>With this method, a script can request the User Agent to create a new credential of a given type and persist it to the underlying platform, which may involve data storage managed by the browser or the OS. The user agent will prompt the user to approve this operation. On success, the promise will be resolved with a {{ScopedCredentialInfo}} object describing the newly created credential.</p>
 
       <p>This method takes the following parameters:</p>
 
@@ -256,7 +255,7 @@ Markup Shorthands: css off, markdown on
 
         <li>The optional <dfn>credentialTimeoutSeconds</dfn> parameter specifies a time, in seconds, that the caller is willing to wait for the call to complete. This is treated as a hint, and may be overridden by the platform.</li>
 
-        <li>The optional <dfn>blacklist</dfn> parameter is intended for use by Relying Parties that wish to limit the creation of multiple credentials for the same account on a single authenticator. The platform is requested to return an error if the new credential would be created on an authenticator that also contains one of the credentials enumerated in this parameter.</li>
+        <li>The optional <dfn>blacklist</dfn> parameter is intended for use by <a>WebAuthn Relying Parties</a> that wish to limit the creation of multiple credentials for the same account on a single authenticator. The platform is requested to return an error if the new credential would be created on an authenticator that also contains one of the credentials enumerated in this parameter.</li>
 
         <li>The optional <dfn>credentialExtensions</dfn> parameter contains additional parameters requesting additional processing by the client and authenticator. For example, the caller may request that only authenticators with certain capabilities be used to create the credential, or that additional information be returned in the attestation statement. Alternatively, the caller may specify an additional message that they would like the authenticator to display to the user. Extensions are defined in [[#signature-format]].</li>
       </ul>
@@ -270,7 +269,7 @@ Markup Shorthands: css off, markdown on
 
         <li>Let <var>promise</var> be a new <a data-lt="Promises">Promise</a>. Return <var>promise</var> and start a timer for <var>adjustedTimeout</var> seconds. Then asynchronously continue executing the following steps.</li>
 
-        <li>Set <var>callerOrigin</var> to the <a><code>origin</code></a> of the caller. Derive the RP ID from <var>callerOrigin</var> by computing the "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "eTLD+1") part of <var>callerOrigin</var> [[PSL]]. Set <var>rpId</var> to the RP ID.</li>
+        <li>Set <var>callerOrigin</var> to the <a><code>origin</code></a> of the caller. Derive the RP ID from <var>callerOrigin</var> by computing the "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>") part of <var>callerOrigin</var> [[PSL]]. Set <var>rpId</var> to the RP ID.</li>
 
         <li>Initialize <var>issuedRequests</var> to an empty list.</li>
 
@@ -340,7 +339,7 @@ Markup Shorthands: css off, markdown on
 
         <li>Let <var>promise</var> be a new <a data-lt="Promises">Promise</a>. Return <var>promise</var> and start a timer for <var>adjustedTimeout</var> seconds. Then asynchronously continue executing the following steps.</li>
 
-        <li>Set <var>callerOrigin</var> to the <a><code>origin</code></a> of the caller. Derive the RP ID from <var>callerOrigin</var> by computing the "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "eTLD+1") part of <var>callerOrigin</var> [[PSL]]. Set <var>rpId</var> to the RP ID.</li>
+        <li>Set <var>callerOrigin</var> to the <a><code>origin</code></a> of the caller. Derive the RP ID from <var>callerOrigin</var> by computing the "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>") part of <var>callerOrigin</var> [[PSL]]. Set <var>rpId</var> to the RP ID.</li>
 
         <li>Initialize <var>issuedRequests</var> to an empty list.</li>
 
@@ -386,7 +385,7 @@ Markup Shorthands: css off, markdown on
 ## <dfn interface>ScopedCredentialInfo</dfn> Interface ## {#iface-credentialInfo}
 
     <div dfn-for="ScopedCredentialInfo">
-      <p>This interface represents a newly-created scoped credential. It contains information about the credential that can be used to locate it later for use, and also contains metadata that can be used by the WebAuthn Relying Party to assess the strength of the credential during registration.</p>
+      <p>This interface represents a newly-created scoped credential. It contains information about the credential that can be used to locate it later for use, and also contains metadata that can be used by the <a>WebAuthn Relying Party</a> to assess the strength of the credential during registration.</p>
 
       <p>The <dfn>credential</dfn> attribute contains a unique identifier for the credential represented by this object.</p>
 
@@ -399,7 +398,7 @@ Markup Shorthands: css off, markdown on
 ## User Account Information (dictionary <dfn dictionary>Account</dfn>) ## {#iface-account}
 
     <div dfn-for="Account">
-      <p>This dictionary is used by the caller to specify information about the user account and Relying Party with which a credential is to be associated. It is intended to help the authenticator in providing a friendly credential selection interface for the user.</p>
+      <p>This dictionary is used by the caller to specify information about the user account and <a>WebAuthn Relying Party</a> with which a credential is to be associated. It is intended to help the authenticator in providing a friendly credential selection interface for the user.</p>
 
       <p> The <dfn>rpDisplayName</dfn> member contains the friendly name of the Relying Party, such as "Acme Corporation", "Widgets Inc" or "Awesome Site".</p>
 
@@ -426,7 +425,7 @@ Markup Shorthands: css off, markdown on
 
 
 ## Supporting Data Structures ## {#supporting-data-structures}
-  
+
     The scoped credential type uses certain data structures that are specified in supporting specifications. These are as follows.
 
 ### Credential Type enumeration (enum <dfn enum>CredentialType</dfn>) ### {#credentialType}
@@ -473,7 +472,7 @@ Markup Shorthands: css off, markdown on
 
 ### Key Attestation Statement (interface <dfn>AttestationStatement</dfn>) ### {#iface-attestation-statement}
 
-      <p>Authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each credential public key, attestation information that can be verified by a WebAuthn Relying Party. Typically this information contains a signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information providing provenance information for the attesting key, enabling a trust decision to be made. The structure of these attestation statements is defined in [[#attestation]].</p>
+      <p>Authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each credential public key, attestation information that can be verified by a <a>WebAuthn Relying Party</a>. Typically this information contains a signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information providing provenance information for the attesting key, enabling a trust decision to be made. The structure of these attestation statements is defined in [[#attestation]].</p>
 
 
 <!-- Included from signature-format.html -->
@@ -488,18 +487,17 @@ server checks these bindings against expected values.</p>
 
 <p>The components of a system using WebAuthn can be divided into three layers:</p>
 <ol>
-  <li>The relying party (RP), which uses the WebAuthn services.
-  The relying party may, for
-  example, be a web-application running in a browser, or a native application
-  that runs directly on the OS platform.</li>
-  <li>The client platform, which consists of the user’s OS and device used to
+  <li>The <a>WebAuthn Relying Party</a> (RP), which uses the WebAuthn services.
+  The relying party may, for example, be a web-application running in a browser,
+  or a native application that runs directly on the OS platform.</li>
+  <li>The <a>WebAuthn Client</a> platform, which consists of the user’s OS and device used to
   host the RP’s client-side app. For web-applications, the browser also belongs
   to this layer.</li>
-  <li>The authenticator itself, which provides key management and
+  <li>The <a>Authenticator</a> itself, which provides key management and
   cryptographic signatures.</li>
 </ol>
 
-<p>When the RP client-side application is a web-application, the interface between 1 and 2
+<p>When the Relying Party client-side application is a web-application, the interface between 1 and 2
 is the <a href="#api">Web Authentication API</a>, but is platform specific for native applications.
 In cases where the authenticator is not tightly integrated with the platform, the interface
 between 2 and 3 is a separately-defined protocol.
@@ -533,11 +531,11 @@ of this hash, and its own authenticator data.</p>
 
 ## Client data ## {#sec-client-data}
 
-  <p>The client data represents the contextual bindings of both the RP and the
+  <p>The client data represents the contextual bindings of both the WebAuthn Relying Party and the
   client platform.  It is a key-value mapping with string-valued keys. Values may be
   any type that has a valid encoding in JSON.  It MUST contain at least the
   following key-value pairs.</p>
-  
+
   <pre class="idl">
   dictionary ClientData {
 	  DOMString       challenge;
@@ -547,7 +545,7 @@ of this hash, and its own authenticator data.</p>
 	  DOMString       hashAlg;
   };
   </pre>
-  
+
   <div dfn-for="ClientData">
   <dl>
     <dt>DOMString <dfn>challenge</dfn></dt>
@@ -557,7 +555,7 @@ of this hash, and its own authenticator data.</p>
     <dt>DOMString <dfn>facet</dfn></dt>
     <dd>
       A string value describing the RP identifier facet.
-      When the RP client-side app is a website, this is its fully qualified web origin,
+      When the WebAuthn Relying Party client-side app is a website, this is its fully qualified web origin,
       using the syntax defined by [[RFC6454]]. When the client-side app is a native
       application, this string is a platform specific identifier.
     </dd>
@@ -591,7 +589,7 @@ of this hash, and its own authenticator data.</p>
     <li>Let <dfn>clientDataJSON</dfn> be the UTF-8 encoded JSON serialization
     [[RFC7159]] of {{ClientData}}.</li>
 
-    <li>Let <var>clientDataHash</var> be the hash (computed using {{hashAlg}}) of 
+    <li>Let <var>clientDataHash</var> be the hash (computed using {{hashAlg}}) of
     <a>clientDataJSON</a>, as an array.</li>
   </ol>
 
@@ -602,11 +600,11 @@ of this hash, and its own authenticator data.</p>
   a signature request.
   The client platform SHOULD also preserve the exact <code>encodedClientData</code>
   string used to create it, for embedding in a signature object sent back to
-  the RP (see <a href="#authenticator-signature"></a>).
+  the WebAuthn Relying Party (see <a href="#authenticator-signature"></a>).
   This is necessary since multiple JSON encodings of the same client
   data are possible.</p>
-  <p>The hash algorithm {{hashAlg}} used to compute <var>clientDataHash</var> is 
-    included in the {{ClientData}} object. This way it is available to the RP and 
+  <p>The hash algorithm {{hashAlg}} used to compute <var>clientDataHash</var> is
+    included in the {{ClientData}} object. This way it is available to the Relying Party and
     it is also hashed over when computing <var>clientDataHash</var> and hence
     anchored in the signature itself.
   </p>
@@ -615,7 +613,7 @@ of this hash, and its own authenticator data.</p>
 ## Authenticator data ## {#sec-authenticator-data}
 
   <p>The authenticator data encodes contextual bindings made by the
-  authenticator itself. The authenticator data has a compact but extensible
+  <a>authenticator</a> itself. The authenticator data has a compact but extensible
   encoding. This is desired since authenticators can be devices with limited
   capabilities and low power requirements, with much simpler software stacks
   than the client platform components.</p>
@@ -675,7 +673,7 @@ of this hash, and its own authenticator data.</p>
 ## Generating a signature ## {#authenticator-signature}
 
   <p>A raw cryptographic signature must assert the integrity of both the
-  client data and the authenticator data. Thus, an authenticator SHALL
+  client data and the authenticator data. Thus, an <a>authenticator</a> SHALL
   compute a signature over the concatenation of the <var>authenticatorData</var>
   and the <var>clientDataHash</var>.
   </p>
@@ -699,8 +697,8 @@ of this hash, and its own authenticator data.</p>
 
 ## Client encoding of assertions ## {#webauthn-assertion}
 
-  <p>The client platform uses an authenticator assertion to construct
-  the final {{WebAuthn assertion}} object returned to the RP as follows.</p>
+  <p>The client platform uses an <a>authenticator</a> assertion to construct
+  the final {{WebAuthnAssertion}} object returned to the Relying Party as follows.</p>
 
   <pre class="idl">
   interface WebAuthnAssertion {
@@ -710,7 +708,7 @@ of this hash, and its own authenticator data.</p>
 	  attribute DOMString  signature;
   };
   </pre>
-  
+
   <div dfn-for="WebAuthnAssertion">
   <dl>
     <dt>attribute Credential <dfn>credential</dfn></dt>
@@ -734,28 +732,28 @@ of this hash, and its own authenticator data.</p>
     </dd>
   </dl>
 
-  <p>This assertion is delivered to the RP in either a platform specific manner, or
+  <p>This assertion is delivered to the <a>WebAuthn Relying Party</a> in either a platform specific manner, or
   in the case of web applications, according to the Web Authentication API ([[#api]]).
-  It contains all the information that the RP's server requires to
+  It contains all the information that the Relying Party's server requires to
   reconstruct the signature base string, as well as to decode and validate
   the bindings of both the client- and authenticator data.</p>
 <!-- End of include from signature-format.html -->
 
-  
+
 <!-- Begin of include from key-attestation.html -->
-  
+
 # Key Attestation Format # {#attestation}
 
     This specification defines generic data structures that cover the
-	semantics of authenticator attestation. This specification also 
-	provides a profile of these structures when a TPM [[TPM]] acts as a crypto kernel. 
+	semantics of authenticator attestation. This specification also
+	provides a profile of these structures when a TPM [[TPM]] acts as a crypto kernel.
 	More profiles are expected to be added as the specification
 	evolves.
-  
+
 ## Overview ## {#attestation-overview}
 
 ### Attestation Models ### {#attestation-models}
-      
+
 	<p>WebAuthn supports multiple attestation models:</p>
 	<dl>
 	  <dt>Full Basic Attestation</dt>
@@ -765,19 +763,19 @@ of this hash, and its own authenticator data.</p>
 	    <p>This model is also used for FIDO UAF 1.0 and FIDO U2F 1.0.</p>
 	  </dd>
 	  <dt>Surrogate Basic Attestation</dt>
-	  <dd>In the case of surrogate basic attestation [[UAFProtocol]], the 
-	    Authenticator doesn't have any specific attestation key.  Instead it uses 
-	    the authentication key to (self-)sign the (surrogate) attestation message.  
+	  <dd>In the case of surrogate basic attestation [[UAFProtocol]], the
+	    Authenticator doesn't have any specific attestation key.  Instead it uses
+	    the authentication key to (self-)sign the (surrogate) attestation message.
 	    Authenticators without meaningful protection measures for an attestation private key
-	    typically use this attestation model.  
+	    typically use this attestation model.
 	  </dd>
 	  <dt>Privacy CA</dt>
-	  <dd>In this case, the authenticator owns an authenticator-specific (endorsement) key.  
-	    This key is used to securely communicate with a trusted third party, 
+	  <dd>In this case, the Authenticator owns an authenticator-specific (endorsement) key.
+	    This key is used to securely communicate with a trusted third party,
 	    the Privacy CA.  The Authenticator can generate
-	    multiple attestation key pairs and asks the Privacy CA to issue an 
-	    attestation certificate for it. 
-	    <p>Using this approach, the Authenticator can limit the exposure of the 
+	    multiple attestation key pairs and asks the Privacy CA to issue an
+	    attestation certificate for it.
+	    <p>Using this approach, the Authenticator can limit the exposure of the
 	      endorsement key (which is a global correlation handle) to Privacy CA(s).
 	      Attestation keys can be requested for each scoped credential individually.
 	    </p>
@@ -789,14 +787,14 @@ of this hash, and its own authenticator data.</p>
 	  <dd>In this case, the Authenticator receives DAA credentials from a single DAA-Issuer.
 	    These DAA credentials are used along with blinding to sign the attestation data.
 	    The concept of blinding avoids the DAA credentials being misused as global correlation handle.
-	    <p>WebAuthn supports DAA using elliptic curve cryptography and bilinear pairings, 
+	    <p>WebAuthn supports DAA using elliptic curve cryptography and bilinear pairings,
 	      called ECDAA (see [[FIDOEcdaaAlgorithm]]) in this specification.</p>
 	  </dd>
 	</dl>
-	<p>Compliant servers MUST support all attestation models.  
+	<p>Compliant servers MUST support all attestation models.
 	  Authenticators can choose what attestation model to implement.
 	</p>
-	<p class="note">Relying parties can always decide what attestation models are acceptable by policy.
+	<p class="note">WebAuthn Relying Parties can always decide what attestation models are acceptable by policy.
 	</p>
 
 ### Contextual Data ### {#attestation-contextual-data}
@@ -805,20 +803,19 @@ of this hash, and its own authenticator data.</p>
 	  observed, and added at different levels of the stack as a signature request
 	  passes from the server to the authenticator. In verifying a signature, the
 	  server checks these bindings against expected values.</p>
-	
+
 	<p>These components can be divided into three layers:</p>
 	<ol>
-	  <li>The WebAuthn relying party (RP) consists of two subcomponents: an online
+	  <li>The <a>WebAuthn Relying Party</a> (RP) consists of two subcomponents: an online
 	    service and a client-side application. The client-side app may, for
 	    example, be a web application running in a browser, or a native application
 	    that runs directly on the OS platform.</li>
-	  <li>The client platform, which consists of the user’s OS and device used to
-	    host the RP’s client-side app. For web applications, the browser also belongs
-	    to this layer.</li>
-	  <li>The authenticator itself, which provides key generation and key management and
+	  <li>The <a>WebAuthn Client</a> platform, which consists of the user’s OS and device used to
+	    host the RP’s client-side app. The <a>Conforming User Agent</a> belongs to this layer.</li>
+	  <li>The <a>Authenticator</a> itself, which provides key generation and key management and
 	    cryptographic signatures.</li>
 	</ol>
-	
+
 	<p>The goals of this design can be summarized as follows.
 	  <ul>
 	    <li>The scheme for generating keys and attestation statements should accommodate cases where the
@@ -834,10 +831,10 @@ of this hash, and its own authenticator data.</p>
 	      to aid adoption and implementation.</li>
 	  </ul>
 	</p>
-	
+
 	<p>
 	  There are two kinds of contextual bindings:
-	  Those added by the RP or the client platform,
+	  Those added by the Relying Party or the client platform,
 	  referred to as <dfn>client data</dfn> (see [[#signature-format]])
 	  and those added by the
 	  authenticator, referred to as the <dfn>attestation data</dfn>.  The client
@@ -852,38 +849,38 @@ of this hash, and its own authenticator data.</p>
 ### Attestation Raw Data Types ### {#attestation-raw-data-types}
 
 	<p>
-	  WebAuthn supports pluggable attestation raw data types, i.e., 
-	  ways to serialize the data being attested to by the authenticator.
+	  WebAuthn supports pluggable attestation raw data types, i.e.,
+	  ways to serialize the data being attested to by the <a>Authenticator</a>.
 	  The reason is to be able to support existing devices like TPMs and other
 	  platform-specific formats.
 	</p>
 	<p>Each attestation type provides the ability to cryptographically attest to a public key, the
 	  authenticator model, and contextual data to a remote party.
 	</p>
-	<p>Attestation raw data types are orthogonal to attestation models, i.e. 
+	<p>Attestation raw data types are orthogonal to attestation models, i.e.
 	  attestation raw data types in general are not restricted to a single attestation model.
 	</p>
-	
+
 
 ## Attestation Statement ## {#attestation-statement}
 
-      <p>When an attestation statement is required for an Authenticator, the client
+      <p>When an attestation statement is required for an <a>Authenticator</a>, the client
 	needs to ask the Authenticator to generate one. This section describes the
 	attestation statement data structures. Attestation statements
 	can also include some host and other Authenticator information.
       </p>
-      
+
       The attestation statement consists of
       <ol>
-	<li>the <code>header</code> object, containing the signing algorithm and 
+	<li>the <code>header</code> object, containing the signing algorithm and
 	  additional information required to verify the attestation signature.
 	</li>
 	<li>the <code>core</code> object, containing the attested data.  This object
-	  is a container and can carry multiple, authenticator model specific, 
-	  attestation rawData types (see section [[#defined-attestation-raw-data-types]]). 
+	  is a container and can carry multiple, authenticator model specific,
+	  attestation rawData types (see section [[#defined-attestation-raw-data-types]]).
 	</li>
 	<li>the <code>signature</code> object.  This object contains the cryptographic
-	  signature computed over the <code>rawData</code> object.  
+	  signature computed over the <code>rawData</code> object. 
 	  The structure of this object depends on the signature algorithm.
 	</li>
       </ol>
@@ -892,10 +889,10 @@ of this hash, and its own authenticator data.</p>
 ## Client encoding of attestation statements ## {#attestation-client-encoding}
 
 
-	<p>The client platform uses an authenticator generated 
-	  attestation signature (<code>signature</code>) and the 
+	<p>The client platform uses an authenticator generated
+	  attestation signature (<code>signature</code>) and the
 	  authenticator generated <code>rawData</code> object to construct
-	  the final attestation statement object (which will be returned to the RP). 
+	  the final attestation statement object (which will be returned to the RP).
 	  This attestation statement is encoded as:
 	</p>
 
@@ -913,16 +910,16 @@ interface AttestationStatement {
 	    and (optionally) the attestation certificate chain.
 	  </dd>
 	  <dt>readonly attribute AttestationCore <dfn>core</dfn></dt>
-	  <dd>AttestationCore object.  This object includes the attested <code>rawData</code> and 
+	  <dd>AttestationCore object.  This object includes the attested <code>rawData</code> and
 	    its <code>type</code> and <code>version</code>.</dd>
 	  <dt>readonly attribute DOMString <dfn>signature</dfn></dt>
 	  <dd>The base64url-encoded attestation signature.  The structure of this 
 	    object depends on the signature algorithm specified in the header.
 	  </dd>
 	</dl>
-	
-	<p>This attestation statement is delivered to the RP according to the Client API.
-	  It contains all the information that the RP's server requires to
+
+	<p>This attestation statement is delivered to the <a>WebAuthn Relying Party</a> according to the Client API.
+	  It contains all the information that the Relying Party's server requires to
 	  reconstruct the signature base string, as well as to decode and validate
 	  the bindings of both the client- and authenticator data.
 	</p>
@@ -930,7 +927,7 @@ interface AttestationStatement {
 ### AttestationCore ### {#sec-attestationcore}
 
 	Data attested by the Authenticator and description of its structure.
-	Different types of Authenticators might generate different object types 
+	Different types of Authenticators might generate different object types
 	(identified by <code>type</code> and <code>version</code>).
 
 <pre class="idl">
@@ -939,7 +936,7 @@ interface AttestationCore {
     readonly    attribute unsigned long version;
     readonly    attribute DOMString     rawData;
     readonly    attribute DOMString     clientData;
-};	
+};
 </pre>
 
 	<dl dfn-for="AttestationCore">
@@ -977,7 +974,7 @@ interface AttestationCore {
 
 ### AttestationHeader ### {#sec-attestation-header}
 
-	Additional data required to verify the attestation signature.  
+	Additional data required to verify the attestation signature. 
 
 <pre class="idl">
 interface AttestationHeader {
@@ -989,20 +986,20 @@ interface AttestationHeader {
 
 	<dl dfn-for="AttestationHeader">
 	  <dt>readonly attribute DOMString <dfn>claimedAAGUID</dfn></dt>
-	  <dd>The claimed Authenticator Attestation GUID (a version 4 GUID, see [[RFC4122]]).  
-	    This value is used by the WebAuthn Relying Party to 
-	    lookup the trust anchor for verifying this AttestationCore object.  
-	    If the verification succeeds, 
+	  <dd>The claimed Authenticator Attestation GUID (a version 4 GUID, see [[RFC4122]]).
+	    This value is used by the <a>WebAuthn Relying Party</a> to
+	    lookup the trust anchor for verifying this AttestationCore object.
+	    If the verification succeeds,
 	    the AAGUID related to the trust anchor is trusted.  This field MUST be present, if either no
-	    attestation certificates are used (e.g., DAA) or if the attestation 
+	    attestation certificates are used (e.g., DAA) or if the attestation
 	    certificate doesn't contain the AAGUID value in an extension.
 	  </dd>
 	  <dt>readonly attribute DOMString[] <dfn>x5c</dfn></dt>
 	  <dd>Attestation Certificate and its certificate chain as described
 	    in [[!RFC7515]] section 4.1.6.</dd>
 	  <dt>readonly attribute DOMString <dfn>alg</dfn></dt>
-	  <dd>The name of the algorithm used to generate the attestation signature according to [[!RFC7518]].  
-	    <p>See [[#packed-attestation-signature]] for the signature algorithms 
+	  <dd>The name of the algorithm used to generate the attestation signature according to [[!RFC7518]].
+	    <p>See [[#packed-attestation-signature]] for the signature algorithms
 	      to be implemented by servers.</p>
 	  </dd>
 	</dl>
@@ -1012,7 +1009,7 @@ interface AttestationHeader {
 	  Attestation Raw Data (<code>rawData</code>) is the to-be-signed object of
 	  the attestation statement. WebAuthn supports pluggable attestation data types.
 	  This allows support of TPM generated attestation data as well as support of
-	  other WebAuthn authenticators.
+	  other WebAuthn <a>authenticators</a>.
 	</p>
 	<p>
 	  The contents of the attestation data must be controlled (i.e., generated or
@@ -1021,14 +1018,14 @@ interface AttestationHeader {
 
 ### Packed Attestation ### {#packed-attestation}
 
-	  Packed attestation is a WebAuthn optimized format of attestation data.  It uses a very compact but 
-	  still extensible encoding method.  Encoding this format can even be implemented by authenticators
+	  Packed attestation is a WebAuthn optimized format of attestation data.  It uses a very compact but
+	  still extensible encoding method.  Encoding this format can even be implemented by <a>authenticators</a>
 	  with very limited resources (e.g., secure elements).
 
 #### Attestation rawData (type="packed") #### {#sec-raw-data-packed}
 
 	    <p>The attestation data encodes contextual bindings made by the
-	      authenticator itself. Unlike client data, the authenticator data has
+	      <a>authenticator</a> itself. Unlike client data, the authenticator data has
 	      a compact but extensible encoding. This is desired since authenticators can
 	      be devices with limited capabilities and low power requirements, with much
 	      simpler software stacks than the client platform components.</p>
@@ -1047,7 +1044,7 @@ interface AttestationHeader {
 	      </tr>
 	      <tr>
 		<td>2</td>
-		<td>0xF1D0, fixed big-endian TAG to make sure this object won't be 
+		<td>0xF1D0, fixed big-endian TAG to make sure this object won't be
 		  confused with other (non-WebAuth) binary objects.</td>
 	      </tr>
 	      <tr>
@@ -1120,68 +1117,68 @@ interface AttestationHeader {
 	      </tr>
 	      <tr>
 		<td>n</td>
-		<td>clientDataHash (see [[#sec-attestation-client-data]]).  
+		<td>clientDataHash (see [[#sec-attestation-client-data]]).
 		  This is the hash of <code>clientData</code>.  The hash algorithm itself is stored
 		  in the <code>clientData</code> object [[#signature-format]].
 		</td>
 	      </tr>
 	      <tr>
 		<td>As defined by the extension map</td>
-		<td>Extension-defined authenticator data. This is a CBOR [[RFC7049]] map with 
-		  extension identifiers as keys, and extension authenticator data values as values. 
-		  See [[#extensions]] for a description 
+		<td>Extension-defined authenticator data. This is a CBOR [[RFC7049]] map with
+		  extension identifiers as keys, and extension authenticator data values as values.
+		  See [[#extensions]] for a description
 		  of the extension mechanism.
-		  See [[#sec-extensions-for-packed-attestation-rawdata]] 
+		  See [[#sec-extensions-for-packed-attestation-rawdata]]
 		  for pre-defined extensions.
 		</td>
 	      </tr>
 	    </table>
-	    
-	    <p>The <code>TUP</code> flag SHALL be set if and only if the authenticator
+
+	    <p>The <code>TUP</code> flag SHALL be set if and only if the <a>authenticator</a>
 	      detected a user through an authenticator-specific gesture. The <code>RFU</code>
 	      bits in the flags byte SHALL be cleared (i.e., zeroed).</p>
-	    
+
 	    <p>If the authenticator does not wish to add extensions, it MUST clear
 	      the <code>ED</code> flag in the third byte.</p>
 
 #### Extensions for Packed Attestation rawData #### {#sec-extensions-for-packed-attestation-rawdata}
-	    
+
 ##### AAGUID Extension ##### {#aaguid-extension}
 
 	  <dl>
 		<dt>Extension identifier</dt>
 		<dd><code>webauthn.aaguid</code></dd>
-		
+
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Client processing</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Authenticator argument</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Authenticator processing</dt>
-		<dd>This extension is added automatically by the authenticator.  This extension can be added
+		<dd>This extension is added automatically by the <a>authenticator</a>.  This extension can be added
 		  to attestation statements and signatures.
 		</dd>
-		
+
 		<dt>Authenticator data</dt>
 		<dd>A 128-bit Authenticator Attestation GUID encoded as a CBOR text string (major type 3).
-		  
+
 		  <p>This AAGUID is used to identify the Authenticator model (Authenticator Attestation GUID).</p>
 		    <div class="note">
-		      <p>The authenticator model (identified by the AAGUID) can be derived from 
-			(a) here, or  
+		      <p>The authenticator model (identified by the AAGUID) can be derived from
+			(a) here, or
 			(b) from the attestation certificate (if we have an authenticator specific
-			or authenticator model specific attestation certificate), 
-			or (c) or from the claimed AAGUID in the client 
-			encoded attestation statement (if we have one attestation root certificate 
+			or authenticator model specific attestation certificate),
+			or (c) or from the claimed AAGUID in the client
+			encoded attestation statement (if we have one attestation root certificate
 			per authenticator model).
 		      </p>
-		      <p>In the case of DAA there is no need for an X.509 
-			attestation certificate hierarchy. 
-			Instead the trust anchor being known to the RP is 
+		      <p>In the case of DAA there is no need for an X.509
+			attestation certificate hierarchy.
+			Instead the trust anchor being known to the Relying Party is
 			the DAA root key (i.e. ECPoint2 X, Y).  This root key must be dedicated
 			to a single authenticator model.
 		      </p>
@@ -1193,50 +1190,50 @@ interface AttestationHeader {
 ##### SupportedExtensions Extension ##### {#supported-extensions-extension}
 	  <dl>
 		<dt>Extension identifier</dt>
-		<dd><code>webauthn.exts</code></dd>		
+		<dd><code>webauthn.exts</code></dd>
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Client processing</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Authenticator argument</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Authenticator processing</dt>
 		<dd>This extension is added automatically by the authenticator.  This extension can be added
 		  to attestation statements.
 		</dd>
 		<dt>Authenticator data</dt>
-		<dd>The SupportedExtension extension is a list (CBOR array) of extension identifiers 
+		<dd>The SupportedExtension extension is a list (CBOR array) of extension identifiers
 		  encoded as UTF-8 Strings.
-		</dd>		
+		</dd>
 	      </dl>
 
 ##### User Verification Index (UVI) Extension ##### {#uvi-extension}
 	  <dl>
 		<dt>Extension identifier</dt>
 		<dd><code>webauthn.uvi</code></dd>
-		
+
 		<dt>Client argument</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Client processing</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Authenticator argument</dt>
 		<dd>N/A</dd>
-		
+
 		<dt>Authenticator processing</dt>
 		<dd>This extension is added automatically by the authenticator.  This extension can be added
 		  to attestation statements and signatures.
 		</dd>
-		
+
 		<dt>Authenticator data</dt>
-		<dd>The user verification index (UVI) is a value uniquely identifying 
-		  a user verification data record.  The UVI is encoded as CBOR byte string (type 0x58). 
-		    <p>Each UVI value MUST be specific to the related key (in order to provide unlinkability).  
-		      It also must contain sufficient entropy that makes guessing impractical.  
+		<dd>The user verification index (UVI) is a value uniquely identifying
+		  a user verification data record.  The UVI is encoded as CBOR byte string (type 0x58).
+		    <p>Each UVI value MUST be specific to the related key (in order to provide unlinkability).
+		      It also must contain sufficient entropy that makes guessing impractical.
 		      UVI values MUST NOT be reused by the Authenticator (for other biometric data or users).
 		    </p>
 		    <p>The UVI data can be used by servers to understand whether an authentication
@@ -1244,9 +1241,9 @@ interface AttestationHeader {
 		      This allows the detection and prevention of "friendly fraud".
 		    </p>
 		    <p>As an example, the UVI could be computed as SHA256(KeyID | SHA256(rawUVI)),
-		      where the rawUVI reflects (a) the biometric reference data, 
+		      where the rawUVI reflects (a) the biometric reference data,
 		      (b) the related OS level user ID and (c) an identifier which changes whenever a
-		      factory reset is performed for the device, e.g. 
+		      factory reset is performed for the device, e.g.
 		      rawUVI = biometricReferenceData | OSLevelUserID | FactoryResetCounter.
 		    </p>
 		    <p>Servers supporting UVI extensions MUST support a length of up to 32 bytes
@@ -1274,22 +1271,21 @@ interface AttestationHeader {
 #### Signature #### {#packed-attestation-signature}
 
 	    <p>The <code>signature</code> is computed over the base64url-decoded <code>rawData</code> field.</p>
-	    The following 
-	    algorithms must be implemented by servers: 
+	    The following
+	    algorithms must be implemented by servers:
 	    <ol>
 	      <li>"ES256" [[!RFC7518]]</li>
 	      <li>"RS256" [[!RFC7518]]</li>
 	      <li>"PS256" [[!RFC7518]]</li>
-	      <li>"ED256" [[!FIDOEcdaaAlgorithm]]</li>  
+	      <li>"ED256" [[!FIDOEcdaaAlgorithm]]</li>
 	    </ol>
-	    Authenticators can choose which algorithm to implement.
+	    <a>Authenticators</a> can choose which algorithm to implement.
 
-	  
-	  
+
 #### Packed attestation statement certificate requirements #### {#packed-attestation-cert-requirements}
 
-	    <p class="note">In the case of DAA attestation 
-	      [[FIDOEcdaaAlgorithm]] no attestation certificate is used.
+	    <p class="note">In the case of DAA attestation
+	      [[FIDOEcdaaAlgorithm]] no <a>attestation certificate</a> is used.
 	    </p>
 
 	    <p>The attestation certificate MUST have the following
@@ -1309,7 +1305,7 @@ interface AttestationHeader {
 		  <dd>No stipulation.</dd>
 		</dl>
 	      </li>
-	      <li>If the related attestation root certificate is used for multiple authenticator 
+	      <li>If the related attestation root certificate is used for multiple authenticator
 		models, the following extension MUST be present:
 		<p>Extension OID <code>1 3 6 1 4 1 45724 1 1 4</code>
 		(id-fido-gen-ce-aaguid) containing the AAGUID as value.
@@ -1318,7 +1314,7 @@ interface AttestationHeader {
 	      <li>The Basic Constraints extension MUST have the cA component set
 		to false
 	      </li>
-	      <li>An Authority Information Access (AIA) extension with entry <code>id-ad-ocsp</code> and 
+	      <li>An Authority Information Access (AIA) extension with entry <code>id-ad-ocsp</code> and
 		a CRL Distribution Point extension [[RFC5280]] are both optional as the status of attestation certificates is
 		available through the FIDO Metadata Service [[FIDOMetadataService]].
 	      </li>
@@ -1331,7 +1327,7 @@ interface AttestationHeader {
 
 	    <p>
               The value of <code>rawData</code> is the <b>base64url encoding of a binary object</b>.
-	      This binary object is either a
+	            This binary object is either a
               TPM_CERTIFY_INFO or a TPM_CERTIFY_INFO2 structure [[TPMv1-2-Part2]]
               sections 11.1 and 11.2, if
               <code>attestationStatement.core.version</code> equals 1. Else, if
@@ -1340,8 +1336,8 @@ interface AttestationHeader {
               [[TPMv2-Part2]] sections 10.12.9.
 	    </p>
 	    <p>
-	      The field "extraData" (in the case of TPMS_ATTEST) or the field "data" 
-	      (in the case of TPM_CERTIFY_INFO or TPM_CERTIFY_INFO2) MUST contain 
+	      The field "extraData" (in the case of TPMS_ATTEST) or the field "data"
+	      (in the case of TPM_CERTIFY_INFO or TPM_CERTIFY_INFO2) MUST contain
 	      the <code>clientDataHash</code> (see [[#signature-format]).
 	    </p>
 
@@ -1357,25 +1353,25 @@ interface AttestationHeader {
               If <code>attestationStatement.core.version</code> equals 2, the
               following algorithms can be used by WebAuthn Authenticators:
 	    </p>
-		
+
 	    <ol>
-	      <li>TPM_ALG_RSASSA (0x14).  This is the same algorithm RSASSA-PKCS1-v1_5 
+	      <li>TPM_ALG_RSASSA (0x14).  This is the same algorithm RSASSA-PKCS1-v1_5
 		as for version 1 but for use with TPMv2. <code>attestationStatement.header.alg</code>="RS256".</li>
 	      <li>TPM_ALG_RSAPSS (0x16); <code>attestationStatement.header.alg</code>="PS256".</li>
 	      <li>TPM_ALG_ECDSA (0x18); <code>attestationStatement.header.alg</code>="ES256".</li>
 	      <li>TPM_ALG_ECDAA (0x1A); <code>attestationStatement.header.alg</code>="ED256".</li>
 	      <li>TPM_ALG_SM2 (0x1B); <code>attestationStatement.header.alg</code>="SM256".</li>
 	    </ol>
-	      
+
 	    <p>The <code>signature</code> is computed over the base64url-decoded <code>rawData</code> field</p>
-	    <p>See [[#packed-attestation-signature]] for the signature algorithms 
+	    <p>See [[#packed-attestation-signature]] for the signature algorithms
 	      to be implemented by servers.
 	    </p>
 
 
 #### TPM attestation statement certificate requirements #### {#tpm-cert-requirements}
-	    
-	    <p>TPM attestation certificate MUST have the following
+
+	    <p>TPM <a>attestation certificate</a> MUST have the following
 	      fields/extensions:
 	    </p>
 	    <ul>
@@ -1392,7 +1388,7 @@ interface AttestationHeader {
 	      <li>The Basic Constraints extension MUST have the CA component set
 		to false
 	      </li>
-	      <li>An Authority Information Access (AIA) extension with entry <code>id-ad-ocsp</code> and 
+	      <li>An Authority Information Access (AIA) extension with entry <code>id-ad-ocsp</code> and
 		a CRL Distribution Point extension [[RFC5280]] are both optional as the status of attestation certificates is
 		available through the FIDO Metadata Service [[FIDOMetadataService]].
 	      </li>
@@ -1401,26 +1397,26 @@ interface AttestationHeader {
 ### Android Attestation ### {#android-attestation}
 
     <p>
-       When the Authenticator in question is a platform-provided
+       When the <a>Authenticator</a> in question is a platform-provided
        Authenticator on the Android platform, the attestation statement is
        based on the <a href='https://developer.android.com/training/safetynet/index.html#compat-check-response'>
 	   SafetyNet API</a>.
     </p>
-	
-	<p>Android attestation statement MUST always be used in conjunction with the more 
+
+	<p>Android attestation statement MUST always be used in conjunction with the more
 	  specific <code>AndroidAttestationClientData</code> (see [[#sec-android-attestationclientdata]])
-	  in order to let the RP App store the public key in the attestation object.
+	  in order to let the Relying Party App store the public key in the attestation object.
 	</p>
 
 #### Attestation rawData (type="android") #### {#sec-attestation-android}
 
 	  <p>
-	    Android SafetyNet returns a JWS [[RFC7515]] object (see 
+	    Android SafetyNet returns a JWS [[RFC7515]] object (see
 	    <a href='https://developer.android.com/training/safetynet/index.html#compat-check-response'>
 	      SafetyNet online documentation</a>) in Compact
 	    Serialization. A JWS in Compact Serialization consists of three segments
 	    (each a base64url-encoded string) separated by a dot ("."). The
-	    <code>rawData</code> object is the concatenation of:    
+	    <code>rawData</code> object is the concatenation of:
 	  </p>
 	  <ol>
 	    <li>the first segment (a base64url encoding of the UTF-8 encoded JWS Protected Header)</li>
@@ -1448,15 +1444,15 @@ interface AttestationHeader {
 #### Converting SafetyNet response to attestationStatement #### {#safetynet-conversion}
 
 	  <p>
-	    The Authenticator and/or platform SHOULD use the steps outlined below to
+	    The <a>Authenticator</a> and/or platform SHOULD use the steps outlined below to
 	    create an attestationStatement from an Android SafetyNet response. It MAY
 	    use a different algorithm, as long as the results are the same.
 	  </p>
-	  
+
 	  <ol>
-	    <li>create clientDataJSON with type AndroidAttestationClientData (see below) and 
+	    <li>create clientDataJSON with type AndroidAttestationClientData (see below) and
 	      compute clientData as base64url-encoded clientDataJSON.</li>
-	    <li>provide the clientDataHash computed as the hash value of clientData 
+	    <li>provide the clientDataHash computed as the hash value of clientData
 	      as Nonce value when requesting the SafetyNet attestation.</li>
 	    <li>take SafetyNet response <var>snr</var>.  This is a JWS object ([[RFC7515]]).</li>
 	    <li>extract the base64url-encoded Protected Header <var>hdr</var> from <var>snr</var> (see [[RFC7515]])</li>
@@ -1469,15 +1465,15 @@ interface AttestationHeader {
 	    <li>if <var>hdr-d</var>.x5c is present, then set 
 	      <code>AttestationStatement.header.x5c</code> = <var>hdr-d</var>.x5c</li>
 	    <li>
-	      if <var>hdr-d</var>.x5u is present, then resolve the URL and add the 
+	      if <var>hdr-d</var>.x5u is present, then resolve the URL and add the
 	      retrieved certificate chain to <code>AttestationStatement.header.x5c</code>
 	    </li>
 	    <li>set <code>AttestationStatement.core.type</code> = "android"</li>
-	    <li>set <code>AttestationStatement.core.version</code> to the 
+	    <li>set <code>AttestationStatement.core.version</code> to the
 	      version number of Google Play Services responsible for providing the SafetyNet API</li>
-	  </ol>	    	  
-	
-#### AndroidAttestationClientData #### {#sec-android-attestationclientdata}	  
+	  </ol>
+
+#### AndroidAttestationClientData #### {#sec-android-attestationclientdata}
 
       <p>
          The ClientData dictionary is extended in the following way:
@@ -1489,7 +1485,7 @@ dictionary AndroidAttestationClientData : ClientData {
              boolean                isInsideSecureHardware;
              DOMString              userAuthentication;
              unsigned long userAuthenticationValidityDurationSeconds; // optional
-};	
+};
 </pre>
 
 	  <dl dfn-for="AndroidAttestationClientData">
@@ -1497,13 +1493,13 @@ dictionary AndroidAttestationClientData : ClientData {
             <dd>
               The public key generated by the Authenticator, as a JsonWebKey object (see [[!WebCryptoAPI]]).
             </dd>
-	    
+
 	    <dt>boolean <dfn>isInsideSecureHardware</dfn></dt>
             <dd>
               <code>true</code> if the key resides inside secure hardware (e.g.,
               Trusted Execution Environment (TEE) or Secure Element (SE)).
             </dd>
-	    
+
 	    <dt>DOMString <dfn>userAuthentication</dfn></dt>
             <dd>
               One of "none", "keyguard", or "fingerprint". <em>none</em> means
@@ -1515,7 +1511,7 @@ dictionary AndroidAttestationClientData : ClientData {
               generated key must be individually authorized by the user by
               presenting a fingerprint.
             </dd>
-	    
+
 	    <dt>optional unsigned long <dfn>userAuthenticationValidityDurationSeconds</dfn></dt>
             <dd>
               If the <code>userAuthentication</code> is set to "keyguard", then
@@ -1526,7 +1522,7 @@ dictionary AndroidAttestationClientData : ClientData {
 	  </dl>
 
 
-          
+
 #### Verifying AndroidClientData specific contextual bindings #### {#verifying-android-contextual-bindings}
 
 	    <p>
@@ -1542,7 +1538,7 @@ dictionary AndroidAttestationClientData : ClientData {
               <li>
 		Check that the <code>facet</code> and <code>tokenBinding</code>
 		parameters in the <code>AndroidAttestationClientData</code> match the
-		RP App.
+		Relying Party App.
               </li>
               <li>
 		Check that <code>AndroidAttestationClientData.publicKey</code> is the same key as the one
@@ -1560,20 +1556,20 @@ dictionary AndroidAttestationClientData : ClientData {
               </li>
               <li>
 		Check that the <code>apkPackageName</code> attribute in the payload of the
-		<code>safetynetResponse</code> matches package name of the application calling 
+		<code>safetynetResponse</code> matches package name of the application calling
 		SafetyNet API.
               </li>
               <li>
 		Check that the <code>apkDigestSha256</code> attribute in the
-		payload of the <code>safetynetResponse</code> matches the package hash 
+		payload of the <code>safetynetResponse</code> matches the package hash
 		of the application calling SafetyNet API.
-              </li>        
+              </li>
               <li>
 		Check that the <code>apkCertificateDigestSha256</code> attribute in the
-		payload of the <code>safetynetResponse</code> matches the hash of the signing certificate 
+		payload of the <code>safetynetResponse</code> matches the hash of the signing certificate
 		of the application calling SafetyNet API.
-              </li>        
-	    </ul>      
+              </li>
+	    </ul>
 
 ## Verifying an Attestation Statement ## {#verifying-an-attestation-statement}
 
@@ -1585,15 +1581,15 @@ dictionary AndroidAttestationClientData : ClientData {
 	</p>
 	<ol>
 	  <li>Verify that the attestation statement is properly formatted</li>
-	  <li>If <code>attestationSignature.alg</code> is not ECDAA (e.g., not "ED256" and not "ED512"): 
+	  <li>If <code>attestationSignature.alg</code> is not ECDAA (e.g., not "ED256" and not "ED512"):
 	    <ol>
-	      <li>Lookup the attestation root certificate from a trusted source.  
+	      <li>Lookup the attestation root certificate from a trusted source.
 		The FIDO Metadata Service [[FIDOMetadataService]]
 		provides an easy way to access such information.
 		The <code>header.claimedAAGUID</code>
 		can be used for this lookup.
 	      </li>
-	      <li>Verify that 
+	      <li>Verify that
 		the attestation certificate chain is valid and
 		chains up to a trusted root (following [[RFC5280]]).
 	      </li>
@@ -1601,8 +1597,8 @@ dictionary AndroidAttestationClientData : ClientData {
 		on the WebAuthn Authenticator type (as denoted by the <code>header.type</code> member). In case of a
 		type="tpm", this EKU shall be OID "2.23.133.8.3".
 	      </li>
-	      <li>If the attestation type is "android", verify that the attestation certificate is issued 
-	          to the hostname "attest.android.com" (see 
+	      <li>If the attestation type is "android", verify that the attestation certificate is issued
+	          to the hostname "attest.android.com" (see
 		<a href='https://developer.android.com/training/safetynet/index.html#compat-check-response'>
 	          SafetyNet online documentation</a>).
 	      </li>
@@ -1614,12 +1610,12 @@ dictionary AndroidAttestationClientData : ClientData {
 		attestation certificate public key and algorithm as identified by <code>header.alg</code>.
 	      </li>
 	      <li>
-		Verify <code>core.rawData</code> syntax and that it doesn't contradict the signing 
+		Verify <code>core.rawData</code> syntax and that it doesn't contradict the signing
 		algorithm specified in <code>header.alg</code>.
 	      </li>
-	      <li>If the attestation certificate contains an extension with 
+	      <li>If the attestation certificate contains an extension with
 		OID <code>1 3 6 1 4 1 45724 1 1 4</code>
-		(id-fido-gen-ce-aaguid) verify that the value of this extension matches 
+		(id-fido-gen-ce-aaguid) verify that the value of this extension matches
 		<code>header.claimedAAGUID</code>.  This identifies the Authenticator model.
 	      </li>
 	      <li>If such extension doesn't exist,
@@ -1644,11 +1640,11 @@ dictionary AndroidAttestationClientData : ClientData {
 	      <li>The DAA root key is dedicated to a single Authenticator model.</li>
 	    </ol>
 	  </li>
-	  <li>Verify the contextual bindings (e.g., channel binding) from the 
+	  <li>Verify the contextual bindings (e.g., channel binding) from the
 	    clientData (see [[#sec-attestation-client-data]]).
 	  </li>
 	  <li>
-	    Verify that user verification method and other authenticator characteristics 
+	    Verify that user verification method and other authenticator characteristics
 	    related to this authenticator model, match the relying party policy.
 	    The FIDO Metadata Service [[FIDOMetadataService]]
 	    provides an easy way to access the authenticator characteristics.
@@ -1664,10 +1660,10 @@ dictionary AndroidAttestationClientData : ClientData {
 	  </li>
 	  <li>
 	    Accept the request associated with the attestation statement but
-	    treat the attested Scoped Credential as one with surrogate basic 
+	    treat the attested Scoped Credential as one with surrogate basic
 	    attestation (see [[#attestation-models]]), if policy allows it.
-	    If doing so, there is no cryptographic proof that the Scoped Credential 
-	    has been generated by a particular Authenticator model.  
+	    If doing so, there is no cryptographic proof that the Scoped Credential
+	    has been generated by a particular Authenticator model.
 	    See [[FIDOSecRef]] and [[UAFProtocol]] for more details on the relevance on attestation.
 	  </li>
 	</ul>
@@ -1683,28 +1679,28 @@ dictionary AndroidAttestationClientData : ClientData {
 ## Security Considerations ## {#sec-attestation-security-considerations}
 
 ### Privacy ### {#sec-attestation-privacy}
-	
+
 	<p>Attestation keys may be used to track users or link
 	  various online identities of the same user together. This may
 	  be mitigated in several ways, including:
 	</p>
 	<ul>
-	  <li>A WebAuthn Authenticator manufacturer may choose to ship all of their devices with
+	  <li>A WebAuthn <a>Authenticator</a> manufacturer may choose to ship all of their devices with
 	    the same (or a fixed number of) attestation key(s) (called Full Basic Attestation). This will
 	    anonymize the user at the risk of not being able to revoke a
 	    particular attestation key should its WebAuthn Authenticator be compromised.
 	  </li>
 	  <li>A WebAuthn Authenticator may be capable of dynamically generating different attestation keys
-	    (and requesting related certificates) per origin (following the Privacy CA model). 
-	    For example, a WebAuthn Authenticator can ship with a master 
+	    (and requesting related certificates) per origin (following the Privacy CA model).
+	    For example, a WebAuthn Authenticator can ship with a master
 	    attestation key (and certificate), and
 	    combined with a cloud operated privacy CA, can dynamically generate per origin
 	    attestation keys and attestation certificates.
 	  </li>
-	  <li>A WebAuthn Authenticator can implement direct anonymous 
+	  <li>A WebAuthn Authenticator can implement direct anonymous
 	    attestation (see [[FIDOEcdaaAlgorithm]]).  Using this scheme the authenticator
-	    generates a blinded attestation signature.  This allows the relying party to verify 
-	    the signature using the DAA root key, but the attestation signature doesn't 
+	    generates a blinded attestation signature.  This allows the relying party to verify
+	    the signature using the DAA root key, but the attestation signature doesn't
 	    serve as a global correlation handle.
 	  </li>
 	</ul>
@@ -1712,12 +1708,12 @@ dictionary AndroidAttestationClientData : ClientData {
 ### Attestation Certificate and Attestation Certificate CA Compromise ### {#ca-compromise}
 
 	<p>When an intermediate CA or a root CA used for issuing attestation
-	  certificates is compromised, WebAuthn Authenticator attestation keys are still
+	  certificates is compromised, WebAuthn <a>Authenticator</a> attestation keys are still
 	  safe although their certificates can no longer be trusted. A
 	  WebAuthn Authenticator manufacturer that has recorded the public attestation keys
 	  for their devices can issue new attestation certificates for
 	  these keys from a new intermediate CA or from a new root CA.
-	  If the root CA changes, the relying parties must update their trusted 
+	  If the root CA changes, the relying parties must update their trusted
 	  root certificates accordingly.
 	</p>
 	<p>A WebAuthn Authenticator attestation certificate must be revoked by the issuing CA
@@ -1741,7 +1737,7 @@ dictionary AndroidAttestationClientData : ClientData {
 	  during Authenticator registration in order to un-register related Scoped Credentials if 
 	  the registration was performed after revocation of such certificates.
 	</p>
-	
+
 	<p>If a DAA attestation key has been compromised, it can be added to the
 	  RogueList (i.e., the list of revoked authenticators) maintained by the related DAA-Issuer.
 	  The relying party should verify whether an authenticator belongs to the
@@ -1751,15 +1747,15 @@ dictionary AndroidAttestationClientData : ClientData {
 
 ### Attestation Certificate Hierarchy ### {#cert-hierarchy}
 
-	<p>A 3 tier hierarchy for attestation certificates is recommended 
-	  (i.e., Attestation Root, Attestation Issuing CA, Attestation Certificate). 
+	<p>A 3 tier hierarchy for attestation certificates is recommended
+	  (i.e., Attestation Root, Attestation Issuing CA, Attestation Certificate).
 	  It is also recommended that
 	  for each WebAuthn Authenticator device line (i.e., model), a separate issuing CA is used to help
 	  facilitate isolating problems with a specific version of a device.
 	</p>
-	<p>If the attestation root certificate is <em>not</em> dedicated 
+	<p>If the attestation root certificate is <em>not</em> dedicated
 	  to a single WebAuthn Authenticator device line (i.e., AAGUID),
-	  the AAGUID must be specified either in the attestation certificate itself or 
+	  the AAGUID must be specified either in the attestation certificate itself or
 	  as an extension in the <code>core.rawData</code>.
 	</p>
 
@@ -1795,7 +1791,7 @@ dictionary AndroidAttestationClientData : ClientData {
 </ul>
 
 <p>
-  When requesting an assertion for a scoped credential, an RP can list a set
+  When requesting an assertion for a scoped credential, an Relying Party can list a set
   of extensions to be used, if they are supported by the client and/or the
   authenticator. It sends the request parameters for each extension in the
   {{getAssertion()}} call (for signature extensions) or
@@ -1853,12 +1849,12 @@ dictionary AndroidAttestationClientData : ClientData {
     supported or processed by the client and/or authenticator.
   </p>
 
-  
+
 ## Extending request parameters ## {#extension-request-parameters}
-  
+
   <p>
     An extension defines two request arguments. The <dfn>client argument</dfn>
-    is passed from the RP to the client in the {{getAssertion()}} or
+    is passed from the <a>WebAuthn Relying Party</a> to the client in the {{getAssertion()}} or
     {{makeCredential()}} call, while the <dfn>authenticator
     argument</dfn> is passed from the client to the authenticator during the
     processing of these calls.
@@ -1871,8 +1867,8 @@ dictionary AndroidAttestationClientData : ClientData {
   </p>
 
   <p>
-    An RP simultaneously requests the use of an extension and sets its client
-    argument by including an entry in the {{credentialExtensions}} 
+    A WebAuthn Relying Party simultaneously requests the use of an extension and sets its client
+    argument by including an entry in the {{credentialExtensions}}
 	or {{assertionExtensions}} dictionary
     parameters to the {{makeCredential()}} or {{getAssertion()}}
     call. The entry key MUST be the extension identifier, and the value
@@ -1923,8 +1919,8 @@ dictionary AndroidAttestationClientData : ClientData {
   <p>
     Extensions may define additional processing requirements on the client
     platform during the creation of credentials or the generation of an
-    assertion. In order for the RP to verify the processing took place, or if
-    the processing has a result value that the RP needs to be aware of, the
+    assertion. In order for the <a>WebAuthn Relying Party</a> to verify the processing took place, or if
+    the processing has a result value that the Relying Party needs to be aware of, the
     extension should specify a client data value to be included in the
     {{ClientData}} structure.
   </p>
@@ -1968,8 +1964,8 @@ dictionary AndroidAttestationClientData : ClientData {
   <p>
     The extension identifier is chosen as <code>com.example.webauthn.geo</code>.
     The client argument is the constant value <code>true</code>, since the
-    extension does not require the RP to pass any particular information to the
-    client, other than that it requests the use of the extension. The RP sets
+    extension does not require the <a>WebAuthn Relying Party</a> to pass any particular information to the
+    client, other than that it requests the use of the extension. The Relying Party sets
     this value in its request for an assertion:
   </p>
   <pre class="highlight">
@@ -1997,7 +1993,7 @@ dictionary AndroidAttestationClientData : ClientData {
 
   <p>
   The extension also requires the client to set the authenticator parameter to the fixed value
-  <code>1</code>. 
+  <code>1</code>.
   </p>
 
   <p>
@@ -2037,7 +2033,7 @@ dictionary AndroidAttestationClientData : ClientData {
   <dl>
     <dt>Extension identifier</dt>
     <dd>
-      <code>webauthn.txauth.simple</code> 
+      <code>webauthn.txauth.simple</code>
     </dd>
     <dt>Client argument</dt>
     <dd>A single UTF-8 encoded string <em>prompt</em></dd>
@@ -2115,7 +2111,7 @@ dictionary AndroidAttestationClientData : ClientData {
 typedef sequence < AAGUID > AuthenticatorSelectionList;
       </pre>
       Each AAGUID corresponds to an authenticator attestation that is
-      acceptable to the RP for this credential creation. The list is ordered by
+      acceptable to the Relying Party for this credential creation. The list is ordered by
       decreasing preference.<br>
 
       An AAGUID is defined as a DOMString, and is the globally unique identifier
@@ -2265,14 +2261,13 @@ typedef DOMString AAGUID;
       </table>
     </p>
 
-
 # Sample scenarios # {#sample-scenarios}
 
   <em>This section is not normative.</em>
 
   <p>In this section, we walk through some events in the lifecycle of a scoped credential, along with the corresponding sample code for using this API. Note that this is an example flow, and does not limit the scope of how the API can be used.</p>
 
-  <p>As was the case in earlier sections, this flow focuses on a use case involving an external first-factor authenticator with its own display. One example of such an authenticator would be a smart phone. Other authenticator types are also supported by this API, subject to implementation by the platform. For instance, this flow also works without modification for the case of an authenticator that is embedded in the client platform. The flow also works for the case of an external authenticator without its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the client platform needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the client platform to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.</p>
+  <p>As was the case in earlier sections, this flow focuses on a use case involving an external first-factor <a>authenticator</a> with its own display. One example of such an authenticator would be a smart phone. Other authenticator types are also supported by this API, subject to implementation by the platform. For instance, this flow also works without modification for the case of an authenticator that is embedded in the client platform. The flow also works for the case of an external authenticator without its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the client platform needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the client platform to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.</p>
 
 ## Registration ## {#sample-registration}
 
@@ -2285,10 +2280,10 @@ typedef DOMString AAGUID;
       <li>The client platform searches for and locates the external authenticator.</li>
       <li>The client platform connects to the external authenticator, performing any pairing actions if necessary.</li>
       <li>The external authenticator shows appropriate UI for the user to select the authenticator on which the new credential will be created, and obtains a biometric or other authorization gesture from the user.</li>
-      <li>The external authenticator returns a response to the client platform, which in turn returns a response to the RP script. If the user declined to select an authenticator or provide authorization, an appropriate error is returned.</li>
+      <li>The external authenticator returns a response to the client platform, which in turn returns a response to the Relying Party script. If the user declined to select an authenticator or provide authorization, an appropriate error is returned.</li>
       <li>If a new credential was created,
       <ol type="a">
-        <li>The RP script sends the newly generated public key to the server, along with additional information about public key such as attestation that it is held in trusted hardware.</li>
+        <li>The Relying Party script sends the newly generated public key to the server, along with additional information about public key such as attestation that it is held in trusted hardware.</li>
         <li>The server stores the public key in its database and associates it with the user as well as with the strength of authentication indicated by attestation, also storing a friendly name for later use.</li>
         <li>The script may store data such as the credential ID in local storage, to improve future UX by narrowing the choice of credential for the user.</li>
       </ol>
@@ -2311,7 +2306,7 @@ typedef DOMString AAGUID;
       imageUri: "https://pics.acme.com/00/p/aBjjjpqPb.png"
     };
 
-    // This RP will accept either an ES256 or RS256 credential, but
+    // This Relying Party will accept either an ES256 or RS256 credential, but
     // prefers an ES256 credential.
     var cryptoParams = [
       {
@@ -2346,12 +2341,12 @@ typedef DOMString AAGUID;
     <ol type ="1">
       <li>The user visits example.com, which serves up a script.</li>
       <li>The script asks the client platform for a WebAuthn identity assertion, providing as much information as possible to narrow the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after registration, or by other means such as prompting the user for a username.</li>
-      <li>The Relying Party script runs one of the code snippets below.</li>
+      <li>The <a>WebAuthn Relying Party</a> script runs one of the code snippets below.</li>
       <li>The client platform searches for and locates the external authenticator.</li>
       <li>The client platform connects to the external authenticator, performing any pairing actions if necessary.</li>
-      <li>The external authenticator presents the user with a notification that their attention is required. On opening the notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided when creating the credentials, along with some information on the origin that is requesting these keys.</li>
+      <li>The <a>external authenticator</a> presents the user with a notification that their attention is required. On opening the notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided when creating the credentials, along with some information on the origin that is requesting these keys.</li>
       <li>The authenticator obtains a biometric or other authorization gesture from the user.</li>
-      <li>The external authenticator returns a response to the client platform, which in turn returns a response to the RP script. If the user declined to select a credential or provide an authorization, an appropriate error is returned.</li>
+      <li>The external authenticator returns a response to the client platform, which in turn returns a response to the Relying Party script. If the user declined to select a credential or provide an authorization, an appropriate error is returned.</li>
       <li>If an assertion was successfully generated and returned,
       <ol type="a">
         <li>The script sends the assertion to the server.</li>
@@ -2422,7 +2417,7 @@ typedef DOMString AAGUID;
           <li>User goes to server.example.net, authenticates and follows a link to report a lost/stolen device.</li>
           <li>Server returns a page showing the list of registered credentials with friendly names as configured during registration.</li>
           <li>User selects a credential and the server deletes it from its database.</li>
-          <li>In future, Relying Party script does not specify this credential in any list of acceptable credentials, and assertions signed by this credential are rejected.</li>
+          <li>In future, the <a>WebAuthn Relying Party</a>a> script does not specify this credential in any list of acceptable credentials, and assertions signed by this credential are rejected.</li>
         </ul>
       </li>
 
@@ -2444,6 +2439,27 @@ typedef DOMString AAGUID;
       </li>
     </ul>
 
+# Terminology # {#terminology}
+
+  : <dfn>Attestation Certificate</dfn>
+  :: A X.509 Certificate for a keypair used by an <a>Authenticator</a> to attest to its manufacture and capabilities.
+
+  : <dfn>Authenticator</dfn>
+  :: The device used by the user agent to authenticate with the Relying Party. These can be <a>Embedded Authenticators</a> or <a>External Authenticators</a>.
+
+  : <dfn>Client</dfn>
+  : <dfn>WebAuthn Client</dfn>
+  :: See <a>Conforming User Agent</a>.
+
+  : <dfn>Conforming User Agent</dfn>
+  :: A user agent which implements algorithms given in this specification, and handles communication between the <a>Authenticator</a> and the <a>WebAuthn Relying Party</a>.
+
+  : <dfn>eTLD+1</dfn>
+  :: The effective top-level domain, plus the first label. Also known as a Registered Domain. See <a href="https://publicsuffix.org/">https://publicsuffix.org/</a>.
+
+  : <dfn>Relying Party</dfn>
+  : <dfn>WebAuthn Relying Party</dfn>
+  :: The entity which needs to rely in the authentication provided by the WebAuthn specification. At the conclusion of the account creation, the Relying Party has the public key that was created by the Authenticator.
 
 # Acknowledgements # {#acknowledgements}
   <p>We would like to thank the following for their contributions to, and thorough review of, this specification: Jing Jin, Michael B. Jones, Rolf Lindemann.


### PR DESCRIPTION
This is a first pass, placing the **Terminology** section just before **Acknowledgements**.

I made a pass through, attempting to ensure the first use of a term within a given section was always linked back to the definition.

I also made an effort to always spell out "WebAuthn Relying Party" for the first use in each section, and remove the use of "RP" (excepting the use of "RP ID").

There are some more whitespace cleanups as well, though I tried to minimize them. Again, I recommend reviewing using the `?w=1` URL such as:
https://github.com/w3c/webauthn/pull/68/files?expand=1&w=1