### PR TITLE
Rename imageUri to imageURL

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4,7 +4,7 @@ Status: ED
 TR: http://www.w3.org/TR/webauthn/
 ED: http://w3c.github.io/webauthn/
 Shortname: webauthnapi
-Level: 1
+Level: 
 Editor: Vijay Bharadwaj, Microsoft, vijay.bharadwaj@microsoft.com
 Editor: Hubert Le Van Gong, PayPal, hlevangong@paypal.com
 Editor: Dirk Balfanz, Google, balfanz@google.com
@@ -215,7 +215,7 @@ Markup Shorthands: css off, markdown on
       required DOMString displayName;
       DOMString          name;
       DOMString          id;
-      DOMString          imageUri;
+      DOMString          imageURL;
   };
 
   dictionary ScopedCredentialParameters {
@@ -408,7 +408,7 @@ Markup Shorthands: css off, markdown on
 
       <p>The <dfn>id</dfn> member contains an identifier for the account, stored for the use of the Relying Party. This is not meant to be displayed to the user.</p>
 
-      <p>The <dfn>imageUri</dfn> member contains a URI that resolves to the user's account image. This may be a URL that can be used to retrieve the user's current avatar, or a data URI that contains the image data.</p>
+      <p>The <dfn>imageURL</dfn> member contains a URL that resolves to the user's account image. This may be a URL that can be used to retrieve an image containing the user's current avatar, or a data URI that contains the image data.</p>
 
     </div>
 
@@ -2303,7 +2303,7 @@ typedef DOMString AAGUID;
       displayName: "John P. Smith",
       name: "johnpsmith@example.com",
       id: "1098237235409872",
-      imageUri: "https://pics.acme.com/00/p/aBjjjpqPb.png"
+      imageURL: "https://pics.acme.com/00/p/aBjjjpqPb.png"
     };
 
     // This Relying Party will accept either an ES256 or RS256 credential, but


### PR DESCRIPTION
Also removed the level from the metadata since it was appending a 1 to
the document title. Fixes #59. I decided not to mandate manifest
formatting of the icon to avoid the added complexity. Authenticators
would have to implement it, and we'd have to explore all the things a
bad person could do (e.g. have very different looking avatars at
different resolutions).