### PR TITLE
Markdown cleanup

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4,7 +4,7 @@ Status: ED
 TR: http://www.w3.org/TR/webauthn/
 ED: http://w3c.github.io/webauthn/
 Shortname: webauthnapi
-Level: 
+Level:
 Editor: Vijay Bharadwaj, Microsoft, vijay.bharadwaj@microsoft.com
 Editor: Hubert Le Van Gong, PayPal, hlevangong@paypal.com
 Editor: Dirk Balfanz, Google, balfanz@google.com
@@ -14,2176 +14,1800 @@ Editor: Jeff Hodges, PayPal, Jeff.Hodges@paypal.com
 Editor: Michael B. Jones, Microsoft, mbj@microsoft.com
 Editor: Rolf Lindemann, Nok Nok Labs, rolf@noknok.com
 group: webauthn
-Ignored Vars: op, current.algorithm, alg
-Abstract: This specification defines an API that enables web pages to access WebAuthn compliant strong cryptographic credentials through browser script. Conceptually, one or more credentials are stored on an authenticator, and each credential is scoped to a single <a>Relying Party</a>. Authenticators are responsible for ensuring that no operation is performed without the user's consent. The user agent mediates access to credentials in order to preserve user privacy. Authenticators use attestation to provide cryptographic proof of their properties to the relying party. This specification also describes a functional model of a WebAuthn compliant authenticator, including its signature and attestation functionality.
+Text Macro: RP WebAuthn Relying Party
+Text Macro: RPS WebAuthn Relying Parties
+Text Macro: INFORMATIVE <em>This section is not normative.</em>
+Ignored Vars: op, alg
+Abstract: This specification defines an API that enables web pages to access WebAuthn compliant strong cryptographic credentials
+    through browser script. Conceptually, one or more credentials are stored on an authenticator, and each credential is scoped
+    to a single Relying Party. Authenticators are responsible for ensuring that no operation is performed without the user's
+    consent. The user agent mediates access to credentials in order to preserve user privacy. Authenticators use attestation
+    to provide cryptographic proof of their properties to the relying party. This specification also describes a functional
+    model of a WebAuthn compliant authenticator, including its signature and attestation functionality.
 Boilerplate: omit conformance, omit feedback-header
 Markup Shorthands: css off, markdown on
 </pre>
 
+
 # Use Cases # {#use-cases}
 
-  <em>This section is not normative.</em>
+[INFORMATIVE]
 
-  <p>This specification defines an API for web pages to access scoped credentials through JavaScript, for the purpose of strongly authenticating a user. Scoped credentials are always scoped to a single <a>WebAuthn Relying Party</a>. This scoping is enforced jointly by the User Agent implementing the Web Authentication API and the authenticator that holds the credential, by constraining the availabilty and usage of credentials. Scoped credentials created by a Relying Party can only be accessed by web origins belonging to that Relying Party. Additionally, privacy across Relying Parties must be maintained; scripts must not be able to detect any properties, or even the existence, of scoped credentials belonging to other Relying Parties.</p>
+This specification defines an API for web pages to access scoped credentials through JavaScript, for the purpose of strongly
+authenticating a user. Scoped credentials are always scoped to a single <a>[RP]</a>. This scoping is enforced jointly by the
+User Agent implementing the Web Authentication API and the authenticator that holds the credential, by constraining the
+availabilty and usage of credentials. Scoped credentials created by a [RP] can only be accessed by web origins belonging to that
+[RP]. Additionally, privacy across [RPS] must be maintained; scripts must not be able to detect any properties, or even the
+existence, of scoped credentials belonging to other [RPS].
 
-  <p>Scoped credentials are located on <a>authenticators</a>, which can use them to perform operations subject to user consent. Broadly, authenticators are of two types:</p>
+Scoped credentials are located on <a>authenticators</a>, which can use them to perform operations subject to user consent.
+Broadly, authenticators are of two types:
 
-  <ol>
-    <li><dfn>Embedded authenticators</dfn> have their operation managed by the same computing device (e.g., smart phone, tablet, desktop PC) as the user agent is running on. For instance, such an authenticator might consist of a Trusted Platform Module (TPM) or Secure Element (SE) integrated into the computing device, along with appropriate platform software to mediate access to this device's functionality.</li>
-    <li><dfn>External authenticators</dfn> operate autonomously from the device running the user agent, and accessed over a transport such as Universal Serial Bus (USB), Bluetooth Low Energy (BLE) or Near Field Communications (NFC).</li>
-  </ol>
+1. <dfn>Embedded authenticators</dfn> have their operation managed by the same computing device (e.g., smart phone, tablet,
+    desktop PC) as the user agent is running on. For instance, such an authenticator might consist of a Trusted Platform Module
+    (TPM) or Secure Element (SE) integrated into the computing device, along with appropriate platform software to mediate
+    access to this device's functionality.
 
-  <p>Note that an external authenticator may itself contain an embedded authenticator. For example, consider a smart phone that contains a scoped credential. The credential may be accessed by a web browser running on the phone itself. In this case the module containing the credential is functioning as an embedded authenticator. However, the credential may also be accessed over BLE by a user agent on a nearby laptop. In this latter case, the phone is functioning as an external authenticator. These modes may even be used in a single end-to-end user scenario. One such scenario is described in the remainder of this section.</p>
+2. <dfn>External authenticators</dfn> operate autonomously from the device running the user agent, and accessed over a transport
+    such as Universal Serial Bus (USB), Bluetooth Low Energy (BLE) or Near Field Communications (NFC).
+
+Note that an external authenticator may itself contain an embedded authenticator. For example, consider a smart phone that
+contains a scoped credential. The credential may be accessed by a web browser running on the phone itself. In this case the
+module containing the credential is functioning as an embedded authenticator. However, the credential may also be accessed over
+BLE by a user agent on a nearby laptop. In this latter case, the phone is functioning as an external authenticator. These modes
+may even be used in a single end-to-end user scenario. One such scenario is described in the remainder of this section.
 
 
 ## Registration (<a>embedded authenticator</a> mode) ## {#registration-embedded}
 
-    <ul>
-      <li>
-        On the phone:
-        <ul>
-          <li>User goes to example.com in the browser, and signs in using whatever method they have been using (possibly a legacy method such as a password).</li>
-          <li>The phone prompts, &quot;Do you want to register this device with example.com?&quot;</li>
-          <li>User agrees.</li>
-          <li>The phone prompts the user for a previously configured authorization gesture (PIN, biometric, etc.); the user provides this.</li>
-          <li>Website shows message, &quot;Registration complete.&quot;</li>
-        </ul>
-      </li>
-    </ul>
+- On the phone:
+    * User goes to example.com in the browser, and signs in using whatever method they have been using (possibly a legacy
+        method such as a password).
+    * The phone prompts, "Do you want to register this device with example.com?"
+    * User agrees.
+    * The phone prompts the user for a previously configured authorization gesture (PIN, biometric, etc.); the user provides
+        this.
+    * Website shows message, "Registration complete."
 
 
 ## Authentication (<a>external authenticator</a> mode) ## {#authentication-external}
 
-    <ul>
-      <li>
-        On the laptop:
-        <ul>
-          <li>User goes to example.com in browser, sees an option &quot;Sign in with your phone.&quot;</li>
-          <li>User chooses this option and gets a message from the browser, &quot;Please complete this action on your phone.&quot;</li>
-        </ul>
-      </li>
+- On the laptop:
+    * User goes to example.com in browser, sees an option "Sign in with your phone."
+    * User chooses this option and gets a message from the browser, "Please complete this action on your phone."
 
-      <li>
-        Next, on the phone:
-        <ul>
-          <li>User sees a discreet prompt or notification, &quot;Sign in to example.com.&quot;</li>
-          <li>User selects this prompt / notification.</li>
-          <li>User is shown a list of their example.com identities, e.g., &quot;Sign in as Alice / Sign in as Bob.&quot;</li>
-          <li>User picks an identity, is prompted for an authorization gesture (PIN, biometric, etc.) and provides this.</li>
-        </ul>
-      </li>
+- Next, on the phone:
+    * User sees a discreet prompt or notification, "Sign in to example.com."
+    * User selects this prompt / notification.
+    * User is shown a list of their example.com identities, e.g., "Sign in as Alice / Sign in as Bob."
+    * User picks an identity, is prompted for an authorization gesture (PIN, biometric, etc.) and provides this.
 
-      <li>
-        Now, on the laptop:
-        <ul>
-          <li>Web page shows that the selected user is signed in, and navigates to the signed-in page.</li>
-        </ul>
-      </li>
-    </ul>
-
+- Now, on the laptop:
+    * Web page shows that the selected user is signed in, and navigates to the signed-in page.
 
 
 ## Other configurations ## {#other-configurations}
 
-    <p>A variety of additional use cases and configurations are also possible, including (but not limited to):</p>
+A variety of additional use cases and configurations are also possible, including (but not limited to):
 
-    <ul>
-      <li>User goes to example.com on their laptop, is guided through a flow to create and register a credential on their phone.</li>
-      <li>User employs a scoped credential as described above to authorize a single transaction, such as a payment or other financial transaction.</li>
-    </ul>
+- User goes to example.com on their laptop, is guided through a flow to create and register a credential on their phone.
+
+- User employs a scoped credential as described above to authorize a single transaction, such as a payment or other financial
+    transaction.
 
 
 # Conformance # {#conformance}
 
-  <p>This specification defines criteria for a <a>Conforming User Agent</a>. A User Agent MUST behave as described in this specification in order to be considered conformant. User Agents MAY implement algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's algorithms. A conforming Web Authentication API User Agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the “Web IDL” specification. [[!WebIDL-1]]</p>
+This specification defines criteria for a <a>Conforming User Agent</a>. A User Agent MUST behave as described in this
+specification in order to be considered conformant. User Agents MAY implement algorithms given in this specification in any way
+desired, so long as the end result is indistinguishable from the result that would be obtained by the specification's
+algorithms. A conforming Web Authentication API User Agent MUST also be a conforming implementation of the IDL fragments of this
+specification, as described in the “Web IDL” specification. [[!WebIDL-1]]
 
-  <p>This specification also defines a model of a Web Authentication compliant authenticator. This is a set of functional and security requirements for an authenticator to be usable by a User Agent that implements the Web Authentication API. As described in [[#use-cases]], the authenticator itself may be implemented in the operating system underlying the User Agent, or in external hardware, or a combination of both.</p>
+This specification also defines a model of a Web Authentication compliant authenticator. This is a set of functional and
+security requirements for an authenticator to be usable by a User Agent that implements the Web Authentication API. As described
+in [[#use-cases]], the authenticator itself may be implemented in the operating system underlying the User Agent, or in external
+hardware, or a combination of both.
+
 
 ## Dependencies ## {#dependencies}
 
-    <p>This specification relies on several other underlying specifications.</p>
+This specification relies on several other underlying specifications.
 
-    <dl>
-      <dt>HTML5</dt>
-      <dd>The concept of <dfn>origin</dfn> and the <dfn>Window</dfn> interface are defined in [[!HTML5]].</dd>
+: HTML5
+:: The concept of <dfn>origin</dfn> and the <dfn>Window</dfn> interface are defined in [[!HTML5]].
 
-      <dt>Web IDL</dt>
-      <dd>Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL-1]]. This updated version of the Web IDL standard adds support for <dfn>Promises</dfn>, which are now the preferred mechanism for asynchronous interaction in all new web APIs.</dd>
+: Web IDL
+:: Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL-1]]. This updated version of
+    the Web IDL standard adds support for <dfn>Promises</dfn>, which are now the preferred mechanism for asynchronous
+    interaction in all new web APIs.
 
-      <dt>DOM</dt>
-      <dd><dfn>DOMException</dfn> and the DOMException values used in this specification are defined in [[!DOM4]].</dd>
+: DOM
+:: <dfn>DOMException</dfn> and the DOMException values used in this specification are defined in [[!DOM4]].
 
-      <dt>Web Cryptography API</dt>
-      <dd>The <dfn interface>AlgorithmIdentifier</dfn> type and the method for normalizing an algorithm are defined in [[!WebCryptoAPI]].</dd>
-	  <dd><dfn interface>JsonWebKey</dfn>: A cryptographic key as defined in [[!WebCryptoAPI]], in [[WebCryptoAPI#JsonWebKey-dictionary]].</dd>
-	  
-	  <dt>Base64url encoding</dt>
-	  <!-- begin from signature-format -->
-	  <dd> The term <dfn>Base64url Encoding</dfn> refers to the base64 encoding using the URL- and filename-safe character set defined in Section 5 of [[!RFC4648]], with all trailing '=' characters omitted (as permitted by Section 3.2) and without the inclusion of any line breaks, whitespace, or other additional characters. This is the same encoding as used by JSON Web Signature (JWS) [[RFC7515]].</dd>
-	  <!-- end from signature-format -->
-    </dl>
+: Web Cryptography API
+:: The <dfn dictionary>AlgorithmIdentifier</dfn> type and the method for normalizing an algorithm are defined in
+    [[WebCryptoAPI#algorithm-dictionary]].
+:: The <dfn interface>JsonWebKey</dfn> interface for representing cryptographic keys is defined in
+    [[WebCryptoAPI#JsonWebKey-dictionary]].
 
+: Base64url encoding
+:: The term <dfn>Base64url Encoding</dfn> refers to the base64 encoding using the URL- and filename-safe character set defined
+    in Section 5 of [[!RFC4648]], with all trailing '=' characters omitted (as permitted by Section 3.2) and without the
+    inclusion of any line breaks, whitespace, or other additional characters. This is the same encoding as used by JSON Web
+    Signature (JWS) [[RFC7515]].
 
 
 # Web Authentication API # {#api}
 
-  <p>This section normatively specifies the API for creating and using scoped credentials. Support for deleting credentials is deliberately omitted; this is expected to be done through platform-specific user interfaces rather than from a script. The basic idea is that the credentials belong to the user and are managed by the browser and underlying platform. Scripts can (with the user&apos;s consent) request the browser to create a new credential for future use by the script's origin. Scripts can also request the user’s permission to perform authentication operations with an existing credential held by the platform. However, all such operations are mediated by the browser and/or platform on the user&apos;s behalf. At no point does the script get access to the credentials themselves; it only gets information about the credentials in the form of objects.</p>
+This section normatively specifies the API for creating and using scoped credentials. Support for deleting credentials is
+deliberately omitted; this is expected to be done through platform-specific user interfaces rather than from a script. The basic
+idea is that the credentials belong to the user and are managed by the browser and underlying platform. Scripts can (with the
+user's consent) request the browser to create a new credential for future use by the script's origin. Scripts can also request
+the user’s permission to perform authentication operations with an existing credential held by the platform. However, all such
+operations are mediated by the browser and/or platform on the user's behalf. At no point does the script get access to the
+credentials themselves; it only gets information about the credentials in the form of objects.
 
-  <p>User agents SHOULD only expose this API to callers in <dfn>secure contexts</dfn>, as defined in [[powerful-features]].</p>
+User agents SHOULD only expose this API to callers in <dfn>secure contexts</dfn>, as defined in [[powerful-features]].
 
-  <p>The API is defined by the following Web IDL fragment.</p>
+The API is defined by the following Web IDL fragment.
 
-  <pre class="idl">
-  partial interface Window {
-      readonly attribute WebAuthentication webauthn;
-  };
+<pre class="idl">
+    partial interface Window {
+        readonly attribute WebAuthentication webauthn;
+    };
 
-  interface WebAuthentication {
-      Promise < ScopedCredentialInfo > makeCredential (
-          Account                                 accountInformation,
-          sequence < ScopedCredentialParameters > cryptoParameters,
-          DOMString                               attestationChallenge,
-          optional unsigned long                  credentialTimeoutSeconds,
-          optional sequence < Credential >        blacklist,
-          optional WebAuthnExtensions             credentialExtensions
-      );
+    interface WebAuthentication {
+        Promise < ScopedCredentialInfo > makeCredential (
+            Account                                 accountInformation,
+            sequence < ScopedCredentialParameters > cryptoParameters,
+            DOMString                               attestationChallenge,
+            optional unsigned long                  credentialTimeoutSeconds,
+            optional sequence < Credential >        blacklist,
+            optional WebAuthnExtensions             credentialExtensions
+        );
 
-      Promise < WebAuthnAssertion > getAssertion (
-          DOMString                        assertionChallenge,
-          optional unsigned long           assertionTimeoutSeconds,
-          optional sequence < Credential > whitelist,
-          optional WebAuthnExtensions      assertionExtensions
-      );
-  };
+        Promise < WebAuthnAssertion > getAssertion (
+            DOMString                        assertionChallenge,
+            optional unsigned long           assertionTimeoutSeconds,
+            optional sequence < Credential > whitelist,
+            optional WebAuthnExtensions      assertionExtensions
+        );
+    };
 
-  interface ScopedCredentialInfo {
-      readonly attribute Credential           credential;
-      readonly attribute any                  publicKey;
-      readonly attribute AttestationStatement attestation;
-  };
+    interface ScopedCredentialInfo {
+        readonly attribute Credential           credential;
+        readonly attribute any                  publicKey;
+        readonly attribute AttestationStatement attestation;
+    };
 
-  dictionary Account {
-      required DOMString rpDisplayName;
-      required DOMString displayName;
-      DOMString          name;
-      DOMString          id;
-      DOMString          imageURL;
-  };
+    dictionary Account {
+        required DOMString rpDisplayName;
+        required DOMString displayName;
+        DOMString          name;
+        DOMString          id;
+        DOMString          imageURL;
+    };
 
-  dictionary ScopedCredentialParameters {
-      required CredentialType        type;
-      required AlgorithmIdentifier   algorithm;
-  };
+    dictionary ScopedCredentialParameters {
+        required CredentialType        type;
+        required AlgorithmIdentifier   algorithm;
+    };
 
-  interface WebAuthnAssertion {
-	  readonly attribute Credential credential;
-	  readonly attribute DOMString  clientData;
-	  readonly attribute DOMString  authenticatorData;
-	  readonly attribute DOMString  signature;
-  };
+    interface WebAuthnAssertion {
+        readonly attribute Credential credential;
+        readonly attribute DOMString  clientData;
+        readonly attribute DOMString  authenticatorData;
+        readonly attribute DOMString  signature;
+    };
 
-  dictionary ClientData {
-	  required DOMString       challenge;
-	  required DOMString       facet;
-	  required JsonWebKey      tokenBinding;
-	  required AlgorithmIdentifier hashAlg;
-	  WebAuthnExtensions          extensions;
-  };
+    dictionary ClientData {
+        required DOMString       challenge;
+        required DOMString       facet;
+        required JsonWebKey      tokenBinding;
+        required AlgorithmIdentifier hashAlg;
+        WebAuthnExtensions          extensions;
+    };
 
-  dictionary WebAuthnExtensions {
-  };
-  
-	interface AttestationStatement {
-		readonly    attribute AttestationHeader header;
-		readonly    attribute AttestationCore   core;
-		readonly    attribute DOMString         signature;
-	};
+    dictionary WebAuthnExtensions {
+    };
 
-	interface AttestationCore {
-		readonly    attribute DOMString     type;
-		readonly    attribute unsigned long version;
-		readonly    attribute DOMString     rawData;
-		readonly    attribute DOMString     clientData;
-	};
+    interface AttestationStatement {
+        readonly    attribute AttestationHeader header;
+        readonly    attribute AttestationCore   core;
+        readonly    attribute DOMString         signature;
+    };
 
-	interface AttestationHeader {
-		readonly    attribute DOMString   claimedAAGUID;
-		readonly    attribute DOMString[] x5c;
-		readonly    attribute DOMString   alg;
-	};
+    interface AttestationCore {
+        readonly    attribute DOMString     type;
+        readonly    attribute unsigned long version;
+        readonly    attribute DOMString     rawData;
+        readonly    attribute DOMString     clientData;
+    };
 
-  enum CredentialType {
-      "ScopedCred"
-  };
+    interface AttestationHeader {
+        readonly    attribute DOMString   claimedAAGUID;
+        readonly    attribute DOMString[] x5c;
+        readonly    attribute DOMString   alg;
+    };
 
-  interface Credential {
-      readonly attribute CredentialType type;
-      readonly attribute DOMString      id;
-  };
-  </pre>
+    enum CredentialType {
+        "ScopedCred"
+    };
+
+    interface Credential {
+        readonly attribute CredentialType type;
+        readonly attribute DOMString      id;
+    };
+</pre>
+
 
 ## <dfn interface>WebAuthentication</dfn> Interface ## {#iface-credential}
 
-    <p>This interface consists of the following methods.</p>
+This interface has two methods, which are described in the following subsections.
+
 
 ### Create a new credential (<dfn method for="WebAuthentication">makeCredential()</dfn> method) ### {#makeCredential}
 
-      <p>With this method, a script can request the User Agent to create a new credential of a given type and persist it to the underlying platform, which may involve data storage managed by the browser or the OS. The user agent will prompt the user to approve this operation. On success, the promise will be resolved with a {{ScopedCredentialInfo}} object describing the newly created credential.</p>
+With this method, a script can request the User Agent to create a new credential of a given type and persist it to the
+underlying platform, which may involve data storage managed by the browser or the OS. The user agent will prompt the user to
+approve this operation. On success, the promise will be resolved with a {{ScopedCredentialInfo}} object describing the newly
+created credential.
 
-      <p>This method takes the following parameters:</p>
+This method takes the following parameters:
 
-      <ul>
-        <li>The <dfn>accountInformation</dfn> parameter specifies information about the user account for which the credential is being created. This is meant for later use by the authenticator when it needs to prompt the user to select a credential.</li>
+- The <dfn>accountInformation</dfn> parameter specifies information about the user account for which the credential is being
+    created. This is meant for later use by the authenticator when it needs to prompt the user to select a credential.
 
-        <li>The <dfn>cryptoParameters</dfn> parameter supplies information about the desired properties of the credential to be created. The sequence is ordered from most preferred to least preferred. The platform makes a best effort to create the most preferred credential that it can.</li>
+- The <dfn>cryptoParameters</dfn> parameter supplies information about the desired properties of the credential to be created.
+    The sequence is ordered from most preferred to least preferred. The platform makes a best effort to create the most
+    preferred credential that it can.
 
-        <li>The <dfn>attestationChallenge</dfn> parameter contains a challenge intended to be used for generating the attestation statement of the newly created credential.</li>
+- The <dfn>attestationChallenge</dfn> parameter contains a challenge intended to be used for generating the attestation
+    statement of the newly created credential.
 
-        <li>The optional <dfn>credentialTimeoutSeconds</dfn> parameter specifies a time, in seconds, that the caller is willing to wait for the call to complete. This is treated as a hint, and may be overridden by the platform.</li>
+- The optional <dfn>credentialTimeoutSeconds</dfn> parameter specifies a time, in seconds, that the caller is willing to wait
+    for the call to complete. This is treated as a hint, and may be overridden by the platform.
 
-        <li>The optional <dfn>blacklist</dfn> parameter is intended for use by <a>WebAuthn Relying Parties</a> that wish to limit the creation of multiple credentials for the same account on a single authenticator. The platform is requested to return an error if the new credential would be created on an authenticator that also contains one of the credentials enumerated in this parameter.</li>
+- The optional <dfn>blacklist</dfn> parameter is intended for use by <a>[RPS]</a> that wish to limit the creation of multiple
+    credentials for the same account on a single authenticator. The platform is requested to return an error if the new
+    credential would be created on an authenticator that also contains one of the credentials enumerated in this parameter.
 
-        <li>The optional <dfn>credentialExtensions</dfn> parameter contains additional parameters requesting additional processing by the client and authenticator. For example, the caller may request that only authenticators with certain capabilities be used to create the credential, or that additional information be returned in the attestation statement. Alternatively, the caller may specify an additional message that they would like the authenticator to display to the user. Extensions are defined in [[#signature-format]].</li>
-      </ul>
+- The optional <dfn>credentialExtensions</dfn> parameter contains additional parameters requesting additional processing by
+    the client and authenticator. For example, the caller may request that only authenticators with certain capabilities be
+    used to create the credential, or that additional information be returned in the attestation statement. Alternatively, the
+    caller may specify an additional message that they would like the authenticator to display to the user. Extensions are
+    defined in [[#extensions]].
 
-      <p>When this method is invoked, the user agent MUST execute the following algorithm:<p>
+When this method is invoked, the user agent MUST execute the following algorithm:
 
-      <ol type="1">
+1. If <a>credentialTimeoutSeconds</a> was specified, check if its value lies within a reasonable range as defined by the
+    platform and if not, correct it to the closest value lying within that range. Set |adjustedTimeout| to this adjusted value.
+    If <a>credentialTimeoutSeconds</a> was not specified then set |adjustedTimeout| to a platform-specific default.
 
+2. Let |promise| be a new <a data-lt="Promises">Promise</a>. Return |promise| and start a timer for |adjustedTimeout| seconds.
+    Then asynchronously continue executing the following steps.
 
-        <li>If <a><code>credentialTimeoutSeconds</code></a> was specified, check if its value lies within a reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set <var>adjustedTimeout</var> to this adjusted value. If <a><code>credentialTimeoutSeconds</code></a> was not specified then set <var>adjustedTimeout</var> to a platform-specific default.</li>
+3. Set |callerOrigin| to the <a>origin</a> of the caller. Derive the RP ID from |callerOrigin| by computing the
+    "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>")
+    part of |callerOrigin| [[PSL]]. Set |rpId| to the RP ID.
 
-        <li>Let <var>promise</var> be a new <a data-lt="Promises">Promise</a>. Return <var>promise</var> and start a timer for <var>adjustedTimeout</var> seconds. Then asynchronously continue executing the following steps.</li>
+4. Initialize |issuedRequests| to an empty list.
 
-        <li>Set <var>callerOrigin</var> to the <a><code>origin</code></a> of the caller. Derive the RP ID from <var>callerOrigin</var> by computing the "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>") part of <var>callerOrigin</var> [[PSL]]. Set <var>rpId</var> to the RP ID.</li>
+5. Process each element of <a>cryptoParameters</a> using the following steps:
+    - Let |current| be the currently selected element of <a>cryptoParameters</a>.
+    - If `current.type` does not contain a {{CredentialType}} supported by this implementation, then stop processing |current|
+        and move on to the next element in <a>cryptoParameters</a>.
+    - Let |normalizedAlgorithm| be the result of normalizing an algorithm using the procedure defined in [[!WebCryptoAPI]],
+        with |alg| set to `current.algorithm` and |op| set to 'generateKey'. If an error occurs during this procedure, then
+        stop processing |current| and move on to the next element in <a>cryptoParameters</a>.
 
-        <li>Initialize <var>issuedRequests</var> to an empty list.</li>
+6. If <a>blacklist</a> is undefined, set it to the empty list.
 
-        <li>
-          Process each element of <a><code>cryptoParameters</code></a> using the following steps:
+7. If <a>credentialExtensions</a> was specified, process any extensions supported by this client platform, to produce the
+    extension data that needs to be sent to the authenticator. Call this data |clientExtensions|.
 
-          <ol type="a">
+8. For each embedded or external authenticator currently available on this platform: asynchronously invoke the
+    <a>authenticatorMakeCredential</a> operation on that authenticator with |callerOrigin|, |rpId|, <a>accountInformation</a>,
+    `current.type`, |normalizedAlgorithm|, <a>blacklist</a>, <a>attestationChallenge</a> and |clientExtensions| as parameters.
+    Add a corresponding entry to |issuedRequests|.
 
-            <li>Let <var>current</var> be the currently selected element of <a><code>cryptoParameters</code></a>.</li>
+9. While |issuedRequests| is not empty, perform the following actions depending upon the |adjustedTimeout| timer and responses
+    from the authenticators:
+    - If the |adjustedTimeout| timer expires, then for each entry in |issuedRequests| invoke the <a>authenticatorCancel</a>
+        operation on that authenticator and remove its entry from the list.
+    - If any authenticator returns a status indicating that the user cancelled the operation, delete that authenticator's
+        entry from |issuedRequests|. For each remaining entry in |issuedRequests| invoke the <a>authenticatorCancel</a>
+        operation on that authenticator and remove its entry from the list.
+    - If any authenticator returns an error status, delete the corresponding entry from |issuedRequests|.
+    - If any authenticator indicates success, create a new {{ScopedCredentialInfo}} object named |value| and populate its
+        fields with the values returned from the authenticator. Resolve |promise| with |value| and terminate this algorithm.
 
-            <li>If <var>current.type</var> does not contain a {{CredentialType}} supported by this implementation, then stop processing <var>current</var> and move on to the next element in <a><code>cryptoParameters</code></a>.</li>
+10. Resolve |promise| with a <a>DOMException</a> whose name is "NotFoundError", and terminate this algorithm.
 
-            <li>Let <var>normalizedAlgorithm</var> be the result of normalizing an algorithm using the procedure defined in [[!WebCryptoAPI]], with <var>alg</var> set to <var>current.algorithm</var> and <var>op</var> set to &quot;generateKey&quot;. If an error occurs during this procedure, then stop processing <var>current</var> and move on to the next element in <a><code>cryptoParameters</code></a>.</li>
-          </ol>
-        </li>
-
-        <li>If <a><code>blacklist</code></a> is undefined, set it to the empty list.</li>
-
-        <li>If <a><code>credentialExtensions</code></a> was specified, process any extensions supported by this client platform, to produce the extension data that needs to be sent to the authenticator. Call this data <var>clientExtensions</var>.</li>
-
-        <li>For each embedded or external authenticator currently available on this platform: asynchronously invoke the <a><code>authenticatorMakeCredential</code></a> operation on that authenticator with <var>callerOrigin</var>, <var>rpId</var>, <a><code>accountInformation</code></a>, <var>current.type</var>, <var>normalizedAlgorithm</var>, <a><code>blacklist</code></a>, <a><code>attestationChallenge</code></a> and <var>clientExtensions</var> as parameters. Add a corresponding entry to <var>issuedRequests</var>.</li>
-
-        <li>
-          While <var>issuedRequests</var> is not empty, perform the following actions depending upon the <var>adjustedTimeout</var> timer and responses from the authenticators:
-
-          <ol type="a">
-
-            <li>If the <var>adjustedTimeout</var> timer expires, then for each entry in <var>issuedRequests</var> invoke the <a><code>authenticatorCancel</code></a> operation on that authenticator and remove its entry from the list.</li>
-
-            <li>If any authenticator returns a status indicating that the user cancelled the operation, delete that authenticator's entry from <var>issuedRequests</var>. For each remaining entry in <var>issuedRequests</var> invoke the <a><code>authenticatorCancel</code></a> operation on that authenticator and remove its entry from the list.</li>
-
-            <li>If any authenticator returns an error status, delete the corresponding entry from <var>issuedRequests</var>.</li>
-            <li>If any authenticator indicates success, create a new {{ScopedCredentialInfo}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <var>value</var> and terminate this algorithm.</li>
-          </ol>
-        </li>
-
-        <li>Resolve <var>promise</var> with a <a><code>DOMException</code></a> whose name is "<code>NotFoundError</code>", and terminate this algorithm.</li>
-
-      </ol>
-
-      <p>During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and authorizing an authenticator.</p>
-
-
+During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and
+authorizing an authenticator.
 
 
 ### Use an existing credential (<dfn method for="WebAuthentication">getAssertion()</dfn> method) ### {#getAssertion}
 
-      <p>This method is used to discover and use an existing scoped credential, with the user's consent. The script optionally specifies some criteria to indicate what credentials are acceptable to it. The user agent and/or platform locates credentials matching the specified criteria, and guides the user to pick one that the script should be allowed to use. The user may choose not to provide a credential even if one is present, for example to maintain privacy.</p>
+This method is used to discover and use an existing scoped credential, with the user's consent. The script optionally specifies
+some criteria to indicate what credentials are acceptable to it. The user agent and/or platform locates credentials matching the
+specified criteria, and guides the user to pick one that the script should be allowed to use. The user may choose not to provide
+a credential even if one is present, for example to maintain privacy.
 
-      <p>This method takes the following parameters:</p>
+This method takes the following parameters:
 
-      <ul>
-        <li>The <dfn>assertionChallenge</dfn> parameter contains a string that the selected authenticator is expected to sign to produce the assertion.</li>
+- The <dfn>assertionChallenge</dfn> parameter contains a string that the selected authenticator is expected to sign to produce
+    the assertion.
 
-        <li>The optional <dfn>assertionTimeoutSeconds</dfn> parameter specifies a time, in seconds, that the caller is willing to wait for the call to complete. This is treated as a hint, and may be overridden by the platform.</li>
+- The optional <dfn>assertionTimeoutSeconds</dfn> parameter specifies a time, in seconds, that the caller is willing to wait
+    for the call to complete. This is treated as a hint, and may be overridden by the platform.
 
-        <li>The optional <dfn>whitelist</dfn> member contains a list of credentials acceptable to the caller, in order of the caller's preference.</li>
+- The optional <dfn>whitelist</dfn> member contains a list of credentials acceptable to the caller, in order of the caller's
+    preference.
 
-        <li>The optional <dfn>assertionExtensions</dfn> parameter contains additional parameters requesting additional processing by the client and authenticator. For example, if transaction confirmation is sought from the user, then the prompt string would be included in an extension. Extensions are defined in a companion specification.</li>
-      </ul>
+- The optional <dfn>assertionExtensions</dfn> parameter contains additional parameters requesting additional processing by the
+    client and authenticator. For example, if transaction confirmation is sought from the user, then the prompt string would be
+    included in an extension. Extensions are defined in a companion specification.
 
-      <p>When this method is invoked, the user agent MUST execute the following algorithm:<p>
+When this method is invoked, the user agent MUST execute the following algorithm:
 
-      <ol type="1">
+1. If <a>assertionTimeoutSeconds</a> was specified, check if its value lies within a reasonable range as defined by the platform
+    and if not, correct it to the closest value lying within that range. Set |adjustedTimeout| to this adjusted value. If
+    <a>assertionTimeoutSeconds</a> was not specified then set |adjustedTimeout| to a platform-specific default.
 
-        <li>If <a><code>assertionTimeoutSeconds</code></a> was specified, check if its value lies within a reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set <var>adjustedTimeout</var> to this adjusted value. If <a><code>assertionTimeoutSeconds</code></a> was not specified then set <var>adjustedTimeout</var> to a platform-specific default.</li>
+2. Let |promise| be a new <a data-lt="Promises">Promise</a>. Return |promise| and start a timer for |adjustedTimeout| seconds.
+    Then asynchronously continue executing the following steps.
 
-        <li>Let <var>promise</var> be a new <a data-lt="Promises">Promise</a>. Return <var>promise</var> and start a timer for <var>adjustedTimeout</var> seconds. Then asynchronously continue executing the following steps.</li>
+3. Set |callerOrigin| to the <a>origin</a> of the caller. Derive the RP ID from |callerOrigin| by computing the
+    "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>")
+    part of |callerOrigin| [[PSL]]. Set |rpId| to the RP ID.
 
-        <li>Set <var>callerOrigin</var> to the <a><code>origin</code></a> of the caller. Derive the RP ID from <var>callerOrigin</var> by computing the "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>") part of <var>callerOrigin</var> [[PSL]]. Set <var>rpId</var> to the RP ID.</li>
+4. Initialize |issuedRequests| to an empty list.
 
-        <li>Initialize <var>issuedRequests</var> to an empty list.</li>
+5. If <a>assertionExtensions</a> was specified, process any extensions supported by this client platform, to produce the
+    extension data that needs to be sent to the authenticator. Call this data |clientExtensions|.
 
-        <li>If <a><code>assertionExtensions</code></a> was specified, process any extensions supported by this client platform, to produce the extension data that needs to be sent to the authenticator. Call this data <var>clientExtensions</var>.</li>
+6. For each embedded or external authenticator currently available on this platform, perform the following steps:
+    - If <a>whitelist</a> is undefined or empty, let |credentialList| be a list containing a single wildcard entry.
+    <!-- TBD The wildcard syntax needs to be defined and/or referenced here. -->
+    - If <a>whitelist</a> is defined and non-empty, optionally execute a platform-specific procedure to determine which of these
+        credentials can possibly be present on this authenticator. Set |credentialList| to this filtered list. If
+        |credentialList| is empty, ignore this authenticator and do not perform any of the following per-authenticator steps.
+    - Asynchronously invoke the <a>authenticatorGetAssertion</a> operation on this authenticator with |callerOrigin|, |rpId|,
+        <a>assertionChallenge</a>, |credentialList|, and |clientExtensions| as parameters.
+    - Add an entry to |issuedRequests|, corresponding to this request.
 
-        <li>
-          For each embedded or external authenticator currently available on this platform, perform the following steps:
+7. While |issuedRequests| is not empty, perform the following actions depending upon the |adjustedTimeout| timer and responses
+    from the authenticators:
+    - If the timer for |adjustedTimeout| expires, then for each entry in |issuedRequests| invoke the <a>authenticatorCancel</a>
+        operation on that authenticator and remove its entry from the list.
+    - If any authenticator returns a status indicating that the user cancelled the operation, delete that authenticator's entry
+        from |issuedRequests|. For each remaining entry in |issuedRequests| invoke the <a>authenticatorCancel</a> operation on
+        that authenticator, and remove its entry from the list.
+    - If any authenticator returns an error status, delete the corresponding entry from |issuedRequests|.
+    - If any authenticator returns success, create a new {{WebAuthnAssertion}} object named |value| and populate its fields
+        with the values returned from the authenticator. Resolve |promise| with |value| and terminate this algorithm.
 
-          <ol type="a">
-            <li>If <a><code>whitelist</code></a> is undefined or empty, let <var>credentialList</var> be a list containing a single wildcard entry.</li> <!-- TBD The wildcard syntax needs to be defined and/or referenced here. -->
+8. Resolve |promise| with a <a>DOMException</a> whose name is "NotFoundError", and terminate this algorithm.
 
-            <li>If <a><code>whitelist</code></a> is defined and non-empty, optionally execute a platform-specific procedure to determine which of these credentials can possibly be present on this authenticator. Set <var>credentialList</var> to this filtered list. If <var>credentialList</var> is empty, ignore this authenticator and do not perform any of the following per-authenticator steps.</li>
-
-            <li>Asynchronously invoke the <a><code>authenticatorGetAssertion</code></a> operation on this authenticator with <var>callerOrigin</var>, <var>rpId</var>, <a><code>assertionChallenge</code></a>, <var>credentialList</var>, and <var>clientExtensions</var> as parameters.</li>
-
-            <li>Add an entry to <var>issuedRequests</var>, corresponding to this request.</li>
-
-          </ol>
-        </li>
-
-        <li>
-          While <var>issuedRequests</var> is not empty, perform the following actions depending upon the <var>adjustedTimeout</var> timer and responses from the authenticators:
-
-          <ol type="a">
-
-            <li>If the timer for <var>adjustedTimeout</var> expires, then for each entry in <var>issuedRequests</var> invoke the <a><code>authenticatorCancel</code></a> operation on that authenticator and remove its entry from the list.</li>
-
-            <li>If any authenticator returns a status indicating that the user cancelled the operation, delete that authenticator's entry from <var>issuedRequests</var>. For each remaining entry in <var>issuedRequests</var> invoke the <a><code>authenticatorCancel</code></a> operation on that authenticator, and remove its entry from the list.</li>
-
-            <li>If any authenticator returns an error status, delete the corresponding entry from <var>issuedRequests</var>.</li>
-
-            <li>If any authenticator returns success, create a new {{WebAuthnAssertion}} object named <var>value</var> and populate its fields with the values returned from the authenticator. Resolve <var>promise</var> with <code>value</code> and terminate this algorithm.</li>
-          </ol>
-        </li>
-
-        <li>Resolve <var>promise</var> with a <a><code>DOMException</code></a> whose name is "<code>NotFoundError</code>", and terminate this algorithm.</li>
-
-      </ol>
-
-      <p>During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and authorizing an authenticator with which to complete the operation.</p>
+During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and
+authorizing an authenticator with which to complete the operation.
 
 
 ## <dfn interface>ScopedCredentialInfo</dfn> Interface ## {#iface-credentialInfo}
 
-    <div dfn-for="ScopedCredentialInfo">
-      <p>This interface represents a newly-created scoped credential. It contains information about the credential that can be used to locate it later for use, and also contains metadata that can be used by the <a>WebAuthn Relying Party</a> to assess the strength of the credential during registration.</p>
+<div dfn-for="ScopedCredentialInfo">
+    This interface represents a newly-created scoped credential. It contains information about the credential that can be used
+    to locate it later for use, and also contains metadata that can be used by the <a>[RP]</a> to assess the strength of the
+    credential during registration.
 
-      <p>The <dfn>credential</dfn> attribute contains a unique identifier for the credential represented by this object.</p>
+    The <dfn>credential</dfn> attribute contains a unique identifier for the credential represented by this object.
 
-      <p>The <dfn>publicKey</dfn> attribute contains the public key associated with the credential, represented as a JsonWebKey structure as defined in [[WebCryptoAPI#JsonWebKey-dictionary]].</p>
+    The <dfn>publicKey</dfn> attribute contains the public key associated with the credential, represented as a JsonWebKey
+    structure as defined in [[WebCryptoAPI#JsonWebKey-dictionary]].
 
-      <p>The <dfn>attestation</dfn> attribute contains a key attestation statement returned by the authenticator. This provides information about the credential and the authenticator it is held in, such as the level of security assurance provided by the authenticator.</p>
-    </div>
+    The <dfn>attestation</dfn> attribute contains a key attestation statement returned by the authenticator. This provides
+    information about the credential and the authenticator it is held in, such as the level of security assurance provided by
+    the authenticator.
+</div>
 
 
 ## User Account Information (dictionary <dfn dictionary>Account</dfn>) ## {#iface-account}
 
-    <div dfn-for="Account">
-      <p>This dictionary is used by the caller to specify information about the user account and <a>WebAuthn Relying Party</a> with which a credential is to be associated. It is intended to help the authenticator in providing a friendly credential selection interface for the user.</p>
+<div dfn-for="Account">
+    This dictionary is used by the caller to specify information about the user account and <a>[RP]</a> with which a credential
+    is to be associated. It is intended to help the authenticator in providing a friendly credential selection interface for the
+    user.
 
-      <p> The <dfn>rpDisplayName</dfn> member contains the friendly name of the Relying Party, such as "Acme Corporation", "Widgets Inc" or "Awesome Site".</p>
+    The <dfn>rpDisplayName</dfn> member contains the friendly name of the [RP], such as "Acme Corporation", "Widgets Inc" or
+    "Awesome Site".
 
-      <p>The <dfn>displayName</dfn> member contains the friendly name associated with the user account by the Relying Party, such as "John P. Smith".</p>
+    The <dfn>displayName</dfn> member contains the friendly name associated with the user account by the [RP], such as "John P.
+    Smith".
 
-      <p>The <dfn>name</dfn> member contains a detailed name for the account, such as "john.p.smith@example.com".</p>
+    The <dfn>name</dfn> member contains a detailed name for the account, such as "john.p.smith@example.com".
 
-      <p>The <dfn>id</dfn> member contains an identifier for the account, stored for the use of the Relying Party. This is not meant to be displayed to the user.</p>
+    The <dfn>id</dfn> member contains an identifier for the account, stored for the use of the [RP]. This is not meant to be
+    displayed to the user.
 
-      <p>The <dfn>imageURL</dfn> member contains a URL that resolves to the user's account image. This may be a URL that can be used to retrieve an image containing the user's current avatar, or a data URI that contains the image data.</p>
-
-    </div>
+    The <dfn>imageURL</dfn> member contains a URL that resolves to the user's account image. This may be a URL that can be used
+    to retrieve an image containing the user's current avatar, or a data URI that contains the image data.
+</div>
 
 
 ## Parameters for Credential Generation (dictionary <dfn dictionary>ScopedCredentialParameters</dfn>) ## {#credential-params}
 
-    <div dfn-for="ScopedCredentialParameters">
-      <p>This dictionary is used to supply additional parameters when creating a new credential.</p>
+<div dfn-for="ScopedCredentialParameters">
+    This dictionary is used to supply additional parameters when creating a new credential.
 
-      <p>The <dfn>type</dfn> member specifies the type of credential to be created.</p>
+    The <dfn>type</dfn> member specifies the type of credential to be created.
 
-      <p>The <dfn>algorithm</dfn> member specifies the cryptographic algorithm with which the newly generated credential will be used.</p> <!-- TBD This should probably say that the type of this field is AlgorithmIdentifier. -->
-    </div>
+    The <dfn>algorithm</dfn> member specifies the cryptographic algorithm with which the newly generated credential will be
+    used.
+</div>
 
 
 ## WebAuthn Assertion (interface <dfn interface>WebAuthnAssertion</dfn>) ## {#iface-assertion}
 
-    <p>Scoped credentials produce a cryptographic signature that provides proof of possession of a private key as well as evidence of user consent to a specific transaction. The structure of these signatures is defined as follows.</p>
-	  
-	<div dfn-for="WebAuthnAssertion">
-		<p>The <dfn>credential</dfn> member represents the credential that was used to generate this assertion.</p>
+Scoped credentials produce a cryptographic signature that provides proof of possession of a private key as well as evidence of
+user consent to a specific transaction. The structure of these signatures is defined as follows.
 
-		<p>The <dfn>clientData</dfn> member contains the base64url encoding of the parameters sent to the authenticator by the client. (See <a>clientDataJSON</a> in <a href="#sec-client-data"></a>)</p>
+<div dfn-for="WebAuthnAssertion">
+    The <dfn>credential</dfn> member represents the credential that was used to generate this assertion.
 
-		<p>The <dfn>authenticatorData</dfn> member contains the base64url encoding of the data returned by the authenticator. (See <a href="#sec-authenticator-data"></a>)</p>
+    The <dfn>clientData</dfn> member contains the base64url encoding of the parameters sent to the authenticator by the client.
+    (See <a>clientDataJSON</a> in [[#sec-client-data]].)
 
-		<p>The <dfn>signature</dfn> member contains the base64url encoding of the raw signature returned from the authenticator. (See <a href="#authenticator-signature"></a>)</p>
-	</div>
+    The <dfn>authenticatorData</dfn> member contains the base64url encoding of the data returned by the authenticator. (See
+    [[#sec-authenticator-data]].)
+
+    The <dfn>signature</dfn> member contains the base64url encoding of the raw signature returned from the authenticator. (See
+    [[#authenticator-signature]].)
+</div>
+
 
 ## Client data used in assertion (dictionary <dfn dictionary>ClientData</dfn>) ## {#sec-client-data}
 
-  <p>The client data represents the contextual bindings of both the WebAuthn Relying Party and the
-  client platform.  It is a key-value mapping with string-valued keys. Values may be
-  any type that has a valid encoding in JSON.  It MUST contain at least the
-  following key-value pairs.</p>
+The client data represents the contextual bindings of both the [RP] and the client platform. It is a key-value mapping with
+string-valued keys. Values may be any type that has a valid encoding in JSON. It MUST contain at least the following key-value
+pairs.
 
-  <div dfn-for="ClientData">
-	<p>The <dfn>challenge</dfn> member contains the base64url-encoded challenge provided by the RP.</p>
+<div dfn-for="ClientData">
+    The <dfn>challenge</dfn> member contains the base64url-encoded challenge provided by the RP.
 
-    <p>The <dfn>facet</dfn> member contains a string value describing the RP identifier facet.
-      When the WebAuthn Relying Party client-side app is a website, this is its fully qualified web origin,
-      using the syntax defined by [[RFC6454]]. When the client-side app is a native
-      application, this string is a platform specific identifier.
-    </p>
-	
-    <p>The <dfn>tokenBinding</dfn> member contains a JsonWebKey object as defined by [[WebCryptoAPI#JsonWebKey-dictionary]] describing the public key that this client uses for
-      the Token Binding protocol when communicating with the WebAuthn Relying Party.
-      This can be omitted if no Token Binding has been negotiated between the
-      client and the Relying Party.
-    </p>
-	
-	<p>The <dfn>hashAlg</dfn> member specifies the hash algorithm used to compute clientDataHash 
-      (see [[#authenticator-signature]]).  Use "S256" for SHA-256, 
-      "S384" for SHA384, "S512" for SHA512, and "SM3" for SM3 
-      (see [[#iana-considerations]]). 
-    </p>
+    The <dfn>facet</dfn> member contains a string value describing the RP identifier facet. When the [RP] client-side app is a
+    website, this is its fully qualified web origin, using the syntax defined by [[RFC6454]]. When the client-side app is a
+    native application, this string is a platform specific identifier.
 
-    <p>The optional <dfn>extensions</dfn> member contains the extension-provided authenticator data.
-      Signature extensions are detailed in Section <a href="#extensions"></a>.
-    </p>	
-  </div>
+    The <dfn>tokenBinding</dfn> member contains a JsonWebKey object as defined by [[WebCryptoAPI#JsonWebKey-dictionary]]
+    describing the public key that this client uses for the Token Binding protocol when communicating with the [RP]. This can be
+    omitted if no Token Binding has been negotiated between the client and the [RP].
 
-## WebAuthn Assertion Extensions (dictionary <dfn>WebAuthExtensions</dfn>) ## {#iface-assertion-extensions}
+    The <dfn>hashAlg</dfn> member specifies the hash algorithm used to compute clientDataHash (see
+    [[#authenticator-signature]]). Use "S256" for SHA-256, "S384" for SHA384, "S512" for SHA512, and "SM3" for SM3 (see
+    [[#iana-considerations]]).
 
-      <p>This is a dictionary containing zero or more extensions as defined in [[#extensions]]. An extension is an additional parameter that can be passed to the <a>getAssertion()</a> method and triggers some additional processing by the client platform and/or the authenticator.</p>
-
-      <p>
-        If the caller wants to pass extensions to the platform, it SHOULD do so by adding one
-        entry per extension to this <code>WebAuthExtensions</code> dictionary with
-        the extension identifier as the key, and the extension's value as the value
-        (see [[#signature-format]] for details).
-      </p>
+    The optional <dfn>extensions</dfn> member contains the extension-provided authenticator data. Signature extensions are
+    detailed in Section [[#extensions]].
+</div>
 
 
-## Key Attestation Statement (interface <dfn>AttestationStatement</dfn>) ## {#iface-attestation-statement}
+## WebAuthn Assertion Extensions (dictionary <dfn dictionary>WebAuthnExtensions</dfn>) ## {#iface-assertion-extensions}
 
-      <p>Authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each credential public key, attestation information that can be verified by a <a>WebAuthn Relying Party</a>. Typically this information contains a signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information providing provenance information for the attesting key, enabling a trust decision to be made.</p>
+This is a dictionary containing zero or more extensions as defined in [[#extensions]]. An extension is an additional parameter
+that can be passed to the <a>getAssertion()</a> method and triggers some additional processing by the client platform and/or the
+authenticator.
 
-	<div dfn-for="AttestationStatement">
-	  <p>
-	  The <dfn>header</dfn> element contains the attestation header, including algorithm, (optionally) the claimed AAGUID 
-	    and (optionally) the attestation certificate chain.
-	  </p>
+If the caller wants to pass extensions to the platform, it SHOULD do so by adding one entry per extension to this dictionary
+with the extension identifier as the key, and the extension's value as the value (see [[#signature-format]] for details).
 
-	  <p>The <dfn>core</dfn> element describes the data that is being attested to, and its type.</p>
 
-	  <p>The <dfn>signature</dfn> element contains the base64url-encoded attestation signature.  The structure of this 
-	    object depends on the signature algorithm specified in the header.
-	  </p>
-	</div>
+## Key Attestation Statement (interface <dfn interface>AttestationStatement</dfn>) ## {#iface-attestation-statement}
 
-	<p>This attestation statement is delivered to the <a>WebAuthn Relying Party</a> according to the Client API.
-	  It contains all the information that the Relying Party's server requires to
-	  reconstruct the signature base string, as well as to decode and validate
-	  the bindings of both the client- and authenticator data.
-	</p>
+Authenticators also provide some form of key attestation. The basic requirement is that the authenticator can produce, for each
+credential public key, attestation information that can be verified by a <a>[RP]</a>. Typically this information contains a
+signature by an attesting key over the attested public key and a challenge, as well as a certificate or similar information
+providing provenance information for the attesting key, enabling a trust decision to be made.
 
-## Credential Attestation Header (interface <dfn>AttestationHeader</dfn>) ## {#sec-attestation-header}
+<div dfn-for="AttestationStatement">
+    The <dfn>header</dfn> element contains the attestation header, including algorithm, (optionally) the claimed AAGUID and
+    (optionally) the attestation certificate chain.
 
-	This structure contains additional data required to verify the attestation signature. 
+    The <dfn>core</dfn> element describes the data that is being attested to, and its type.
 
-	<div dfn-for="AttestationHeader">
-	  <p>The <dfn>claimedAAGUID</dfn> element contains the claimed Authenticator Attestation GUID (a version 4 GUID, see [[RFC4122]]).
-	    This value is used by the <a>WebAuthn Relying Party</a> to
-	    lookup the trust anchor for verifying the following <a>AttestationCore</a> object.
-	    If the verification succeeds,
-	    the AAGUID related to the trust anchor is trusted.  This field MUST be present, if either no
-	    attestation certificates are used (e.g., DAA) or if the attestation
-	    certificate doesn't contain the AAGUID value in an extension.
-	  </p>
+    The <dfn>signature</dfn> element contains the base64url-encoded attestation signature. The structure of this object depends
+    on the signature algorithm specified in the header.
+</div>
 
-	  <p>The <dfn>x5c</dfn> attribute contains the attestation certificate and its certificate chain as described
-	    in [[!RFC7515]] section 4.1.6.</p>
+This attestation statement is delivered to the <a>[RP]</a> according to the Client API. It contains all the information that the
+[RP]'s server requires to reconstruct the signature base string, as well as to decode and validate the bindings of both the
+client- and authenticator data.
 
-	  <p>The <dfn>alg</dfn> element contains the name of the algorithm used to generate the attestation signature according to [[!RFC7518]].
-	    See [[#packed-attestation-signature]] for the signature algorithms
-	      to be implemented by servers.</p>
-	</div>
 
-## Attestation core data (interface <dfn>AttestationCore</dfn>) ## {#sec-attestationcore}
+## Credential Attestation Header (interface <dfn interface>AttestationHeader</dfn>) ## {#sec-attestation-header}
 
-	This structure contains the data attested by the Authenticator and a description of its structure.
-	Different types of Authenticators might generate different object types
-	(identified by <code>type</code> and <code>version</code>).
+This structure contains additional data required to verify the attestation signature.
 
-	<div dfn-for="AttestationCore">
-	  <p>The <dfn>type</dfn> member specifies the type of the rawData object. This specification defines a number of
-	    attestation raw data types, in [[#defined-attestation-raw-data-types]]. Other attestation
-	    raw data types may be defined in further versions of this specification.
-	  </p>
-	  
-	  <p>The <dfn>version</dfn> member specifies the version number of the rawData object.</p>
+<div dfn-for="AttestationHeader">
+    The <dfn>claimedAAGUID</dfn> element contains the claimed Authenticator Attestation GUID (a version 4 GUID, see
+    [[RFC4122]]). This value is used by the <a>[RP]</a> to look up the trust anchor for verifying the following
+    {{AttestationCore}} object. If the verification succeeds, the AAGUID related to the trust anchor is trusted. This field MUST
+    be present, if either no attestation certificates are used (e.g., DAA) or if the attestation certificate doesn't contain the
+    AAGUID value in an extension.
 
-	  <p>The <dfn>rawData</dfn> object contains the attested public key
-	    and the <code>clientDataHash</code>.
-	  </p>
+    The <dfn>x5c</dfn> attribute contains the attestation certificate and its certificate chain as described in [[!RFC7515]]
+    section 4.1.6.
 
-	  <p>The <dfn>clientData</dfn> member contains the base64url encoding of <a>clientDataJSON</a> (see [[#signature-format]]). The
-	    exact encoding must be preserved as the hash (clientDataHash) has been
-	    computed over it.
-	  </p>
-	</div>
+    The <dfn>alg</dfn> element contains the name of the algorithm used to generate the attestation signature according to
+    [[!RFC7518]]. See [[#packed-attestation-signature]] for the signature algorithms to be implemented by servers.
+</div>
+
+
+## Attestation core data (interface <dfn interface>AttestationCore</dfn>) ## {#sec-attestationcore}
+
+This structure contains the data attested by the Authenticator and a description of its structure. Different types of
+Authenticators might generate different object types (identified by {{AttestationCore/type}} and {{AttestationCore/version}}).
+
+<div dfn-for="AttestationCore">
+    The <dfn>type</dfn> member specifies the type of the rawData object. This specification defines a number of attestation raw
+    data types, in [[#defined-attestation-raw-data-types]]. Other attestation raw data types may be defined in further versions
+    of this specification.
+
+    The <dfn>version</dfn> member specifies the version number of the rawData object.
+
+    The <dfn>rawData</dfn> object contains the attested public key and the |clientDataHash|.
+
+    The <dfn>clientData</dfn> member contains the base64url encoding of <a>clientDataJSON</a> (see [[#signature-format]]). The
+    exact encoding must be preserved as the hash (clientDataHash) has been computed over it.
+</div>
 
 
 ## Supporting Data Structures ## {#supporting-data-structures}
 
-    The scoped credential type uses certain data structures that are specified in supporting specifications. These are as follows.
+The scoped credential type uses certain data structures that are specified in supporting specifications. These are as follows.
+
 
 ### Credential Type enumeration (enum <dfn enum>CredentialType</dfn>) ### {#credentialType}
 
-      <div dfn-for="CredentialType">
-        <p>This enumeration defines the valid credential types. It is an extension point; values may be added to it in the future, as more credential types are defined. The values of this enumeration are used for versioning the WebAuthn assertion and attestation statement according to the type of the authenticator.</p>
+<div dfn-for="CredentialType">
+    This enumeration defines the valid credential types. It is an extension point; values may be added to it in the future, as
+    more credential types are defined. The values of this enumeration are used for versioning the WebAuthn assertion and
+    attestation statement according to the type of the authenticator.
 
-        <p>Currently one credential type is defined, namely &quot;<dfn>ScopedCred</dfn>&quot;.</p>
-      </div>
+    Currently one credential type is defined, namely "<dfn>ScopedCred</dfn>".
+</div>
 
 
 ### Unique Identifier for Credential (interface <dfn interface>Credential</dfn>) ### {#credential-identifier}
 
-      <p>This interface contains the attributes that are returned to the caller when a new credential is created, and can be used later by the caller to select a credential for use.</p>
+This interface contains the attributes that are returned to the caller when a new credential is created, and can be used later
+by the caller to select a credential for use.
 
-      <div dfn-for="Credential">
-      <p>The <dfn>type</dfn> attribute indicates the specification and version that this credential conforms to.</p> <!-- TBD Why isn't this called "version", since it's a version identifier? -->
+<div dfn-for="Credential">
+    The <dfn>type</dfn> attribute indicates the specification and version that this credential conforms to.
 
-        <p>The <dfn>id</dfn> attribute contains an identifier for the credential, chosen by the platform with help from the authenticator. This identifier is used to look up credentials for use, and is therefore expected to be globally unique with high probability across all credentials of the same type. This API does not constrain the format or length of this identifier, except that it must be sufficient for the platform to uniquely select a key. For example, an authenticator without on-board storage may create identifiers that consist of the key material wrapped with a key that is burned into the authenticator.</p>
-      </div>
+    The <dfn>id</dfn> attribute contains an identifier for the credential, chosen by the platform with help from the
+    authenticator. This identifier is used to look up credentials for use, and is therefore expected to be globally unique with
+    high probability across all credentials of the same type. This API does not constrain the format or length of this
+    identifier, except that it must be sufficient for the platform to uniquely select a key. For example, an authenticator
+    without on-board storage may create identifiers that consist of the key material wrapped with a key that is burned into the
+    authenticator.
+</div>
 
 
 ### Cryptographic Algorithm Identifier (type {{AlgorithmIdentifier}}) ### {#alg-identifier}
 
-      <p>A string or dictionary identifying a cryptographic algorithm and optionally a set of parameters for that algorithm. This type is defined in [[!WebCryptoAPI]].</p>
+A string or dictionary identifying a cryptographic algorithm and optionally a set of parameters for that algorithm. This type is
+defined in [[!WebCryptoAPI]].
 
-	  
+
 # WebAuthn Authenticator model # {#authenticator-model}
 
-  <p>The API defined in this specification implies a specific abstract functional model for an <a>authenticator</a>. This section describes the authenticator model. Client platforms may implement and expose this abstract model in any way desired. However, the behavior of the client's Web Authentication API implementation, when operating on the embedded and external authenticators supported by that platform, MUST be indistinguishable from the behavior specified in the <a href="#api">Web Authentication API</a> section.</p>
+The API defined in this specification implies a specific abstract functional model for an <a>authenticator</a>. This section
+describes the authenticator model. Client platforms may implement and expose this abstract model in any way desired. However,
+the behavior of the client's Web Authentication API implementation, when operating on the embedded and external authenticators
+supported by that platform, MUST be indistinguishable from the behavior specified in [[#api]].
 
-  <p>In this abstract model, each authenticator stores some number of scoped credentials. Each scoped credential has an identifier which is unique (or extremely unlikely to be duplicated) among all scoped credentials. Each credential is also associated with a <a>WebAuthn Relying Party</a>, whose identity is represented by a <dfn>Relying Party Identifier</dfn> (RP ID).</p>
+In this abstract model, each authenticator stores some number of scoped credentials. Each scoped credential has an identifier
+which is unique (or extremely unlikely to be duplicated) among all scoped credentials. Each credential is also associated with a
+<a>[RP]</a>, whose identity is represented by a <dfn>Relying Party Identifier</dfn> (RP ID).
+
 
 ## Authenticator operations ## {#authenticator-ops}
-  
-  <p>A client must connect to an authenticator in order to invoke any of the operations of that authenticator. This connection defines an authenticator session. An authenticator must maintain isolation between sessions. It may do this by only allowing one session to exist at any particular time, or by providing more complicated session management.</p>
 
-  <p>The following operations can be invoked by the client in an authenticator session.</p>
+A client must connect to an authenticator in order to invoke any of the operations of that authenticator. This connection
+defines an authenticator session. An authenticator must maintain isolation between sessions. It may do this by only allowing one
+session to exist at any particular time, or by providing more complicated session management.
+
+The following operations can be invoked by the client in an authenticator session.
+
 
 ### The <dfn>authenticatorMakeCredential</dfn> operation ### {#op-make-cred}
 
-    <p>This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following input parameters:</p>
+This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following
+input parameters:
 
-    <ul>
-      <li>The web origin of the script on whose behalf the operation is being initiated, as determined by the user agent and the client.</li>
-      <li>The RP ID corresponding to the above web origin, as determined by the user agent and the client.</li>
-      <li>All input parameters accepted by the <a><code>makeCredential()</code></a> method, specified below.</li>
-    </ul>
+- The web origin of the script on whose behalf the operation is being initiated, as determined by the user agent and the client.
 
-    <p>When this operation is invoked, the authenticator obtains user consent for creating a new credential. The prompt for obtaining this consent is shown by the authenticator if it has its own output capability, or by the user agent otherwise. Once user consent is obtained, the authenticator generates the appropriate cryptographic keys and creates a new credential. It then associates the credential with the specified RP ID such that it will be able to retrieve the RP ID later, given the credential ID.</p>
+- The RP ID corresponding to the above web origin, as determined by the user agent and the client.
 
-    <p>On successful completion of this operation, the authenticator returns the type and unique identifier of this new credential to the user agent.</p>
+- All input parameters accepted by the {{makeCredential()}} method.
 
-    <p>If the user refuses consent, the authenticator returns an appropriate error status to the client.</p>
+When this operation is invoked, the authenticator obtains user consent for creating a new credential. The prompt for obtaining
+this consent is shown by the authenticator if it has its own output capability, or by the user agent otherwise. Once user
+consent is obtained, the authenticator generates the appropriate cryptographic keys and creates a new credential. It then
+associates the credential with the specified RP ID such that it will be able to retrieve the RP ID later, given the credential
+ID.
+
+On successful completion of this operation, the authenticator returns the type and unique identifier of this new credential to
+the user agent.
+
+If the user refuses consent, the authenticator returns an appropriate error status to the client.
+
 
 ### The <dfn>authenticatorGetAssertion</dfn> operation ### {#op-get-assertion}
 
-    <p>This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following input parameters:</p>
+This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following
+input parameters:
 
-    <ul>
-      <li>The web origin of the script on whose behalf the operation is being initiated, as determined by the user agent and the client.</li>
-      <li>The RP ID corresponding to the above web origin, as determined by the user agent and the client.</li>
-      <li>All input parameters accepted by the <a><code>getAssertion()</code></a> method, specified below.</li>
-    </ul>
+- The web origin of the script on whose behalf the operation is being initiated, as determined by the user agent and the client.
 
-    <p>When this method is invoked, the authenticator allows the user to select a credential from among the credentials associated with that Relying Party and matching the specified criteria, then obtains user consent for using that credential. The prompt for obtaining this consent may be shown by the authenticator if it has its own output capability, or by the user agent otherwise. Once a credential is selected and user consent is obtained, the authenticator computes a cryptographic signature using the credential's private key and constructs an assertion as specified in [[#signature-format]]. It then returns this assertion to the user agent.</p>
+- The RP ID corresponding to the above web origin, as determined by the user agent and the client.
 
-    <p>If the authenticator cannot find any credential corresponding to the specified Relying Party that matches the specified criteria, it terminates the operation and returns an error.</p>
+- All input parameters accepted by the {{getAssertion()}} method, specified below.
 
-    <p>If the user refuses consent, the authenticator returns an appropriate error status to the client.</p>
+When this method is invoked, the authenticator allows the user to select a credential from among the credentials associated with
+that [RP] and matching the specified criteria, then obtains user consent for using that credential. The prompt for obtaining
+this consent may be shown by the authenticator if it has its own output capability, or by the user agent otherwise. Once a
+credential is selected and user consent is obtained, the authenticator computes a cryptographic signature using the credential's
+private key and constructs an assertion as specified in [[#signature-format]]. It then returns this assertion to the user agent.
+
+If the authenticator cannot find any credential corresponding to the specified [RP] that matches the specified criteria, it
+terminates the operation and returns an error.
+
+If the user refuses consent, the authenticator returns an appropriate error status to the client.
+
 
 ### The <dfn>authenticatorCancel</dfn> operation ### {#op-cancel}
 
-    <p>This operation takes no input parameters and returns no result.</p>
+This operation takes no input parameters and returns no result.
 
-    <p>When this operation is invoked by the client in an authenticator session, it has the effect of terminating any <a><code>authenticatorMakeCredential</code></a> or <a><code>authenticatorGetAssertion</code></a> operation currently in progress in that authenticator session. The authenticator stops prompting for, or accepting, any user input related to authorizing the canceled operation. The client ignores any further responses from the authenticator for the canceled operation.</p>
+When this operation is invoked by the client in an authenticator session, it has the effect of terminating any
+<a>authenticatorMakeCredential</a> or <a>authenticatorGetAssertion</a> operation currently in progress in that authenticator
+session. The authenticator stops prompting for, or accepting, any user input related to authorizing the canceled operation. The
+client ignores any further responses from the authenticator for the canceled operation.
 
-    <p>This operation is ignored if it is invoked in an authenticator session which does not have an <a><code>authenticatorMakeCredential</code></a> or <a><code>authenticatorGetAssertion</code></a> operation currently in progress.</p>
+This operation is ignored if it is invoked in an authenticator session which does not have an <a>authenticatorMakeCredential</a>
+or <a>authenticatorGetAssertion</a> operation currently in progress.
 
-
-<!-- Included from signature-format.html -->
 
 ## Signature Format ## {#signature-format}
 
+WebAuthn signatures are bound to various contextual data. These data are observed, and added at different levels of the stack as
+a signature request passes from the server to the authenticator. In verifying a signature, the server checks these bindings
+against expected values.
 
-<p>WebAuthn signatures are bound to various contextual data. These data are
-observed, and added at different levels of the stack as a signature request
-passes from the server to the authenticator. In verifying a signature, the
-server checks these bindings against expected values.</p>
+The components of a system using WebAuthn can be divided into three layers:
 
-<p>The components of a system using WebAuthn can be divided into three layers:</p>
-<ol>
-  <li>The <a>WebAuthn Relying Party</a> (RP), which uses the WebAuthn services.
-  The relying party may, for example, be a web-application running in a browser,
-  or a native application that runs directly on the OS platform.</li>
-  <li>The <a>WebAuthn Client</a> platform, which consists of the user’s OS and device used to
-  host the RP’s client-side app. For web-applications, the browser also belongs
-  to this layer.</li>
-  <li>The <a>Authenticator</a> itself, which provides key management and
-  cryptographic signatures.</li>
-</ol>
+1. The <a>[RP]</a> (RP), which uses the WebAuthn services. The RP may, for example, be a web-application running in a browser,
+    or a native application that runs directly on the OS platform.
 
-<p>When the Relying Party client-side application is a web-application, the interface between 1 and 2
-is the <a href="#api">Web Authentication API</a>, but is platform specific for native applications.
-In cases where the authenticator is not tightly integrated with the platform, the interface
-between 2 and 3 is a separately-defined protocol.
-This specification defines the common signature format
-shared by all layers.  This includes how the different contextual bindings are
-encoded, signed over, and delivered to the RP.</p>
+2. The <a>WebAuthn Client</a> platform, which consists of the user’s OS and device used to host the RP’s client-side app. For
+    web-applications, the browser also belongs to this layer.
 
-<p>The goals of this design can be summarized as follows.</p>
-<ul>
-  <li>The scheme for generating signatures should accommodate cases where the
-  link between the client platform and authenticator is very limited, in
-  bandwidth and/or latency. Examples include Bluetooth Low Energy and Near-Field
-  Communication.</li>
-  <li>The data processed by the authenticator should be small and easy to
-  interpret in low-level code. In particular, authenticators should not have to
-  parse high-level encodings such as JSON.</li>
-  <li>Both the client platform and the authenticator should have the flexibility
-  to add contextual bindings as needed.</li>
-  <li>The design aims to reuse as much as possible of existing encoding formats
-  in order to aid adoption and implementation.</li>
-</ul>
+3. The <a>Authenticator</a> itself, which provides key management and cryptographic signatures.
 
-<p>The contextual bindings are divided in two: Those added by the RP or the
-client platform, referred to as client data; and those added by the
-authenticator, referred to as the authenticator data.  The client
-data must be signed over, but an authenticator is otherwise not interested in
-its contents. To save bandwidth and processing requirements on the
-authenticator, the client platform hashes the client data and sends only
-the result to the authenticator. The authenticator signs over the combination
-of this hash, and its own authenticator data.</p>
+When the [RP] client-side application is a web-application, the interface between 1 and 2 is the [[#api]], but is platform
+specific for native applications. In cases where the authenticator is not tightly integrated with the platform, the interface
+between 2 and 3 is a separately-defined protocol. This specification defines the common signature format shared by all layers.
+This includes how the different contextual bindings are encoded, signed over, and delivered to the RP.
+
+The goals of this design can be summarized as follows.
+
+- The scheme for generating signatures should accommodate cases where the link between the client platform and authenticator
+    is very limited, in bandwidth and/or latency. Examples include Bluetooth Low Energy and Near-Field Communication.
+
+- The data processed by the authenticator should be small and easy to interpret in low-level code. In particular, authenticators
+    should not have to parse high-level encodings such as JSON.
+
+- Both the client platform and the authenticator should have the flexibility to add contextual bindings as needed.
+
+- The design aims to reuse as much as possible of existing encoding formats in order to aid adoption and implementation.
+
+The contextual bindings are divided in two: Those added by the RP or the client platform, referred to as client data; and those
+added by the authenticator, referred to as the authenticator data. The client data must be signed over, but an authenticator is
+otherwise not interested in its contents. To save bandwidth and processing requirements on the authenticator, the client
+platform hashes the client data and sends only the result to the authenticator. The authenticator signs over the combination of
+this hash, and its own authenticator data.
 
 
 ### Authenticator data ### {#sec-authenticator-data}
 
-  <p>The authenticator data encodes contextual bindings made by the
-  <a>authenticator</a> itself. The authenticator data has a compact but extensible
-  encoding. This is desired since authenticators can be devices with limited
-  capabilities and low power requirements, with much simpler software stacks
-  than the client platform components.</p>
+The authenticator data encodes contextual bindings made by the <a>authenticator</a> itself. The authenticator data has a compact
+but extensible encoding. This is desired since authenticators can be devices with limited capabilities and low power
+requirements, with much simpler software stacks than the client platform components.
 
-  <p>The encoding of authenticator data is a byte array <code>#JsonWebKey-dictionary</code>
-  of 5 bytes or more, as follows.</p>
-  <table class="complex data longlastcol">
+The encoding of authenticator data is a byte array [[WebCryptoAPI#JsonWebKey-dictionary]] of 5 bytes or more, as follows.
+
+<table class="complex data longlastcol">
     <tr>
-      <th>Byte index</th>
-      <th>Description</th>
+        <th>Byte index</th>
+        <th>Description</th>
     </tr>
     <tr>
-      <td>0</td>
-      <td>Flags (bit 0 is the least significant bit):
-        <ul>
-          <li>Bit 0: Test of User Presence (<code>TUP</code>) result.</li>
-          <li>Bits 1-6: Reserved for future use (<code>RFU</code>).</li>
-          <li>Bit 7: Extension data included (<code>ED</code>). Indicates if the
-          authenticator data has extensions.</li>
-        </ul>
-      </td>
+        <td>0</td>
+        <td>
+            Flags (bit 0 is the least significant bit):
+            - Bit 0: Test of User Presence (`TUP`) result.
+            - Bits 1-6: Reserved for future use (`RFU`).
+            - Bit 7: Extension data included (`ED`). Indicates if the authenticator data has extensions.
+        </td>
     </tr>
     <tr>
-      <td>1-4</td>
-      <td>Signature counter (<code>signCount</code>), 32-bit unsigned big-endian integer.</td>
+        <td>1-4</td>
+        <td>Signature counter (`signCount`), 32-bit unsigned big-endian integer.</td>
     </tr>
     <tr>
-      <td>5-</td>
-      <td>Extension-defined authenticator data. This is a CBOR [[RFC7049]] map with extension
-      identifiers as keys, and extension authenticator data values as values. See 
-      <a href="#extensions"></a> for details.</td>
+        <td>5-</td>
+        <td>
+            Extension-defined authenticator data. This is a CBOR [[RFC7049]] map with extension identifiers as keys, and
+            extension authenticator data values as values. See [[#extensions]] for details.
+        </td>
     </tr>
-  </table>
+</table>
 
-  <p>The <code>TUP</code> flag SHALL be set if and only if the authenticator
-  detected a user through an authenticator specific gesture. The <code>RFU</code>
-  bits in the flags byte SHALL be set to zero.</p>
+The `TUP` flag SHALL be set if and only if the authenticator detected a user through an authenticator specific gesture. The
+`RFU` bits in the flags byte SHALL be set to zero.
 
-  <p>If the authenticator does not include any extension data, it MUST set the
-  <code>ED</code> flag in the first byte to zero, and to one if extension data
-  is included.</p>
+If the authenticator does not include any extension data, it MUST set the `ED` flag in the first byte to zero, and to one if
+extension data is included.
 
-  <p>The figure below shows a visual representation of the
-  authenticator data structure.</p>
+The figure below shows a visual representation of the authenticator data structure.
 
-  <figure>
+<figure>
     <img src="img/fido-signature-formats-figure1.svg"/>
-    <figcaption><code>authenticatorData</code> layout.</figcaption>
-  </figure>
+    <figcaption>`authenticatorData` layout.</figcaption>
+</figure>
 
-  <p class="note">
-  The <code>signatureData</code> describes its own length: If the ED flag is not set, it
-  is always 5 bytes long. If the ED flag is set, it is 5 bytes plus the CBOR map that follows.
-  </p>
+Note: The `signatureData` describes its own length: If the ED flag is not set, it is always 5 bytes long. If the ED flag is set,
+it is 5 bytes plus the CBOR map that follows.
 
 
 ### Generating a signature ### {#authenticator-signature}
 
-  <p>Before making a request to an authenticator, the
-  client platform layer SHALL perform the following steps.</p>
-  <ol>
-    <li>Let <dfn>clientDataJSON</dfn> be the UTF-8 encoded JSON serialization
-    [[RFC7159]] of {{ClientData}}.</li>
+Before making a request to an authenticator, the client platform layer SHALL perform the following steps.
 
-    <li>Let <var>clientDataHash</var> be the hash (computed using <a>hashAlg</a>) of
-    <a>clientDataJSON</a>, as an array.</li>
-  </ol>
+1. Let <dfn>clientDataJSON</dfn> be the UTF-8 encoded JSON serialization [[RFC7159]] of {{ClientData}}.
 
-  <p>The <var>clientDataHash</var> value is incorporated into a signature
-  by an authenticator (see <a href="#authenticator-signature"></a>).
-  It is delivered to integrated authenticators
-  in platform specific manners, and to external authenticators as a part of
-  a signature request.
-  The client platform SHOULD also preserve the exact <code>encodedClientData</code>
-  string used to create it, for embedding in a signature object sent back to
-  the WebAuthn Relying Party (see <a href="#authenticator-signature"></a>).
-  This is necessary since multiple JSON encodings of the same client
-  data are possible.</p>
+2. Let |clientDataHash| be the hash (computed using <a>hashAlg</a>) of <a>clientDataJSON</a>, as an array.
 
-  <p>The hash algorithm <a>hashAlg</a> used to compute <var>clientDataHash</var> is
-    included in the {{ClientData}} object. This way it is available to the Relying Party and
-    it is also hashed over when computing <var>clientDataHash</var> and hence
-    anchored in the signature itself.
-  </p>
+The |clientDataHash| value is incorporated into a signature by an authenticator (see [[#authenticator-signature]]). It is
+delivered to integrated authenticators in platform specific manners, and to external authenticators as a part of a signature
+request. The client platform SHOULD also preserve the exact `encodedClientData` string used to create it, for embedding in a
+signature object sent back to the [RP] (see [[#authenticator-signature]]). This is necessary since multiple JSON encodings of
+the same client data are possible.
 
-  <p>A raw cryptographic signature must assert the integrity of both the
-  client data and the authenticator data. Thus, an <a>authenticator</a> SHALL
-  compute a signature over the concatenation of the <var>authenticatorData</var>
-  and the <var>clientDataHash</var>.
-  </p>
+The hash algorithm <a>hashAlg</a> used to compute |clientDataHash| is included in the {{ClientData}} object. This way it is
+available to the [RP] and it is also hashed over when computing |clientDataHash| and hence anchored in the signature itself.
 
-  <figure id="fig-signature">
+A raw cryptographic signature must assert the integrity of both the client data and the authenticator data. Thus, an
+<a>authenticator</a> SHALL compute a signature over the concatenation of the |authenticatorData| and the |clientDataHash|.
+
+<figure id="fig-signature">
     <img src="img/fido-signature-formats-figure2.svg"/>
     <figcaption>Generating a signature on the authenticator.</figcaption>
-  </figure>
+</figure>
 
-  <p class="note">
-    A simple, undelimited concatenation, is safe to use here because the
-    <var>authenticatorData</var> describes its own length. The 
-    <var>clientDataHash</var> (which potentially has a variable length) 
-    is always the last element.
-  </p>
+Note: A simple, undelimited concatenation, is safe to use here because the |authenticatorData| describes its own length. The
+    |clientDataHash| (which potentially has a variable length) is always the last element.
 
-  <p>
-    The authenticator MUST return both the <var>authenticatorData</var> and
-    the raw signature back to the client.
-  </p>
+The authenticator MUST return both the |authenticatorData| and the raw signature back to the client.
 
-<!-- End of include from signature-format.html -->
-
-
-<!-- Begin of include from key-attestation.html -->
 
 ## Key Attestation Format ## {#attestation}
 
-An attestation statement is a specific type of signature, which contains
-statements about a credential itself and the authenticator that holds it.
-Therefore, the format of attestation statements and the procedures for
-generating them closely parallel those for generating WebAuthn assertions
-as described in [[#signature-format]], though the semantics of the
-contextual bindings are quite different. 
+An attestation statement is a specific type of signature, which contains statements about a credential itself and the
+authenticator that holds it. Therefore, the format of attestation statements and the procedures for generating them closely
+parallel those for generating WebAuthn assertions as described in [[#signature-format]], though the semantics of the contextual
+bindings are quite different.
 
-The general structure of an attestation statement is specified in [[#iface-attestation-statement]].
-    This section 
-	provides a profile of these structures when different types of hardware act as the crypto kernel.
-	More profiles are expected to be added as the specification
-	evolves.
+The general structure of an attestation statement is specified in [[#iface-attestation-statement]]. This section provides a
+profile of these structures when different types of hardware act as the crypto kernel. More profiles are expected to be added as
+the specification evolves.
+
 
 ### Overview ### {#attestation-overview}
 
+
 #### Attestation Models #### {#attestation-models}
 
-	<p>WebAuthn supports multiple attestation models:</p>
-	<dl>
-	  <dt>Full Basic Attestation</dt>
-	  <dd>In the case of full basic attestation [[UAFProtocol]], the Authenticator's attestation private key is
-	    specific to an Authenticator model.  That means that an Authenticator of the same model
-	    typically shares the same attestation private key.
-	    <p>This model is also used for FIDO UAF 1.0 and FIDO U2F 1.0.</p>
-	  </dd>
-	  <dt>Surrogate Basic Attestation</dt>
-	  <dd>In the case of surrogate basic attestation [[UAFProtocol]], the
-	    Authenticator doesn't have any specific attestation key.  Instead it uses
-	    the authentication key to (self-)sign the (surrogate) attestation message.
-	    Authenticators without meaningful protection measures for an attestation private key
-	    typically use this attestation model.
-	  </dd>
-	  <dt>Privacy CA</dt>
-	  <dd>In this case, the Authenticator owns an authenticator-specific (endorsement) key.
-	    This key is used to securely communicate with a trusted third party,
-	    the Privacy CA.  The Authenticator can generate
-	    multiple attestation key pairs and asks the Privacy CA to issue an
-	    attestation certificate for it.
-	    <p>Using this approach, the Authenticator can limit the exposure of the
-	      endorsement key (which is a global correlation handle) to Privacy CA(s).
-	      Attestation keys can be requested for each scoped credential individually.
-	    </p>
-	    <p class="note">This concept typically leads to multiple attestation certificates.
-	      The attestation certificate requested most recently is called "active".
-	    </p>
-	  </dd>
-	  <dt>Direct Anonymous Attestation (DAA)</dt>
-	  <dd>In this case, the Authenticator receives DAA credentials from a single DAA-Issuer.
-	    These DAA credentials are used along with blinding to sign the attestation data.
-	    The concept of blinding avoids the DAA credentials being misused as global correlation handle.
-	    <p>WebAuthn supports DAA using elliptic curve cryptography and bilinear pairings,
-	      called ECDAA (see [[FIDOEcdaaAlgorithm]]) in this specification.</p>
-	  </dd>
-	</dl>
-	<p>Compliant servers MUST support all attestation models.
-	  Authenticators can choose what attestation model to implement.
-	</p>
-	<p class="note">WebAuthn Relying Parties can always decide what attestation models are acceptable by policy.
-	</p>
+WebAuthn supports multiple attestation models:
+
+: Full Basic Attestation
+:: In the case of full basic attestation [[UAFProtocol]], the Authenticator's attestation private key is specific to an
+    Authenticator model.  That means that an Authenticator of the same model typically shares the same attestation private key.
+    This model is also used for FIDO UAF 1.0 and FIDO U2F 1.0.
+
+: Surrogate Basic Attestation
+:: In the case of surrogate basic attestation [[UAFProtocol]], the Authenticator doesn't have any specific attestation key.
+    Instead it uses the authentication key to (self-)sign the (surrogate) attestation message. Authenticators without meaningful
+    protection measures for an attestation private key typically use this attestation model.
+
+: Privacy CA
+:: In this case, the Authenticator owns an authenticator-specific (endorsement) key. This key is used to securely communicate
+    with a trusted third party, the Privacy CA.  The Authenticator can generate multiple attestation key pairs and asks the
+    Privacy CA to issue an attestation certificate for it. Using this approach, the Authenticator can limit the exposure of the
+    endorsement key (which is a global correlation handle) to Privacy CA(s). Attestation keys can be requested for each scoped
+    credential individually.
+
+    Note: This concept typically leads to multiple attestation certificates. The attestation certificate requested most recently
+        is called "active".
+
+: Direct Anonymous Attestation (DAA)
+:: In this case, the Authenticator receives DAA credentials from a single DAA-Issuer. These DAA credentials are used along with
+    blinding to sign the attestation data. The concept of blinding avoids the DAA credentials being misused as global
+    correlation handle. WebAuthn supports DAA using elliptic curve cryptography and bilinear pairings, called ECDAA (see
+    [[FIDOEcdaaAlgorithm]]) in this specification.
+
+
+Compliant servers MUST support all attestation models. Authenticators can choose what attestation model to implement.
+
+Note: [RPS] can always decide what attestation models are acceptable to them by policy.
 
 
 #### Attestation Raw Data Types #### {#attestation-raw-data-types}
 
-	<p>
-	  WebAuthn supports pluggable attestation raw data types, i.e.,
-	  ways to serialize the data being attested to by the <a>Authenticator</a>.
-	  The reason is to be able to support existing devices like TPMs and other
-	  platform-specific formats.
-	</p>
-	<p>Each attestation type provides the ability to cryptographically attest to a public key, the
-	  authenticator model, and contextual data to a remote party.
-	</p>
-	<p>Attestation raw data types are orthogonal to attestation models, i.e.
-	  attestation raw data types in general are not restricted to a single attestation model.
-	</p>
+WebAuthn supports pluggable attestation raw data types, i.e., ways to serialize the data being attested to by the
+<a>Authenticator</a>. The reason is to be able to support existing devices like TPMs and other platform-specific formats.
+
+Each attestation type provides the ability to cryptographically attest to a public key, the authenticator model, and contextual
+data to a remote party.
+
+Attestation raw data types are orthogonal to attestation models, i.e. attestation raw data types in general are not restricted
+to a single attestation model.
 
 
 ### Defined Attestation Raw Data Types ### {#defined-attestation-raw-data-types}
-	<p>
-	  Attestation Raw Data (<code>rawData</code>) is the to-be-signed object of
-	  the attestation statement. WebAuthn supports pluggable attestation data types.
-	  This allows support of TPM generated attestation data as well as support of
-	  other WebAuthn <a>authenticators</a>.
-	</p>
-	<p>
-	  The contents of the attestation data must be controlled (i.e., generated or
-	  at least verified) by the authenticator itself.
-	</p>
+
+Attestation Raw Data (`rawData`) is the to-be-signed object of the attestation statement. WebAuthn supports pluggable
+attestation data types. This allows support of TPM generated attestation data as well as support of other WebAuthn
+<a>authenticators</a>.
+
+The contents of the attestation data must be controlled (i.e., generated or at least verified) by the authenticator itself.
+
 
 #### Packed Attestation #### {#packed-attestation}
 
-	  Packed attestation is a WebAuthn optimized format of attestation data.  It uses a very compact but
-	  still extensible encoding method.  Encoding this format can even be implemented by <a>authenticators</a>
-	  with very limited resources (e.g., secure elements).
+ Packed attestation is a WebAuthn optimized format of attestation data. It uses a very compact but still extensible encoding
+method. Encoding this format can even be implemented by <a>authenticators</a> with very limited resources (e.g., secure
+elements).
+
 
 ##### Attestation rawData (type="packed") ##### {#sec-raw-data-packed}
 
-	    <p>The attestation data encodes contextual bindings made by the
-	      <a>authenticator</a> itself. Unlike client data, the authenticator data has
-	      a compact but extensible encoding. This is desired since authenticators can
-	      be devices with limited capabilities and low power requirements, with much
-	      simpler software stacks than the client platform components.</p>
+The attestation data encodes contextual bindings made by the <a>authenticator</a> itself. Unlike client data, the authenticator
+data has a compact but extensible encoding. This is desired since authenticators can be devices with limited capabilities and
+low power requirements, with much simpler software stacks than the client platform components.
 
-	    <p>For this type, only version="1" is defined at this time.</p>
+For this type, only version="1" is defined at this time.
 
-	    <p>The field <code>rawData</code> is the <b>base64url encoding of the byte array</b>.
-	      The encoding of attestation data (for type "packed") is a byte array
-	      of 45 bytes + length of public key + length of KeyHandle + potentially more extensions.
-	      The first bytes before the extensions have a fixed layout as follows:</p>
+The field `rawData` is the *base64url encoding of the byte array*. The encoding of attestation data (for type "packed") is a
+byte array of 45 bytes + length of public key + length of KeyHandle + potentially more extensions. The first bytes before the
+extensions have a fixed layout as follows:
 
-	    <table class="complex data longlastcol">
-	      <tr>
-		<th>Length (in bytes)</th>
-		<th>Description</th>
-	      </tr>
-	      <tr>
-		<td>2</td>
-		<td>0xF1D0, fixed big-endian TAG to make sure this object won't be
-		  confused with other (non-WebAuth) binary objects.</td>
-	      </tr>
-	      <tr>
-		<td>1</td>
-		<td>Flags (bit 0 is the least significant bit):
-		  <ul>
-		    <li>Bit 0: Test of User Presence (<code>TUP</code>) result.</li>
-		    <li>Bits 1-6: Reserved for future use (<code>RFU</code>).</li>
-		    <li>Bit 7: Extension data included (<code>ED</code>). Indicates whether the
-		      authenticator added extensions (see below).</li>
-		  </ul>
-		</td>
-	      </tr>
-	      <tr>
-		<td>4</td>
-		<td>Signature counter (<code>signCount</code>), 32-bit unsigned big-endian integer.</td>
-	      </tr>
-	      <tr>
-		<td>2</td>
-		<td>
-		  Public key algorithm and encoding (16-bit big-endian value).
-		  Allowed values are:
-		  <ol>
-		    <li>0x0100. This is raw ANSI X9.62 formatted Elliptic Curve public key [[!SEC1]].
-		      <p>I.e., <code>[0x04, X (n bytes), Y (n bytes)]</code>.  Where the
-			byte <code>0x04</code> denotes the uncompressed point compression method
-			and n denotes the key length in bytes.</p>
-		    </li>
-		    <li>0x0102.  Raw encoded RSA PKCS1 or
-		      RSASSA-PSS public key [[RFC3447]].
-		      <p>In the case of RSASSA-PSS, the default parameters according
-			to [[RFC4055]] MUST be assumed, i.e.,
-			<ul>
-			  <li>Mask Generation Algorithm MGF1 with SHA256</li>
-			  <li>Salt Length of 32 bytes, i.e., the length of a SHA256 hash value.</li>
-			  <li>Trailer Field value of 1, which represents the trailer field with
-			    hexadecimal value <code>0xBC</code>.
-			</ul>
-		      </p>
-		      <p>That is, <code>[modulus (256 bytes), e (m-n bytes)]</code>.
-			Where <code>m</code> is the total length of the field.</p>
-		      <p>This total length should be taken from the object containing this key</p>
-		    </li>
-		  </ol>
-		</td>
-	      </tr>
-	      <tr>
-		<td>2</td>
-		<td>Byte length m of following public key bytes (16 bit value
-		  with most significant byte first).
-		</td>
-	      </tr>
-	      <tr>
-		<td>(length)</td>
-		<td>The public key (m bytes) according to the encoding denoted before.</td>
-	      </tr>
-	      <tr>
-		<td>2</td>
-		<td>Byte length l of KeyHandle
-		</td>
-	      </tr>
-	      <tr>
-		<td>(length)</td>
-		<td>KeyHandle (l bytes)</td>
-	      </tr>
-	      <tr>
-		<td>2</td>
-		<td>Byte length n of clientDataHash
-		</td>
-	      </tr>
-	      <tr>
-		<td>n</td>
-		<td>clientDataHash (see [[#authenticator-signature]]).
-		  This is the hash of <code>clientData</code>.  The hash algorithm itself is stored
-		  in the <code>clientData</code> object [[#signature-format]].
-		</td>
-	      </tr>
-	      <tr>
-		<td>As defined by the extension map</td>
-		<td>Extension-defined authenticator data. This is a CBOR [[RFC7049]] map with
-		  extension identifiers as keys, and extension authenticator data values as values.
-		  See [[#extensions]] for a description
-		  of the extension mechanism.
-		  See [[#extension-standard]]
-		  for pre-defined extensions.
-		</td>
-	      </tr>
-	    </table>
+<table class="complex data longlastcol">
+    <tr>
+        <th>Length (in bytes)</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>
+            0xF1D0, fixed big-endian TAG to make sure this object won't be confused with other (non-WebAuthn) binary objects.
+        </td>
+    </tr>
+    <tr>
+        <td>1</td>
+        <td>
+            Flags (bit 0 is the least significant bit):
+            - Bit 0: Test of User Presence (`TUP`) result.
+            - Bits 1-6: Reserved for future use (`RFU`).
+            - Bit 7: Extension data included (`ED`). Indicates whether the authenticator added extensions (see below).
+        </td>
+    </tr>
+    <tr>
+        <td>4</td>
+        <td>Signature counter (`signCount`), 32-bit unsigned big-endian integer.</td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>
+            Public key algorithm and encoding (16-bit big-endian value). Allowed values are:
 
-	    <p>The <code>TUP</code> flag SHALL be set if and only if the <a>authenticator</a>
-	      detected a user through an authenticator-specific gesture. The <code>RFU</code>
-	      bits in the flags byte SHALL be cleared (i.e., zeroed).</p>
+            1. 0x0100. This is raw ANSI X9.62 formatted Elliptic Curve public key [[!SEC1]], i.e.,
+                `[0x04, X (n bytes), Y (n bytes)]`, where the byte `0x04` denotes the uncompressed point compression method and
+                n denotes the key length in bytes.
 
-	    <p>If the authenticator does not wish to add extensions, it MUST clear
-	      the <code>ED</code> flag in the third byte.</p>
+            2. 0x0102.  Raw encoded RSA PKCS1 or RSASSA-PSS public key [[RFC3447]]. In the case of RSASSA-PSS, the default
+                parameters according to [[RFC4055]] MUST be assumed, i.e.,
+                - Mask Generation Algorithm MGF1 with SHA256
+                - Salt Length of 32 bytes, i.e., the length of a SHA256 hash value.
+                - Trailer Field value of 1, which represents the trailer field with hexadecimal value `0xBC`.
+
+                That is, `[modulus (256 bytes), e (m-n bytes)]`, where `m` is the total length of the field. This total length
+                should be taken from the object containing this key
+        </td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>Byte length m of following public key bytes (16 bit value with most significant byte first).</td>
+    </tr>
+    <tr>
+        <td>(length)</td>
+        <td>The public key (m bytes) according to the encoding denoted before.</td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>Byte length l of KeyHandle</td>
+    </tr>
+    <tr>
+        <td>(length)</td>
+        <td>KeyHandle (l bytes)</td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>Byte length n of clientDataHash</td>
+    </tr>
+    <tr>
+        <td>n</td>
+        <td>
+            clientDataHash (see [[#authenticator-signature]]). This is the hash of `clientData`. The hash algorithm itself is
+            stored in the `clientData` object [[#signature-format]].
+        </td>
+    </tr>
+    <tr>
+        <td>As defined by the extension map</td>
+        <td>
+            Extension-defined authenticator data. This is a CBOR [[RFC7049]] map with extension identifiers as keys, and
+            extension authenticator data values as values. See [[#extensions]] for a description of the extension mechanism.
+            See [[#extension-standard]] for pre-defined extensions.
+        </td>
+    </tr>
+</table>
+
+The `TUP` flag SHALL be set if and only if the <a>authenticator</a> detected a user through an authenticator-specific gesture.
+The `RFU` bits in the flags byte SHALL be cleared (i.e., zeroed).
+
+If the authenticator does not wish to add extensions, it MUST clear the `ED` flag in the third byte.
 
 
 ##### Signature ##### {#packed-attestation-signature}
 
-	    <p>The <code>signature</code> is computed over the base64url-decoded <code>rawData</code> field.</p>
-	    The following
-	    algorithms must be implemented by servers:
-	    <ol>
-	      <li>"ES256" [[!RFC7518]]</li>
-	      <li>"RS256" [[!RFC7518]]</li>
-	      <li>"PS256" [[!RFC7518]]</li>
-	      <li>"ED256" [[!FIDOEcdaaAlgorithm]]</li>
-	    </ol>
-	    <a>Authenticators</a> can choose which algorithm to implement.
+The `signature` is computed over the base64url-decoded `rawData` field. The following algorithms must be implemented by servers:
+
+1. "ES256" [[!RFC7518]]
+2. "RS256" [[!RFC7518]]
+3. "PS256" [[!RFC7518]]
+4. "ED256" [[!FIDOEcdaaAlgorithm]]
+
+<a>Authenticators</a> can choose which algorithm(s) to implement.
 
 
 ##### Packed attestation statement certificate requirements ##### {#packed-attestation-cert-requirements}
 
-	    <p class="note">In the case of DAA attestation
-	      [[FIDOEcdaaAlgorithm]] no <a>attestation certificate</a> is used.
-	    </p>
+Note: In the case of DAA attestation [[FIDOEcdaaAlgorithm]] no <a>attestation certificate</a> is used.
 
-	    <p>The attestation certificate MUST have the following
-	      fields/extensions:
-	    </p>
-	    <ul>
-	      <li>Version must be set to 3.</li>
-	      <li>Subject field MUST be set to:
-		<dl>
-		  <dt>Subject-C</dt>
-		  <dd>Country where the Authenticator vendor is incorporated</dd>
-		  <dt>Subject-O</dt>
-		  <dd>Legal name of the Authenticator vendor</dd>
-		  <dt>Subject-OU</dt>
-		  <dd>Authenticator Attestation</dd>
-		  <dt>Subject-CN</dt>
-		  <dd>No stipulation.</dd>
-		</dl>
-	      </li>
-	      <li>If the related attestation root certificate is used for multiple authenticator
-		models, the following extension MUST be present:
-		<p>Extension OID <code>1 3 6 1 4 1 45724 1 1 4</code>
-		(id-fido-gen-ce-aaguid) containing the AAGUID as value.
-		</p>
-	      </li>
-	      <li>The Basic Constraints extension MUST have the cA component set
-		to false
-	      </li>
-	      <li>An Authority Information Access (AIA) extension with entry <code>id-ad-ocsp</code> and
-		a CRL Distribution Point extension [[RFC5280]] are both optional as the status of attestation certificates is
-		available through the FIDO Metadata Service [[FIDOMetadataService]].
-	      </li>
-	    </ul>
+The attestation certificate MUST have the following fields/extensions:
+
+- Version must be set to 3.
+- Subject field MUST be set to:
+    : Subject-C
+    :: Country where the Authenticator vendor is incorporated
+    : Subject-O
+    :: Legal name of the Authenticator vendor
+    : Subject-OU
+    :: Authenticator Attestation
+    : Subject-CN
+    :: No stipulation.
+
+- If the related attestation root certificate is used for multiple authenticator models, the Extension OID
+    `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) MUST be present, containing the AAGUID as value.
+
+- The Basic Constraints extension MUST have the cA component set to false
+
+- An Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension [[RFC5280]]
+    are both optional as the status of attestation certificates is available through the FIDO Metadata Service
+    [[FIDOMetadataService]].
 
 
 #### TPM Attestation #### {#tpm-attestation}
 
+
 ##### Attestation rawData (type="tpm") ##### {#sec-raw-data-tpm}
 
-	    <p>
-              The value of <code>rawData</code> is the <b>base64url encoding of a binary object</b>.
-	            This binary object is either a
-              TPM_CERTIFY_INFO or a TPM_CERTIFY_INFO2 structure [[TPMv1-2-Part2]]
-              sections 11.1 and 11.2, if
-              <code>attestationStatement.core.version</code> equals 1. Else, if
-              <code>attestationStatement.core.version</code> equals 2, it MUST be
-              the base64url encoding of a TPMS_ATTEST structure as defined in
-              [[TPMv2-Part2]] sections 10.12.9.
-	    </p>
-	    <p>
-	      The field "extraData" (in the case of TPMS_ATTEST) or the field "data"
-	      (in the case of TPM_CERTIFY_INFO or TPM_CERTIFY_INFO2) MUST contain
-	      the <code>clientDataHash</code> (see [[#signature-format]).
-	    </p>
+The value of `rawData` is the *base64url encoding of a binary object*. This binary object is either a TPM_CERTIFY_INFO or a
+TPM_CERTIFY_INFO2 structure [[TPMv1-2-Part2]] sections 11.1 and 11.2, if `attestationStatement.core.version` equals 1. Else, if
+`attestationStatement.core.version` equals 2, it MUST be the base64url encoding of a TPMS_ATTEST structure as defined in
+[[TPMv2-Part2]] sections 10.12.9.
+
+The field "extraData" (in the case of TPMS_ATTEST) or the field "data" (in the case of TPM_CERTIFY_INFO or TPM_CERTIFY_INFO2)
+MUST contain the `clientDataHash` (see [[#signature-format]).
+
 
 ##### Signature ##### {#tpm-attestation-signature}
 
-	    <p>
-              If <code>attestationStatement.core.version</code> equals 1, (i.e., for
-              TPM 1.2), RSASSA-PKCS1-v1_5 signature algorithm (section 8.2 of
-              [[RFC3447]]) can be used by WebAuthn Authenticators (i.e.
-              <code>attestationStatement.header.alg</code>="RS256").
-	    </p>
-	    <p>
-              If <code>attestationStatement.core.version</code> equals 2, the
-              following algorithms can be used by WebAuthn Authenticators:
-	    </p>
+If `attestationStatement.core.version` equals 1, (i.e., for TPM 1.2), RSASSA-PKCS1-v1_5 signature algorithm (section 8.2 of
+[[RFC3447]]) can be used by WebAuthn Authenticators (i.e. `attestationStatement.header.alg`="RS256").
 
-	    <ol>
-	      <li>TPM_ALG_RSASSA (0x14).  This is the same algorithm RSASSA-PKCS1-v1_5
-		as for version 1 but for use with TPMv2. <code>attestationStatement.header.alg</code>="RS256".</li>
-	      <li>TPM_ALG_RSAPSS (0x16); <code>attestationStatement.header.alg</code>="PS256".</li>
-	      <li>TPM_ALG_ECDSA (0x18); <code>attestationStatement.header.alg</code>="ES256".</li>
-	      <li>TPM_ALG_ECDAA (0x1A); <code>attestationStatement.header.alg</code>="ED256".</li>
-	      <li>TPM_ALG_SM2 (0x1B); <code>attestationStatement.header.alg</code>="SM256".</li>
-	    </ol>
+If `attestationStatement.core.version` equals 2, the following algorithms can be used by WebAuthn Authenticators:
 
-	    <p>The <code>signature</code> is computed over the base64url-decoded <code>rawData</code> field</p>
-	    <p>See [[#packed-attestation-signature]] for the signature algorithms
-	      to be implemented by servers.
-	    </p>
+1. TPM_ALG_RSASSA (0x14).  This is the same algorithm RSASSA-PKCS1-v1_5 as for version 1 but for use with TPMv2.
+    `attestationStatement.header.alg`="RS256".
+
+2. TPM_ALG_RSAPSS (0x16); `attestationStatement.header.alg`="PS256".
+
+3. TPM_ALG_ECDSA (0x18); `attestationStatement.header.alg`="ES256".
+
+4. TPM_ALG_ECDAA (0x1A); `attestationStatement.header.alg`="ED256".
+
+5. TPM_ALG_SM2 (0x1B); `attestationStatement.header.alg`="SM256".
+
+The `signature` is computed over the base64url-decoded `rawData` field See [[#packed-attestation-signature]] for the signature
+algorithms to be implemented by servers.
 
 
 ##### TPM attestation statement certificate requirements ##### {#tpm-cert-requirements}
 
-	    <p>TPM <a>attestation certificate</a> MUST have the following
-	      fields/extensions:
-	    </p>
-	    <ul>
-	      <li>Version must be set to 3.</li>
-	      <li>Subject field MUST be set to empty.</li>
-	      <li>The Subject Alternative Name extension must be set as defined in
-		[[TPMv2-EK-Profile]] section 3.2.9 if "version" equals 2 and
-		[[TPMv1-2-Credential-Profiles]] section 3.2.9 if "version" equals 1.
-	      </li>
-	      <li>The Extended Key Usage extension MUST contain the
-		"joint-iso-itu-t(2) internationalorganizations(23) 133
-		tcg-kp(8) tcg-kp-AIKCertificate(3)" OID.
-	      </li>
-	      <li>The Basic Constraints extension MUST have the CA component set
-		to false
-	      </li>
-	      <li>An Authority Information Access (AIA) extension with entry <code>id-ad-ocsp</code> and
-		a CRL Distribution Point extension [[RFC5280]] are both optional as the status of attestation certificates is
-		available through the FIDO Metadata Service [[FIDOMetadataService]].
-	      </li>
-	    </ul>
+TPM <a>attestation certificate</a> MUST have the following fields/extensions:
+
+- Version must be set to 3.
+
+- Subject field MUST be set to empty.
+
+- The Subject Alternative Name extension must be set as defined in [[TPMv2-EK-Profile]] section 3.2.9 if "version" equals 2 and
+    [[TPMv1-2-Credential-Profiles]] section 3.2.9 if "version" equals 1.
+
+- The Extended Key Usage extension MUST contain the
+    "joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8) tcg-kp-AIKCertificate(3)" OID.
+
+- The Basic Constraints extension MUST have the CA component set to false
+
+- An Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension [[RFC5280]] are
+    both optional as the status of attestation certificates is available through the FIDO Metadata Service [[FIDOMetadataService]].
+
 
 #### Android Attestation #### {#android-attestation}
 
-    <p>
-       When the <a>Authenticator</a> in question is a platform-provided
-       Authenticator on the Android platform, the attestation statement is
-       based on the <a href='https://developer.android.com/training/safetynet/index.html#compat-check-response'>
-	   SafetyNet API</a>.
-    </p>
+ When the <a>Authenticator</a> in question is a platform-provided Authenticator on the Android platform, the attestation
+statement is based on the [SafetyNet API](https://developer.android.com/training/safetynet/index.html#compat-check-response).
 
-	<p>Android attestation statement MUST always be used in conjunction with the more
-	  specific <code>AndroidAttestationClientData</code> (see [[#sec-android-attestationclientdata]])
-	  in order to let the Relying Party App store the public key in the attestation object.
-	</p>
+Android attestation statement MUST always be used in conjunction with the more specific `AndroidAttestationClientData` (see
+[[#sec-android-attestationclientdata]]) in order to let the [RP] App store the public key in the attestation object.
+
 
 ##### Attestation rawData (type="android") ##### {#sec-attestation-android}
 
-	  <p>
-	    Android SafetyNet returns a JWS [[RFC7515]] object (see
-	    <a href='https://developer.android.com/training/safetynet/index.html#compat-check-response'>
-	      SafetyNet online documentation</a>) in Compact
-	    Serialization. A JWS in Compact Serialization consists of three segments
-	    (each a base64url-encoded string) separated by a dot ("."). The
-	    <code>rawData</code> object is the concatenation of:
-	  </p>
-	  <ol>
-	    <li>the first segment (a base64url encoding of the UTF-8 encoded JWS Protected Header)</li>
-	    <li>a dot "."</li>
-	    <li>the second segment (a base64url encoding of the UTF-8 encoded JWS Payload).</li>
-	  </ol>
-	  <p>
-	    In contrast to the "packed" and "tpm" attestation types, for the
-	    "android" attestation type, the <code>rawData</code> field and the
-	    <code>rawData</code> object are the same string. (In the "packed" and
-	    "tpm" attestation types the <code>rawData</code> field is the
-	    base64url-encoding of the <code>rawData</code> object.)
-	  </p>
+Android SafetyNet returns a JWS [[RFC7515]] object (see
+[SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response))
+in Compact Serialization. A JWS in Compact Serialization consists of three segments (each a base64url-encoded string) separated
+by a dot ("."). The `rawData` object is the concatenation of:
+
+1. the first segment (a base64url encoding of the UTF-8 encoded JWS Protected Header)
+
+2. a dot "."
+
+3. the second segment (a base64url encoding of the UTF-8 encoded JWS Payload).
+
+In contrast to the "packed" and "tpm" attestation types, for the "android" attestation type, the `rawData` field and the
+`rawData` object are the same string. (In the "packed" and "tpm" attestation types the `rawData` field is the base64url-encoding
+of the `rawData` object.)
+
 
 ##### Signature ##### {#sec-android-attestation-signature}
 
-	  <p>
-	    The signature is directly computed over the <code>rawData</code> field, as
-	    defined above (see [[RFC7515]] for more details). The third segment of the
-	    JWS returned by SafetyNet is the base64url encoding of this signature,
-	    and also becomes the <code>AttestationStatement.signature</code>.
-	  </p>
+The signature is directly computed over the `rawData` field, as defined above (see [[RFC7515]] for more details). The third
+segment of the JWS returned by SafetyNet is the base64url encoding of this signature, and also becomes the
+`AttestationStatement.signature`.
 
 
 ##### Converting SafetyNet response to attestationStatement ##### {#safetynet-conversion}
 
-	  <p>
-	    The <a>Authenticator</a> and/or platform SHOULD use the steps outlined below to
-	    create an attestationStatement from an Android SafetyNet response. It MAY
-	    use a different algorithm, as long as the results are the same.
-	  </p>
+The <a>Authenticator</a> and/or platform SHOULD use the steps outlined below to create an attestationStatement from an Android
+SafetyNet response. It MAY use a different algorithm, as long as the results are the same.
 
-	  <ol>
-	    <li>create clientDataJSON with type AndroidAttestationClientData (see below) and
-	      compute clientData as base64url-encoded clientDataJSON.</li>
-	    <li>provide the clientDataHash computed as the hash value of clientData
-	      as Nonce value when requesting the SafetyNet attestation.</li>
-	    <li>take SafetyNet response <var>snr</var>.  This is a JWS object ([[RFC7515]]).</li>
-	    <li>extract the base64url-encoded Protected Header <var>hdr</var> from <var>snr</var> (see [[RFC7515]])</li>
-	    <li>extract the base64url-encoded payload <var>p</var> from <var>snr</var></li>
-	    <li>extract the base64url-encoded signature <var>s</var> from <var>snr</var></li>
-	    <li>set <code>AttestationStatement.core.rawData</code> = <var>hdr</var> | "." | <var>p</var></li>
-	    <li>set <code>AttestationStatement.signature</code> = <var>s</var></li>
-	    <li>base64url-decode <var>hdr</var> into <var>hdr-d</var></li>
-	    <li>set <code>AttestationStatement.header.alg</code> = <var>hdr-d</var>.alg</li>
-	    <li>if <var>hdr-d</var>.x5c is present, then set 
-	      <code>AttestationStatement.header.x5c</code> = <var>hdr-d</var>.x5c</li>
-	    <li>
-	      if <var>hdr-d</var>.x5u is present, then resolve the URL and add the
-	      retrieved certificate chain to <code>AttestationStatement.header.x5c</code>
-	    </li>
-	    <li>set <code>AttestationStatement.core.type</code> = "android"</li>
-	    <li>set <code>AttestationStatement.core.version</code> to the
-	      version number of Google Play Services responsible for providing the SafetyNet API</li>
-	  </ol>
+1. create clientDataJSON with type AndroidAttestationClientData (see below) and compute clientData as base64url-encoded
+    clientDataJSON.
+
+2. provide the clientDataHash computed as the hash value of clientData as Nonce value when requesting the SafetyNet attestation.
+
+3. take SafetyNet response |snr|.  This is a JWS object ([[RFC7515]]).
+
+4. extract the base64url-encoded Protected Header |hdr| from |snr| (see [[RFC7515]])
+
+5. extract the base64url-encoded payload |p| from |snr|
+
+6. extract the base64url-encoded signature |s| from |snr|
+
+7. set `AttestationStatement.core.rawData` = |hdr| | "." | |p|
+
+8. set `AttestationStatement.signature` = |s|
+
+9. base64url-decode |hdr| into |hdr-d|
+
+10. set `AttestationStatement.header.alg` = |hdr-d|.alg
+
+11. if |hdr-d|.x5c is present, then set `AttestationStatement.header.x5c` = |hdr-d|.x5c
+
+12. if |hdr-d|.x5u is present, then resolve the URL and add the retrieved certificate chain to
+    `AttestationStatement.header.x5c`
+
+13. set `AttestationStatement.core.type` = "android"
+
+14. set `AttestationStatement.core.version` to the version number of Google Play Services responsible for providing the
+    SafetyNet API
+
 
 ##### AndroidAttestationClientData ##### {#sec-android-attestationclientdata}
 
-      <p>
-         The ClientData dictionary is extended in the following way:
-      </p>
+The ClientData dictionary is extended in the following way:
 
 <pre class="idl">
-dictionary AndroidAttestationClientData : ClientData {
-             JsonWebKey             publicKey;
-             boolean                isInsideSecureHardware;
-             DOMString              userAuthentication;
-             unsigned long userAuthenticationValidityDurationSeconds; // optional
-};
+    dictionary AndroidAttestationClientData : ClientData {
+        JsonWebKey    publicKey;
+        boolean       isInsideSecureHardware;
+        DOMString     userAuthentication;
+        unsigned long userAuthenticationValidityDurationSeconds; // optional
+    };
 </pre>
 
-	  <dl dfn-for="AndroidAttestationClientData">
-	    <dt>JsonWebKey <dfn>publicKey</dfn></dt>
-            <dd>
-              The public key generated by the Authenticator, as a JsonWebKey object (see [[WebCryptoAPI#JsonWebKey-dictionary]]).
-            </dd>
+<div dfn-for="AndroidAttestationClientData">
+    : JsonWebKey <dfn>publicKey</dfn>
+    :: The public key generated by the Authenticator, as a JsonWebKey object (see [[WebCryptoAPI#JsonWebKey-dictionary]]).
 
-	    <dt>boolean <dfn>isInsideSecureHardware</dfn></dt>
-            <dd>
-              <code>true</code> if the key resides inside secure hardware (e.g.,
-              Trusted Execution Environment (TEE) or Secure Element (SE)).
-            </dd>
+    : boolean <dfn>isInsideSecureHardware</dfn>
+    :: `true` if the key resides inside secure hardware (e.g., Trusted Execution Environment (TEE) or Secure Element (SE)).
 
-	    <dt>DOMString <dfn>userAuthentication</dfn></dt>
-            <dd>
-              One of "none", "keyguard", or "fingerprint". <em>none</em> means
-              that the user has not enrolled a fingerprint, or set up a secure
-              lock screen, and that therefore the key has not been linked to user
-              authentication. <em>keyguard</em> means that the generated key only
-              be used after the user unlocks a secure lock screen.
-              <em>fingerprint</em> means that each operation involving the
-              generated key must be individually authorized by the user by
-              presenting a fingerprint.
-            </dd>
+    : DOMString <dfn>userAuthentication</dfn>
+    :: One of "none", "keyguard", or "fingerprint".
+        - *none* means that the user has not enrolled a fingerprint, or set up a secure lock screen, and that therefore the key
+            has not been linked to user authentication.
+        - *keyguard* means that the generated key only be used after the user unlocks a secure lock screen.
+        - *fingerprint* means that each operation involving the generated key must be individually authorized by the user by
+            presenting a fingerprint.
 
-	    <dt>optional unsigned long <dfn>userAuthenticationValidityDurationSeconds</dfn></dt>
-            <dd>
-              If the <code>userAuthentication</code> is set to "keyguard", then
-              this parameter specifies the duration of time (seconds) for which
-              this key is authorized to be used after the user is successfully
-              authenticated.
-            </dd>
-	  </dl>
-
+    : optional unsigned long <dfn>userAuthenticationValidityDurationSeconds</dfn>
+    :: If the `userAuthentication` is set to "keyguard", then this parameter specifies the duration of time (seconds) for which
+        this key is authorized to be used after the user is successfully authenticated.
+</div>
 
 
 ##### Verifying AndroidClientData specific contextual bindings ##### {#verifying-android-contextual-bindings}
 
-	    <p>
-              A relying party shall verify the clientData contextual bindings (see step 4 
-	      in [[#verifying-an-attestation-statement]]) as follows:
-	    </p>
-	    <ul>
-              <li>
-		Check that <code>AndroidAttestationClientData.challenge</code> equals the
-		attestationChallenge that was passed into the
-		{{makeCredential()}} call.
-              </li>
-              <li>
-		Check that the <code>facet</code> and <code>tokenBinding</code>
-		parameters in the <code>AndroidAttestationClientData</code> match the
-		Relying Party App.
-              </li>
-              <li>
-		Check that <code>AndroidAttestationClientData.publicKey</code> is the same key as the one
-		returned in the <code>ScopedCredentialInfo</code> by the
-		<code>makeCredential</code> call.
-              </li>
-              <li>
-		Check that the hash of the clientDataJSON matches the
-		<code>nonce</code> attribute in the payload of the
-		<code>safetynetResponse</code> JWS.
-              </li>
-              <li>
-		Check that the <code>ctsProfileMatch</code> attribute in the payload
-		of the <code>safetynetResponse</code> is true.
-              </li>
-              <li>
-		Check that the <code>apkPackageName</code> attribute in the payload of the
-		<code>safetynetResponse</code> matches package name of the application calling
-		SafetyNet API.
-              </li>
-              <li>
-		Check that the <code>apkDigestSha256</code> attribute in the
-		payload of the <code>safetynetResponse</code> matches the package hash
-		of the application calling SafetyNet API.
-              </li>
-              <li>
-		Check that the <code>apkCertificateDigestSha256</code> attribute in the
-		payload of the <code>safetynetResponse</code> matches the hash of the signing certificate
-		of the application calling SafetyNet API.
-              </li>
-	    </ul>
+A [RP] shall verify the clientData contextual bindings (see step 4 in [[#verifying-an-attestation-statement]]) as follows:
+
+- Check that `AndroidAttestationClientData.challenge` equals the attestationChallenge that was passed into the
+    {{makeCredential()}} call.
+
+- Check that the `facet` and `tokenBinding` parameters in the `AndroidAttestationClientData` match the [RP] App.
+
+- Check that `AndroidAttestationClientData.publicKey` is the same key as the one returned in the `ScopedCredentialInfo` by the
+    `makeCredential` call.
+
+- Check that the hash of the clientDataJSON matches the `nonce` attribute in the payload of the `safetynetResponse` JWS.
+
+- Check that the `ctsProfileMatch` attribute in the payload of the `safetynetResponse` is true.
+
+- Check that the `apkPackageName` attribute in the payload of the `safetynetResponse` matches package name of the application
+    calling SafetyNet API.
+
+- Check that the `apkDigestSha256` attribute in the payload of the `safetynetResponse` matches the package hash of the
+    application calling SafetyNet API.
+
+- Check that the `apkCertificateDigestSha256` attribute in the payload of the `safetynetResponse` matches the hash of the
+    signing certificate of the application calling SafetyNet API.
+
 
 ### Verifying an Attestation Statement ### {#verifying-an-attestation-statement}
 
-	<p>This section outlines the recommended algorithm for verifying an
-	  attestation statement, independent of attestation type.
-	</p>
-	<p>Upon receiving an attestation statement, the relying party
-	  shall:
-	</p>
-	<ol>
-	  <li>Verify that the attestation statement is properly formatted</li>
-	  <li>If <code>attestationSignature.alg</code> is not ECDAA (e.g., not "ED256" and not "ED512"):
-	    <ol>
-	      <li>Lookup the attestation root certificate from a trusted source.
-		The FIDO Metadata Service [[FIDOMetadataService]]
-		provides an easy way to access such information.
-		The <code>header.claimedAAGUID</code>
-		can be used for this lookup.
-	      </li>
-	      <li>Verify that
-		the attestation certificate chain is valid and
-		chains up to a trusted root (following [[RFC5280]]).
-	      </li>
-	      <li>Verify that the attestation certificate has the right Extended Key Usage (EKU) based
-		on the WebAuthn Authenticator type (as denoted by the <code>header.type</code> member). In case of a
-		type="tpm", this EKU shall be OID "2.23.133.8.3".
-	      </li>
-	      <li>If the attestation type is "android", verify that the attestation certificate is issued
-	          to the hostname "attest.android.com" (see
-		<a href='https://developer.android.com/training/safetynet/index.html#compat-check-response'>
-	          SafetyNet online documentation</a>).
-	      </li>
-	      <li>Verify that all issuing CA certificates in the chain are valid
-		and not revoked.
-	      </li>
-	      <li>
-		Verify the <code>signature</code> on <code>core.rawData</code> using the
-		attestation certificate public key and algorithm as identified by <code>header.alg</code>.
-	      </li>
-	      <li>
-		Verify <code>core.rawData</code> syntax and that it doesn't contradict the signing
-		algorithm specified in <code>header.alg</code>.
-	      </li>
-	      <li>If the attestation certificate contains an extension with
-		OID <code>1 3 6 1 4 1 45724 1 1 4</code>
-		(id-fido-gen-ce-aaguid) verify that the value of this extension matches
-		<code>header.claimedAAGUID</code>.  This identifies the Authenticator model.
-	      </li>
-	      <li>If such extension doesn't exist,
-		the attestation root certificate is dedicated to a single Authenticator model.
-	      </li>
-	    </ol>
-	  </li>
-	  <li>If <code>attestationSignature.alg</code> is ECDAA (e.g., "ED256", "ED512"):
-	    <ol>
-	      <li>Lookup the DAA
-		root key from a trusted source.  The FIDO Metadata Service [[FIDOMetadataService]]
-		provides an easy way to access such information.
-		The <code>header.claimedAAGUID</code>
-		can be used for this lookup.
-	      </li>
-	      <li>Perform DAA-Verify on <code>signature</code>
-		for <code>core.rawData</code> (see [[!FIDOEcdaaAlgorithm]]).</li>
-	      <li>
-		Verify <code>core.rawData</code> syntax and that it doesn't contradict the signing
-		algorithm specified in <code>header.alg</code>.
-	      </li>
-	      <li>The DAA root key is dedicated to a single Authenticator model.</li>
-	    </ol>
-	  </li>
-	  <li>Verify the contextual bindings (e.g., channel binding) from the
-	    clientData (see [[#authenticator-signature]]).
-	  </li>
-	  <li>
-	    Verify that user verification method and other authenticator characteristics
-	    related to this authenticator model, match the relying party policy.
-	    The FIDO Metadata Service [[FIDOMetadataService]]
-	    provides an easy way to access the authenticator characteristics.
-	  </li>
-	</ol>
+This section outlines the recommended algorithm for verifying an attestation statement, independent of attestation type.
 
-	The relying party MAY take any of the below actions when
-	verification of an attestation statement fails:
-	<ul>
-	  <li>
-	    Reject the request, such as a registration request, associated
-	    with the attestation statement.
-	  </li>
-	  <li>
-	    Accept the request associated with the attestation statement but
-	    treat the attested Scoped Credential as one with surrogate basic
-	    attestation (see [[#attestation-models]]), if policy allows it.
-	    If doing so, there is no cryptographic proof that the Scoped Credential
-	    has been generated by a particular Authenticator model.
-	    See [[FIDOSecRef]] and [[UAFProtocol]] for more details on the relevance on attestation.
-	  </li>
-	</ul>
-	<p>Verification of attestation statements requires that the relying
-	  party trusts the root of the attestation certificate chain.
-	  Also, the relying party must have access to certificate status
-	  information for the intermediate CA certificates. The relying
-	  party must also be able to build the attestation certificate
-	  chain if the client didn't provide this chain in the
-	  attestation information.
-	</p>
+Upon receiving an attestation statement, the [RP] shall:
+
+1. Verify that the attestation statement is properly formatted.
+
+2. If `attestationSignature.alg` is not ECDAA (e.g., not "ED256" and not "ED512"):
+    - Look up the attestation root certificate from a trusted source. The FIDO Metadata Service [[FIDOMetadataService]] provides
+        an easy way to access such information. The `header.claimedAAGUID` can be used for this lookup.
+    - Verify that the attestation certificate chain is valid and chains up to a trusted root (following [[RFC5280]]).
+    - Verify that the attestation certificate has the right Extended Key Usage (EKU) based on the WebAuthn Authenticator type
+        (as denoted by the `header.type` member). In case of a type="tpm", this EKU shall be OID "2.23.133.8.3".
+    - If the attestation type is "android", verify that the attestation certificate is issued to the hostname
+        "attest.android.com" (see
+        [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response)).
+    - Verify that all issuing CA certificates in the chain are valid and not revoked.
+    - Verify the `signature` on `core.rawData` using the attestation certificate public key and algorithm as identified by
+        `header.alg`.
+    - Verify `core.rawData` syntax and that it doesn't contradict the signing algorithm specified in `header.alg`.
+    - If the attestation certificate contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify
+        that the value of this extension matches `header.claimedAAGUID`.  This identifies the Authenticator model.
+    - If such extension doesn't exist, the attestation root certificate is dedicated to a single Authenticator model.
+
+3. If `attestationSignature.alg` is ECDAA (e.g., "ED256", "ED512"):
+    - Look up the DAA root key from a trusted source.  The FIDO Metadata Service [[FIDOMetadataService]] provides an easy way to
+        access such information. The `header.claimedAAGUID` can be used for this lookup.
+    - Perform DAA-Verify on `signature` for `core.rawData` (see [[!FIDOEcdaaAlgorithm]]).
+    - Verify `core.rawData` syntax and that it doesn't contradict the signing algorithm specified in `header.alg`.
+    - The DAA root key is dedicated to a single Authenticator model.
+
+4. Verify the contextual bindings (e.g., channel binding) from the clientData (see [[#authenticator-signature]]).
+
+5. Verify that user verification method and other authenticator characteristics related to this authenticator model, match the
+    [RP] policy. The FIDO Metadata Service [[FIDOMetadataService]] provides an easy way to access the authenticator
+    characteristics.
+
+The [RP] MAY take any of the below actions when verification of an attestation statement fails:
+
+- Reject the request, such as a registration request, associated with the attestation statement.
+
+- Accept the request associated with the attestation statement but treat the attested Scoped Credential as one with surrogate
+    basic attestation (see [[#attestation-models]]), if policy allows it. If doing so, there is no cryptographic proof that the
+    Scoped Credential has been generated by a particular Authenticator model. See [[FIDOSecRef]] and [[UAFProtocol]] for more
+    details on the relevance on attestation.
+
+Verification of attestation statements requires that the relying party trusts the root of the attestation certificate chain.
+Also, the [RP] must have access to certificate status information for the intermediate CA certificates. The relying party must
+also be able to build the attestation certificate chain if the client didn't provide this chain in the attestation information.
+
 
 ### Security Considerations ### {#sec-attestation-security-considerations}
 
+
 #### Privacy #### {#sec-attestation-privacy}
 
-	<p>Attestation keys may be used to track users or link
-	  various online identities of the same user together. This may
-	  be mitigated in several ways, including:
-	</p>
-	<ul>
-	  <li>A WebAuthn <a>Authenticator</a> manufacturer may choose to ship all of their devices with
-	    the same (or a fixed number of) attestation key(s) (called Full Basic Attestation). This will
-	    anonymize the user at the risk of not being able to revoke a
-	    particular attestation key should its WebAuthn Authenticator be compromised.
-	  </li>
-	  <li>A WebAuthn Authenticator may be capable of dynamically generating different attestation keys
-	    (and requesting related certificates) per origin (following the Privacy CA model).
-	    For example, a WebAuthn Authenticator can ship with a master
-	    attestation key (and certificate), and
-	    combined with a cloud operated privacy CA, can dynamically generate per origin
-	    attestation keys and attestation certificates.
-	  </li>
-	  <li>A WebAuthn Authenticator can implement direct anonymous
-	    attestation (see [[FIDOEcdaaAlgorithm]]).  Using this scheme the authenticator
-	    generates a blinded attestation signature.  This allows the relying party to verify
-	    the signature using the DAA root key, but the attestation signature doesn't
-	    serve as a global correlation handle.
-	  </li>
-	</ul>
+Attestation keys may be used to track users or link various online identities of the same user together. This may be mitigated
+in several ways, including:
+
+- A WebAuthn <a>Authenticator</a> manufacturer may choose to ship all of their devices with the same (or a fixed number of)
+    attestation key(s) (called Full Basic Attestation). This will anonymize the user at the risk of not being able to revoke a
+    particular attestation key should its WebAuthn Authenticator be compromised.
+
+- A WebAuthn Authenticator may be capable of dynamically generating different attestation keys (and requesting related
+    certificates) per origin (following the Privacy CA model). For example, a WebAuthn Authenticator can ship with a master
+    attestation key (and certificate), and combined with a cloud operated privacy CA, can dynamically generate per origin
+    attestation keys and attestation certificates.
+
+- A WebAuthn Authenticator can implement direct anonymous attestation (see [[FIDOEcdaaAlgorithm]]).  Using this scheme the
+    authenticator generates a blinded attestation signature.  This allows the [RP] to verify the signature using the DAA root
+    key, but the attestation signature doesn't serve as a global correlation handle.
+
 
 #### Attestation Certificate and Attestation Certificate CA Compromise #### {#ca-compromise}
 
-	<p>When an intermediate CA or a root CA used for issuing attestation
-	  certificates is compromised, WebAuthn <a>Authenticator</a> attestation keys are still
-	  safe although their certificates can no longer be trusted. A
-	  WebAuthn Authenticator manufacturer that has recorded the public attestation keys
-	  for their devices can issue new attestation certificates for
-	  these keys from a new intermediate CA or from a new root CA.
-	  If the root CA changes, the relying parties must update their trusted
-	  root certificates accordingly.
-	</p>
-	<p>A WebAuthn Authenticator attestation certificate must be revoked by the issuing CA
-	  if its key has been compromised. A WebAuthn Authenticator manufacturer may need to
-	  ship a firmware update and inject new attestation keys and
-	  certificates into already manufactured WebAuthn Authenticators, if
-	  the exposure was due to a firmware flaw.
-	  (The process by which this happens is out of scope for this specification.)
-	  No further valid
-	  attestation statements can be made by the affected WebAuthn Authenticators unless
-	  the WebAuthn Authenticator manufacturer has this capability.
-	</p>
-	<p>If attestation certificate validation fails due to a revoked
-	  intermediate attestation CA certificate, and relying party policy requires rejecting
-	  the registration/authentication request in these situations,
-	  then it is recommended that the relying party also un-registers
-	  (or marks as "surrogate attestation" (see <a href='#attestation-models'></a>), policy permitting) 
-	  scoped credentials that were registered post the CA compromise date using an attestation
-	  certificate chaining up to the same intermediate CA. It is thus
-	  recommended that relying parties remember intermediate attestation CA certificates
-	  during Authenticator registration in order to un-register related Scoped Credentials if 
-	  the registration was performed after revocation of such certificates.
-	</p>
+When an intermediate CA or a root CA used for issuing attestation certificates is compromised, WebAuthn <a>Authenticator</a>
+attestation keys are still safe although their certificates can no longer be trusted. A WebAuthn Authenticator manufacturer that
+has recorded the public attestation keys for their devices can issue new attestation certificates for these keys from a new
+intermediate CA or from a new root CA. If the root CA changes, the [RPS] must update their trusted root certificates
+accordingly.
 
-	<p>If a DAA attestation key has been compromised, it can be added to the
-	  RogueList (i.e., the list of revoked authenticators) maintained by the related DAA-Issuer.
-	  The relying party should verify whether an authenticator belongs to the
-	  RogueList when performing DAA-Verify.  The FIDO Metadata Service [[FIDOMetadataService]]
-	  provides an easy way to access such information.
-	</p>
+A WebAuthn Authenticator attestation certificate must be revoked by the issuing CA if its key has been compromised. A WebAuthn
+Authenticator manufacturer may need to ship a firmware update and inject new attestation keys and certificates into already
+manufactured WebAuthn Authenticators, if the exposure was due to a firmware flaw. (The process by which this happens is out of
+scope for this specification.) No further valid attestation statements can be made by the affected WebAuthn Authenticators
+unless the WebAuthn Authenticator manufacturer has this capability.
+
+If attestation certificate validation fails due to a revoked intermediate attestation CA certificate, and the [RP]'s policy
+requires rejecting the registration/authentication request in these situations, then it is recommended that the [RP] also
+un-registers (or marks as "surrogate attestation" (see [[#attestation-models]]), policy permitting) scoped credentials that were
+registered post the CA compromise date using an attestation certificate chaining up to the same intermediate CA. It is thus
+recommended that [RPS] remember intermediate attestation CA certificates during Authenticator registration in order to
+un-register related Scoped Credentials if the registration was performed after revocation of such certificates.
+
+If a DAA attestation key has been compromised, it can be added to the RogueList (i.e., the list of revoked authenticators)
+maintained by the related DAA-Issuer. The [RP] should verify whether an authenticator belongs to the RogueList when performing
+DAA-Verify. The FIDO Metadata Service [[FIDOMetadataService]] provides an easy way to access such information.
+
 
 #### Attestation Certificate Hierarchy #### {#cert-hierarchy}
 
-	<p>A 3 tier hierarchy for attestation certificates is recommended
-	  (i.e., Attestation Root, Attestation Issuing CA, Attestation Certificate).
-	  It is also recommended that
-	  for each WebAuthn Authenticator device line (i.e., model), a separate issuing CA is used to help
-	  facilitate isolating problems with a specific version of a device.
-	</p>
-	<p>If the attestation root certificate is <em>not</em> dedicated
-	  to a single WebAuthn Authenticator device line (i.e., AAGUID),
-	  the AAGUID must be specified either in the attestation certificate itself or
-	  as an extension in the <code>core.rawData</code>.
-	</p>
+A 3 tier hierarchy for attestation certificates is recommended (i.e., Attestation Root, Attestation Issuing CA, Attestation
+Certificate). It is also recommended that for each WebAuthn Authenticator device line (i.e., model), a separate issuing CA is
+used to help facilitate isolating problems with a specific version of a device.
 
-<!-- End of include from key-attestation.html -->
+If the attestation root certificate is *not* dedicated to a single WebAuthn Authenticator device line (i.e., AAGUID), the AAGUID
+must be specified either in the attestation certificate itself or as an extension in the `core.rawData`.
+
 
 # WebAuthn Extensions # {#extensions}
-<p>
-  The mechanism for generating scoped credentials, as well as requesting and
-  generating WebAuthn assertions, as defined in [[#api]],
-  can be extended to suit particular use cases. Each case is
-  addressed by defining a <em>registration extension</em> and/or a
-  <em>signature extension</em>. Extensions can define additions to the
-  following steps and data:
-</p>
 
-<ul>
-  <li>
-    {{makeCredential()}} request parameters for
-    registration extension.
-  </li>
-  <li>
-    {{getAssertion()}} request parameters for
-    signature extensions.
-  </li>
-  <li>
-    Client processing, and the {{ClientData}} structure, for
-    registration extensions and signature extensions.
-  </li>
-  <li>
-    Authenticator processing, and the <a>authenticatorData</a>
-    structure, for signature extensions.
-  </li>
-</ul>
+The mechanism for generating scoped credentials, as well as requesting and generating WebAuthn assertions, as defined in
+[[#api]], can be extended to suit particular use cases. Each case is addressed by defining a *registration extension* and/or a
+*signature extension*. Extensions can define additions to the following steps and data:
 
-<p>
-  When requesting an assertion for a scoped credential, an Relying Party can list a set
-  of extensions to be used, if they are supported by the client and/or the
-  authenticator. It sends the request parameters for each extension in the
-  {{getAssertion()}} call (for signature extensions) or
-  {{makeCredential()}} call (for registration extensions) to the client
-  platform. The client platform performs additional processing for each
-  extension that it supports, and augments {{ClientData}} as required
-  by the extension. For extensions that the client platform does not support,
-  it passes the request parameters on to the authenticator when possible
-  (criteria defined below). This allows one to define extensions that affect
-  the authenticator only.
-</p>
-<p>
-  Similarly, the authenticator performs additional processing for the
-  extensions that it supports, and augments <var>authenticatorData</var> as
-  specified by the extension.
-</p>
-<p>
-  Extensions that are not supported are ignored.
-</p>
+- {{makeCredential()}} request parameters for registration extension.
+
+- {{getAssertion()}} request parameters for signature extensions.
+
+- Client processing, and the {{ClientData}} structure, for registration extensions and signature extensions.
+
+- Authenticator processing, and the <a>authenticatorData</a> structure, for signature extensions.
+
+When requesting an assertion for a scoped credential, a [RP] can list a set of extensions to be used, if they are supported by
+the client and/or the authenticator. It sends the request parameters for each extension in the {{getAssertion()}} call (for
+signature extensions) or {{makeCredential()}} call (for registration extensions) to the client platform. The client platform
+performs additional processing for each extension that it supports, and augments {{ClientData}} as required by the extension.
+For extensions that the client platform does not support, it passes the request parameters on to the authenticator when possible
+(criteria defined below). This allows one to define extensions that affect the authenticator only.
+
+Similarly, the authenticator performs additional processing for the extensions that it supports, and augments
+|authenticatorData| as specified by the extension.
+
+Extensions that are not supported are ignored.
+
 
 ## Extension identifiers ## {#extension-id}
 
-  <p>
-  Extensions are identified by a string, chosen by the extension author. Extension identifiers
-  should aim to be globally unique, e.g., by using reverse domain-name of the defining entity such
-  as <code>com.example.webauthn.myextension</code>.
-  </p>
+Extensions are identified by a string, chosen by the extension author. Extension identifiers should aim to be globally unique,
+e.g., by using reverse domain-name of the defining entity such as `com.example.webauthn.myextension`.
 
-  <p>
-  Extensions that may exist in multiple versions should take care to include a version
-  in their identifier. In effect, different versions are thus treated as different extensions.
-  </p>
+Extensions that may exist in multiple versions should take care to include a version in their identifier. In effect, different
+versions are thus treated as different extensions.
 
-  <p>
-  Extensions defined in this specification use a fixed prefix of <code>webauthn</code>
-  for the extension identifiers. This prefix should not be used for extensions not defined by the W3C.
-  </p>
+Extensions defined in this specification use a fixed prefix of `webauthn` for the extension identifiers. This prefix should not
+be used for extensions not defined by the W3C.
 
 
 ## Defining extensions ## {#extension-specification}
 
-  <p>
-    A definition of an extension must specify, at minimum, an extension
-    identifier and an extension client argument sent via the
-    {{getAssertion()}} or {{makeCredential()}} call (see below).
-    Additionally, extensions may specify additional values in
-    {{ClientData}}, <code>authenticatorData</code> (in the case of
-    signature extensions), or both.
-  </p>
+A definition of an extension must specify, at minimum, an extension identifier and an extension client argument sent via the
+{{getAssertion()}} or {{makeCredential()}} call (see below). Additionally, extensions may specify additional values in
+{{ClientData}}, `authenticatorData` (in the case of signature extensions), or both.
 
-  <p class="note">
-    An extension that does not define additions to {{ClientData}} nor
-    <code>authenticatorData</code> is possible, but should be avoided. In such
-    cases, the relying party would have no indication if the extension was
-    supported or processed by the client and/or authenticator.
-  </p>
+Note: An extension that does not define additions to {{ClientData}} nor `authenticatorData` is possible, but should be avoided.
+    In such cases, the [RP] would have no indication if the extension was supported or processed by the client and/or
+    authenticator.
 
 
 ## Extending request parameters ## {#extension-request-parameters}
 
-  <p>
-    An extension defines two request arguments. The <dfn>client argument</dfn>
-    is passed from the <a>WebAuthn Relying Party</a> to the client in the {{getAssertion()}} or
-    {{makeCredential()}} call, while the <dfn>authenticator
-    argument</dfn> is passed from the client to the authenticator during the
-    processing of these calls.
-  </p>
-  <p>
-    Extension definitions MUST specify the valid values for their client
-    argument. Clients are free to ignore extensions with an invalid client
-    argument. Specifying an authenticator argument is optional, since some
-    extensions may only affect client processing.
-  </p>
+An extension defines two request arguments. The <dfn>client argument</dfn> is passed from the <a>[RP]</a> to the client in the
+{{getAssertion()}} or {{makeCredential()}} call, while the <dfn>authenticator argument</dfn> is passed from the client to the
+authenticator during the processing of these calls.
 
-  <p>
-    A WebAuthn Relying Party simultaneously requests the use of an extension and sets its client
-    argument by including an entry in the <a>credentialExtensions</a>
-	or <a>assertionExtensions</a> dictionary
-    parameters to the {{makeCredential()}} or {{getAssertion()}}
-    call. The entry key MUST be the extension identifier, and the value
-    MUST be the <a>client argument</a>.
-  </p>
+Extension definitions MUST specify the valid values for their client argument. Clients are free to ignore extensions with an
+invalid client argument. Specifying an authenticator argument is optional, since some extensions may only affect client
+processing.
 
-  <pre class="example highlight">
-  var assertionPromise = credentials.getAssertion(..., /* extensions */ {
-    "com.example.webauthn.foobar": 42
-  });
-  </pre>
+A [RP] simultaneously requests the use of an extension and sets its client argument by including an entry in the
+<a>credentialExtensions</a> or <a>assertionExtensions</a> dictionary parameters to the {{makeCredential()}} or
+{{getAssertion()}} call. The entry key MUST be the extension identifier, and the value MUST be the <a>client argument</a>.
 
-  <p>
-    Extensions that affect the behavior of the client platform can define their
-    argument to be any set of values that can be encoded in JSON. Such an
-    extension will in general (but not always) specify additional values to the
-    {{ClientData}} structure (see below). It may also specify an
-    authenticator argument that platforms implementing the extension are
-    expected to send to the authenticator. The authenticator argument should be
-    a byte string.
-  </p>
+<pre class="example highlight">
+    var assertionPromise = credentials.getAssertion(..., /* extensions */ {
+        "com.example.webauthn.foobar": 42
+    });
+</pre>
 
-  <p class="note">
-    Extensions should aim to define authenticator arguments that are as small
-    as possible. Some authenticators communicate over low-bandwidth links such
-    as Bluetooth Low-Energy or NFC.
-  </p>
+Extensions that affect the behavior of the client platform can define their argument to be any set of values that can be encoded
+in JSON. Such an extension will in general (but not always) specify additional values to the {{ClientData}} structure (see
+below). It may also specify an authenticator argument that platforms implementing the extension are expected to send to the
+authenticator. The authenticator argument should be a byte string.
 
-  <p class="note">
-    Extensions that do not need to pass any particular argument value, must
-    still define a client argument. It is recommended that the argument be
-    defined as the constant value <code>true</code> in this case.
-  </p>
+Note: Extensions should aim to define authenticator arguments that are as small as possible. Some authenticators communicate
+    over low-bandwidth links such as Bluetooth Low-Energy or NFC.
 
-  <p>
-    For extensions that specify additional authenticator processing only, it is
-    desirable that the platform need not know the extension. To support this,
-    platforms SHOULD pass the client argument of unknown extension as the
-    authenticator argument unchanged, under the same extension identifier. The
-    authenticator argument should be the CBOR encoding of the client argument,
-    as specified in Section 4.2 of [[RFC7049]]. Clients SHOULD silently drop
-    unknown extensions whose client argument cannot be encoded as a CBOR
-    structure.
-  </p>
+Note: Extensions that do not need to pass any particular argument value, must still define a client argument. It is recommended
+    that the argument be defined as the constant value `true` in this case.
+
+For extensions that specify additional authenticator processing only, it is desirable that the platform need not know the
+extension. To support this, platforms SHOULD pass the client argument of unknown extension as the authenticator argument
+unchanged, under the same extension identifier. The authenticator argument should be the CBOR encoding of the client argument,
+as specified in Section 4.2 of [[RFC7049]]. Clients SHOULD silently drop unknown extensions whose client argument cannot be
+encoded as a CBOR structure.
+
 
 ## Extending client processing ## {#extension-client-processing}
 
-  <p>
-    Extensions may define additional processing requirements on the client
-    platform during the creation of credentials or the generation of an
-    assertion. In order for the <a>WebAuthn Relying Party</a> to verify the processing took place, or if
-    the processing has a result value that the Relying Party needs to be aware of, the
-    extension should specify a client data value to be included in the
-    {{ClientData}} structure.
-  </p>
-  <p>
-    The value may be any value that can be encoded as a JSON value. If any
-    extension processed by a client defines such a value, the client SHOULD
-    include a dictionary in {{ClientData}} with the key
-    <a>extensions</a>. For each such extension, the client SHOULD add an
-    entry to this dictionary with the extension identifier as the key, and the
-    extension's client data value.
-  </p>
+Extensions may define additional processing requirements on the client platform during the creation of credentials or the
+generation of an assertion. In order for the <a>[RP]</a> to verify the processing took place, or if the processing has a result
+value that the [RP] needs to be aware of, the extension should specify a client data value to be included in the {{ClientData}}
+structure.
+
+The value may be any value that can be encoded as a JSON value. If any extension processed by a client defines such a value, the
+client SHOULD include a dictionary in {{ClientData}} with the key <a>extensions</a>. For each such extension, the client SHOULD
+add an entry to this dictionary with the extension identifier as the key, and the extension's client data value.
 
 
 ## Extending authenticator processing with signature extensions ## {#extension-authenticator-processing}
 
-  <p>
-    Signature extensions that define additional authenticator processing should
-    similarly define an authenticator data value. The value may be any data
-    that can be encoded as a CBOR value. An authenticator that processes a
-    signature extension that defines such a value must include it in the
-    <code>authenticatorData</code>.
-  </p>
+Signature extensions that define additional authenticator processing should similarly define an authenticator data value. The
+value may be any data that can be encoded as a CBOR value. An authenticator that processes a signature extension that defines
+such a value must include it in the `authenticatorData`.
 
-  <p>
-    As specified in <a href="#sec-authenticator-data"></a>, the authenticator data
-    value of each processed extension is included in the extended data part of
-    the <code>authenticatorData</code>. This part is a CBOR map, with extension
-    identifiers as keys, and the authenticator data value of each extension as
-    the value.
-  </p>
+As specified in [[#sec-authenticator-data]], the authenticator data value of each processed extension is included in the
+extended data part of the `authenticatorData`. This part is a CBOR map, with extension identifiers as keys, and the
+authenticator data value of each extension as the value.
+
 
 ## Example extension ## {#sample-extensions}
 
-  <p>This section is non-normative.</p>
-  <p>
-    To illustrate the requirements above, consider a hypothetical extension
-    <em>Geo</em>. This extension, if supported, lets both clients and
-    authenticators embed their geolocation in signatures.
-  </p>
+[INFORMATIVE]
 
-  <p>
-    The extension identifier is chosen as <code>com.example.webauthn.geo</code>.
-    The client argument is the constant value <code>true</code>, since the
-    extension does not require the <a>WebAuthn Relying Party</a> to pass any particular information to the
-    client, other than that it requests the use of the extension. The Relying Party sets
-    this value in its request for an assertion:
-  </p>
-  <pre class="highlight">
-  var assertionPromise =
-      credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
-          {}, /* Empty filter */
-          { 'com.example.webauthn.geo': true });
-  </pre>
+To illustrate the requirements above, consider a hypothetical extension *Geo*. This extension, if supported, lets both clients
+and authenticators embed their geolocation in signatures.
 
-  <p>
-  The extension defines the additional client data to be the client's location, if known,
-  as a GeoJSON [[GeoJSON]] point. The client constructs the following client data:
-  </p>
-  <pre class="highlight">
-  {
-     ...,
-     'extensions': {
-         'com.example.webauthn.geo': {
-             'type': 'Point',
-             'coordinates': [65.059962, -13.993041]
-         }
-     }
-  }
-  </pre>
+The extension identifier is chosen as `com.example.webauthn.geo`. The client argument is the constant value `true`, since the
+extension does not require the <a>[RP]</a> to pass any particular information to the client, other than that it requests the use
+of the extension. The [RP] sets this value in its request for an assertion:
 
-  <p>
-  The extension also requires the client to set the authenticator parameter to the fixed value
-  <code>1</code>.
-  </p>
+<pre class="highlight">
+    var assertionPromise =
+        credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
+            {}, /* Empty filter */
+            { 'com.example.webauthn.geo': true });
+</pre>
 
-  <p>
-  Finally, the extension requires the authenticator to specify its geolocation in the authenticator
-  data, if known. The extension e.g. specifies that the location shall be encoded as a two-element
-  array of floating point numbers, encoded with CBOR.
-  An authenticator does this by including it in the <code>authenticatorData</code>.
-  As an example, authenticator data may be as follows (notation taken from [[RFC7049]]):
-  </p>
+The extension defines the additional client data to be the client's location, if known, as a GeoJSON [[GeoJSON]] point. The
+client constructs the following client data:
 
-  <pre>
-  81 (hex)                                -- Flags, ED and TUP both set.
-  20 05 58 1F                             -- Signature counter
-  A1                                      -- CBOR map of one element
-    6C                                    -- Key 1: CBOR text string of 12 bytes
-      77 65 62 61 75 74 68 6E 2E 67 65 6F -- "webauthn.geo" UTF-8 string
-    82                                    -- Value 1: CBOR array of two elements
-      FA 42 82 1E B3                      -- Element 1: Latitude as CBOR encoded float
-      FA C1 5F E3 7F                      -- Element 2: Longitude as CBOR encoded float
-  </pre>
+<pre class="highlight">
+    {
+        ...,
+        'extensions': {
+            'com.example.webauthn.geo': {
+                'type': 'Point',
+                'coordinates': [65.059962, -13.993041]
+            }
+        }
+    }
+</pre>
+
+The extension also requires the client to set the authenticator parameter to the fixed value `1`.
+
+Finally, the extension requires the authenticator to specify its geolocation in the authenticator data, if known. The extension
+e.g. specifies that the location shall be encoded as a two-element array of floating point numbers, encoded with CBOR. An
+authenticator does this by including it in the `authenticatorData`. As an example, authenticator data may be as follows
+(notation taken from [[RFC7049]]):
+
+<pre class="highlight">
+    81 (hex)                                    -- Flags, ED and TUP both set.
+    20 05 58 1F                                 -- Signature counter
+    A1                                          -- CBOR map of one element
+        6C                                      -- Key 1: CBOR text string of 12 bytes
+            77 65 62 61 75 74 68 6E 2E 67 65 6F -- "webauthn.geo" UTF-8 string
+        82                                      -- Value 1: CBOR array of two elements
+            FA 42 82 1E B3                      -- Element 1: Latitude as CBOR encoded float
+            FA C1 5F E3 7F                      -- Element 2: Longitude as CBOR encoded float
+</pre>
 
 
 # Standard extensions # {#extension-standard}
 
-  <p>
-  This section defines standard extensions defined by the W3C.
-  </p>
+This section defines standard extensions defined by the W3C.
+
 
 ## Transaction authorization ## {#extension-txauth}
 
-  <p>
-    This signature extension allows for a simple form of transaction
-    authorization. A relying party can specify a prompt string, intended for
-    display on a trusted device on the authenticator.
-  </p>
+This signature extension allows for a simple form of transaction authorization. A [RP] can specify a prompt string, intended for
+display on a trusted device on the authenticator.
 
-  <dl>
-    <dt>Extension identifier</dt>
-    <dd>
-      <code>webauthn.txauth.simple</code>
-    </dd>
-    <dt>Client argument</dt>
-    <dd>A single UTF-8 encoded string <em>prompt</em></dd>
+: Extension identifier
+:: `webauthn.txauth.simple`
 
-    <dt>Client processing</dt>
-    <dd>None, except default forwarding of client argument to authenticator argument.</dd>
+: Client argument
+:: A single UTF-8 encoded string prompt.
 
-    <dt>Authenticator argument</dt>
-    <dd>The client argument encoded as a CBOR text string (major type 3).</dd>
+: Client processing
+:: None, except default forwarding of client argument to authenticator argument.
 
-    <dt>Authenticator processing</dt>
-    <dd>The authenticator MUST display the prompt to the user before performing
-        the user verification / test of user presence. The authenticator may insert line breaks if needed.</dd>
+: Authenticator argument
+:: The client argument encoded as a CBOR text string (major type 3).
 
-    <dt>Authenticator data</dt>
-    <dd>A single UTF-8 string, representing the prompt <em>as displayed</em> (including any
-        eventual line breaks).</dd>
-  </dl>
+: Authenticator processing
+:: The authenticator MUST display the prompt to the user before performing the user verification / test of user presence. The
+    authenticator may insert line breaks if needed.
 
-  The generic version of this extension allows images to be used as prints as well.  This is allows
-  authenticators without a font rendering engine to be used and also supports a richer visual appearance.
-  <dl>
-    <dt>Extension identifier</dt>
-    <dd>
-      <code>webauthn.txauth.generic</code>
-    </dd>
+: Authenticator data
+:: A single UTF-8 string, representing the prompt *as displayed* (including any eventual line breaks).
 
-    <dt>Client argument</dt>
-    <dd>A CBOR map with one pair of data items (CBOR tagged as 0xa1). The pair of data items consists of
-      <ol>
-	<li>one UTF-8 encoded string <dfn>contentType</dfn>, containing
-	  the MIME-Type of the content, e.g. "image/png"</li>
-	<li>and the <dfn>content</dfn> itself, encoded as CBOR byte array.</li>
-      </ol>
-    </dd>
+The generic version of this extension allows images to be used as prompts as well.  This allows authenticators without a font
+rendering engine to be used and also supports a richer visual appearance.
 
-    <dt>Client processing</dt>
-    <dd>None, except default forwarding of client argument to authenticator argument.</dd>
+: Extension identifier
+:: `webauthn.txauth.generic`
 
-    <dt>Authenticator argument</dt>
-    <dd>The client argument encoded as a CBOR map.</dd>
+: Client argument
+:: A CBOR map with one pair of data items (CBOR tagged as 0xa1). The pair of data items consists of
+    1. one UTF-8 encoded string <dfn>contentType</dfn>, containing the MIME-Type of the content, e.g. "image/png"
+    2. and the <dfn>content</dfn> itself, encoded as CBOR byte array.
 
-    <dt>Authenticator processing</dt>
-    <dd>The authenticator MUST display the <a>content</a> to the user before performing
-        the user verification / test of user presence. The authenticator may add other information below the <a>content</a>.
-        No changes are allowed to the <a>content</a> itself, i.e. inside <a>content</a> boundary box.
-    </dd>
+: Client processing
+:: None, except default forwarding of client argument to authenticator argument.
 
-    <dt>Authenticator data</dt>
-    <dd>
-      The hash value of the <a>content</a> which was displayed.
-      The authenticator MUST use the same hash algorithm as it uses for the signature itself.
-    </dd>
-  </dl>
-</section>
+: Authenticator argument
+:: The client argument encoded as a CBOR map.
+
+: Authenticator processing
+:: The authenticator MUST display the <a>content</a> to the user before performing the user verification / test of user
+    presence. The authenticator may add other information below the <a>content</a>. No changes are allowed to the <a>content</a>
+    itself, i.e. inside <a>content</a> boundary box.
+
+: Authenticator data
+:: The hash value of the <a>content</a> which was displayed. The authenticator MUST use the same hash algorithm as it uses for
+    the signature itself.
+
 
 ## Authenticator Selection Extension ## {#extension-authenticator-selection}
 
-  <p>
-    This registration extension allows a Relying Party to guide the selection
-    of the authenticator that will be leveraged when creating the credential.
-    It is intended primarily for Relying Parties that wish to tightly control
-    the experience around credential creation.
-  </p>
+This registration extension allows a [RP] to guide the selection of the authenticator that will be leveraged when creating the
+credential. It is intended primarily for [RPS] that wish to tightly control the experience around credential creation.
 
-  <dl>
-    <dt>Extension identifier</dt>
-    <dd>
-      <code>webauthn.authn-sel</code> (only used during {{makeCredential()}})
-    </dd>
-    <dt>Client argument</dt>
-    <dd>
-      A sequence of AAGUIDs:
-      <pre class="idl highlight">
-typedef sequence < AAGUID > AuthenticatorSelectionList;
-      </pre>
-      Each AAGUID corresponds to an authenticator attestation that is
-      acceptable to the Relying Party for this credential creation. The list is ordered by
-      decreasing preference.<br>
+: Extension identifier
+:: `webauthn.authn-sel`
 
-      An AAGUID is defined as a DOMString, and is the globally unique identifier
-      of the authenticator attestation being sought.
-      <pre class="idl highlight">
-typedef DOMString AAGUID;
-      </pre>
-    </dd>
+: Client argument
+:: A sequence of AAGUIDs:
 
-    <dt>Client processing</dt>
-    <dd>
-      If the client supports the Authenticator Selection Extension, it MUST use
-      the first available authenticator whose AAGUID is present in the
-      <dfn>AuthenticatorSelectionList</dfn>. If none of the available
-      authenticators match a provided AAGUID, the client MUST select an
-      authenticator from among the available authenticators to generate the
-      credential.
-    </dd>
+    <pre class="idl highlight">
+        typedef sequence < AAGUID > AuthenticatorSelectionList;
+    </pre>
 
-    <dt>Authenticator argument</dt>
-    <dd>There is no authenticator argument.</dd>
+    Each AAGUID corresponds to an authenticator attestation that is acceptable to the [RP] for this credential creation. The
+    list is ordered by decreasing preference.
 
-    <dt>Authenticator processing</dt>
-    <dd>None.</dd>
-  </dl>
+    An AAGUID is defined as a DOMString, and is the globally unique identifier of the authenticator attestation being sought.
+
+    <pre class="idl highlight">
+        typedef DOMString AAGUID;
+    </pre>
+
+: Client processing
+:: This extension can only used during {{makeCredential()}}. If the client supports the Authenticator Selection Extension, it
+    MUST use the first available authenticator whose AAGUID is present in the <dfn>AuthenticatorSelectionList</dfn>. If none of
+    the available authenticators match a provided AAGUID, the client MUST select an authenticator from among the available
+    authenticators to generate the credential.
+
+: Authenticator argument
+:: There is no authenticator argument.
+
+: Authenticator processing
+:: None.
+
 
 ## AAGUID Extension ## {#aaguid-extension}
 
-	  <dl>
-		<dt>Extension identifier</dt>
-		<dd><code>webauthn.aaguid</code></dd>
+: Extension identifier
+:: `webauthn.aaguid`
 
-		<dt>Client argument</dt>
-		<dd>N/A</dd>
+: Client argument
+:: N/A
 
-		<dt>Client processing</dt>
-		<dd>N/A</dd>
+: Client processing
+:: N/A
 
-		<dt>Authenticator argument</dt>
-		<dd>N/A</dd>
+: Authenticator argument
+:: N/A
 
-		<dt>Authenticator processing</dt>
-		<dd>This extension is added automatically by the <a>authenticator</a>.  This extension can be added
-		  to attestation statements and signatures.
-		</dd>
+: Authenticator processing
+:: This extension is added automatically by the <a>authenticator</a>.  This extension can be added to attestation statements and
+    signatures.
 
-		<dt>Authenticator data</dt>
-		<dd>A 128-bit Authenticator Attestation GUID encoded as a CBOR text string (major type 3).
+: Authenticator data
+:: A 128-bit Authenticator Attestation GUID encoded as a CBOR text string (major type 3). This AAGUID is used to identify the
+    Authenticator model (Authenticator Attestation GUID).
 
-		  <p>This AAGUID is used to identify the Authenticator model (Authenticator Attestation GUID).</p>
-		    <div class="note">
-		      <p>The authenticator model (identified by the AAGUID) can be derived from
-			(a) here, or
-			(b) from the attestation certificate (if we have an authenticator specific
-			or authenticator model specific attestation certificate),
-			or (c) or from the claimed AAGUID in the client
-			encoded attestation statement (if we have one attestation root certificate
-			per authenticator model).
-		      </p>
-		      <p>In the case of DAA there is no need for an X.509
-			attestation certificate hierarchy.
-			Instead the trust anchor being known to the Relying Party is
-			the DAA root key (i.e. ECPoint2 X, Y).  This root key must be dedicated
-			to a single authenticator model.
-		      </p>
-		    </div>
-		</dd>
-	  </dl>
+    <div class='note'>
+        Note: The authenticator model (identified by the AAGUID) can be derived from
+            - here, or
+            - from the attestation certificate (if we have an authenticator specific or authenticator model specific attestation
+                certificate), or
+            - from the claimed AAGUID in the client encoded attestation statement (if we have one attestation root certificate
+                per authenticator model).
+
+            In the case of DAA there is no need for an X.509 attestation certificate hierarchy. Instead the trust anchor being
+            known to the [RP] is the DAA root key (i.e. ECPoint2 X, Y).  This root key must be dedicated to a single
+            authenticator model.
+    </div>
 
 
 ## SupportedExtensions Extension ## {#supported-extensions-extension}
-	  <dl>
-		<dt>Extension identifier</dt>
-		<dd><code>webauthn.exts</code></dd>
-		<dt>Client argument</dt>
-		<dd>N/A</dd>
 
-		<dt>Client processing</dt>
-		<dd>N/A</dd>
+: Extension identifier
+:: `webauthn.exts`
 
-		<dt>Authenticator argument</dt>
-		<dd>N/A</dd>
+: Client argument
+:: N/A
 
-		<dt>Authenticator processing</dt>
-		<dd>This extension is added automatically by the authenticator.  This extension can be added
-		  to attestation statements.
-		</dd>
-		<dt>Authenticator data</dt>
-		<dd>The SupportedExtension extension is a list (CBOR array) of extension identifiers
-		  encoded as UTF-8 Strings.
-		</dd>
-	      </dl>
+: Client processing
+:: N/A
+
+: Authenticator argument
+:: N/A
+
+: Authenticator processing
+:: This extension is added automatically by the authenticator.  This extension can be added to attestation statements.
+
+: Authenticator data
+:: The SupportedExtension extension is a list (CBOR array) of extension identifiers encoded as UTF-8 Strings.
+
 
 ## User Verification Index (UVI) Extension ## {#uvi-extension}
-	  <dl>
-		<dt>Extension identifier</dt>
-		<dd><code>webauthn.uvi</code></dd>
 
-		<dt>Client argument</dt>
-		<dd>N/A</dd>
+: Extension identifier
+:: `webauthn.uvi`
 
-		<dt>Client processing</dt>
-		<dd>N/A</dd>
+: Client argument
+:: N/A
 
-		<dt>Authenticator argument</dt>
-		<dd>N/A</dd>
+: Client processing
+:: N/A
 
-		<dt>Authenticator processing</dt>
-		<dd>This extension is added automatically by the authenticator.  This extension can be added
-		  to attestation statements and signatures.
-		</dd>
+: Authenticator argument
+:: N/A
 
-		<dt>Authenticator data</dt>
-		<dd>The user verification index (UVI) is a value uniquely identifying
-		  a user verification data record.  The UVI is encoded as CBOR byte string (type 0x58).
-		    <p>Each UVI value MUST be specific to the related key (in order to provide unlinkability).
-		      It also must contain sufficient entropy that makes guessing impractical.
-		      UVI values MUST NOT be reused by the Authenticator (for other biometric data or users).
-		    </p>
-		    <p>The UVI data can be used by servers to understand whether an authentication
-		      was authorized by the exact same biometric data as the initial key generation.
-		      This allows the detection and prevention of "friendly fraud".
-		    </p>
-		    <p>As an example, the UVI could be computed as SHA256(KeyID | SHA256(rawUVI)),
-		      where the rawUVI reflects (a) the biometric reference data,
-		      (b) the related OS level user ID and (c) an identifier which changes whenever a
-		      factory reset is performed for the device, e.g.
-		      rawUVI = biometricReferenceData | OSLevelUserID | FactoryResetCounter.
-		    </p>
-		    <p>Servers supporting UVI extensions MUST support a length of up to 32 bytes
-		      for the UVI value.
-		    </p>
-		    <p>Example for rawData containing one UVI extension</p>
-  <pre>
-  F1 D0                                   -- This is a WebAuthn packed rawData object
-  81                                      -- TUP and ED set
-  00 00 00 01                             -- (initial) signature counter
-  ...                                     -- all public key alg etc.
-  A1                                      -- extension: CBOR map of one element
-    6C                                    -- Key 1: CBOR text string of 12 bytes
-      77 65 62 61 75 74 68 6E 2E 75 76 69 -- "webauthn.uvi" UTF-8 string
-    58 20                                 -- Value 1: CBOR byte string with 0x20 bytes
-    00 43 B8 E3 BE 27 95 8C               -- the UVI value itself
-    28 D5 74 BF 46 8A 85 CF
-    46 9A 14 F0 E5 16 69 31
-    DA 4B CF FF C1 BB 11 32
-    82
-  </pre>
-		</dd>
-	  </dl>
+: Authenticator processing
+:: This extension is added automatically by the authenticator. This extension can be added to attestation statements and
+    signatures.
 
-	  
+: Authenticator data
+:: The user verification index (UVI) is a value uniquely identifying a user verification data record. The UVI is encoded as CBOR
+    byte string (type 0x58). Each UVI value MUST be specific to the related key (in order to provide unlinkability). It also
+    must contain sufficient entropy that makes guessing impractical. UVI values MUST NOT be reused by the Authenticator (for
+    other biometric data or users).
+
+    The UVI data can be used by servers to understand whether an authentication was authorized by the exact same biometric data
+    as the initial key generation. This allows the detection and prevention of "friendly fraud".
+
+    As an example, the UVI could be computed as SHA256(KeyID | SHA256(rawUVI)), where the rawUVI reflects (a) the biometric
+    reference data, (b) the related OS level user ID and (c) an identifier which changes whenever a factory reset is performed
+    for the device, e.g. rawUVI = biometricReferenceData | OSLevelUserID | FactoryResetCounter.
+
+    Servers supporting UVI extensions MUST support a length of up to 32 bytes for the UVI value.
+
+    Example for rawData containing one UVI extension
+    <pre class="highlight">
+        F1 D0                                       -- This is a WebAuthn packed rawData object
+        81                                          -- TUP and ED set
+        00 00 00 01                                 -- (initial) signature counter
+        ...                                         -- all public key alg etc.
+        A1                                          -- extension: CBOR map of one element
+            6C                                      -- Key 1: CBOR text string of 12 bytes
+                77 65 62 61 75 74 68 6E 2E 75 76 69 -- "webauthn.uvi" UTF-8 string
+            58 20                                   -- Value 1: CBOR byte string with 0x20 bytes
+                00 43 B8 E3 BE 27 95 8C             -- the UVI value itself
+                28 D5 74 BF 46 8A 85 CF
+                46 9A 14 F0 E5 16 69 31
+                DA 4B CF FF C1 BB 11 32
+                82
+    </pre>
+
+
 # IANA Considerations # {#iana-considerations}
 
-  This specification registers the algorithm names "S256", "S384", "S512", and "SM3"
-  with the IANA JSON Web Algorithms registry as defined in section
-  "Cryptographic Algorithms for Digital Signatures and MACs" in [[RFC7518]].
-  <p>
-    These names follow the naming strategy in
-    <a href="https://tools.ietf.org/html/draft-ietf-oauth-spop-15">draft-ietf-oauth-spop-15</a>.
-  </p>
+This specification registers the algorithm names "S256", "S384", "S512", and "SM3" with the IANA JSON Web Algorithms registry as
+defined in section "Cryptographic Algorithms for Digital Signatures and MACs" in [[RFC7518]].
 
-    <p>
-      <table class="def">
-	<tbody>
-	  <tr> <td>Algorithm Name</td>
-	       <td>"S256"</td>
-	  </tr>
-	  <tr> <td>Algorithm Description</td>
-	       <td>The SHA256 hash algorithm.</td>
-	  </tr>
-	  <tr> <td>Algorithm Usage Location(s)</td>
-	       <td>"alg", i.e. used with JWS.</td>
-	  </tr>
-	  <tr> <td>JOSE Implementation Requirements</td>
-	       <td>Optional+</td>
-	  </tr>
-	  <tr> <td>Change Controller</td>
-	       <td>FIDO Alliance, <a href='https://fidoalliance.org/contact/'>Contact Us</a></td>
-	  </tr>
-	  <tr> <td>Specification Documents</td>
-	       <td> [[!FIPS-180-4]] </td>
-	  </tr>
-	  <tr> <td>Algorithm Analysis Document(s)</td>
-	       <td>[[SP800-107r1]]</td>
-	  </tr>
-	</tbody>
-      </table>
-    </p>
+These names follow the naming strategy in [draft-ietf-oauth-spop-15](https://tools.ietf.org/html/draft-ietf-oauth-spop-15).
 
-    <p>
-      <table class="def">
-	<tbody>
-	  <tr> <td>Algorithm Name</td>
-	       <td>"S384"</td>
-	  </tr>
-	  <tr> <td>Algorithm Description</td>
-	       <td>The SHA384 hash algorithm.</td>
-	  </tr>
-	  <tr> <td>Algorithm Usage Location(s)</td>
-	       <td>"alg", i.e. used with JWS.</td>
-	  </tr>
-	  <tr> <td>JOSE Implementation Requirements</td>
-	       <td>Optional</td>
-	  </tr>
-	  <tr> <td>Change Controller</td>
-	       <td>FIDO Alliance, <a href='https://fidoalliance.org/contact/'>Contact Us</a></td>
-	  </tr>
-	  <tr> <td>Specification Documents</td>
-	       <td> [[!FIPS-180-4]] </td>
-	  </tr>
-	  <tr> <td>Algorithm Analysis Document(s)</td>
-	       <td>[[SP800-107r1]]</td>
-	  </tr>
-	</tbody>
-      </table>
-    </p>
+<table class="def">
+<tbody>
+    <tr> <td>Algorithm Name</td>                   <td>"S256"</td> </tr>
+    <tr> <td>Algorithm Description</td>            <td>The SHA256 hash algorithm.</td> </tr>
+    <tr> <td>Algorithm Usage Location(s)</td>      <td>"alg", i.e. used with JWS.</td> </tr>
+    <tr> <td>JOSE Implementation Requirements</td> <td>Optional+</td> </tr>
+    <tr> <td>Change Controller</td>                <td><a href='https://fidoalliance.org/contact/'>FIDO Alliance</a></td> </tr>
+    <tr> <td>Specification Documents</td>          <td>[[!FIPS-180-4]] </td> </tr>
+    <tr> <td>Algorithm Analysis Document(s)</td>   <td>[[SP800-107r1]]</td> </tr>
+</tbody>
+</table>
 
-    <p>
-      <table class="def">
-	<tbody>
-	  <tr> <td>Algorithm Name</td>
-	       <td>"S512"</td>
-	  </tr>
-	  <tr> <td>Algorithm Description</td>
-	       <td>The SHA512 hash algorithm.</td>
-	  </tr>
-	  <tr> <td>Algorithm Usage Location(s)</td>
-	       <td>"alg", i.e. used with JWS.</td>
-	  </tr>
-	  <tr> <td>JOSE Implementation Requirements</td>
-	       <td>Optional+</td>
-	  </tr>
-	  <tr> <td>Change Controller</td>
-	       <td>FIDO Alliance, <a href='https://fidoalliance.org/contact/'>Contact Us</a></td>
-	  </tr>
-	  <tr> <td>Specification Documents</td>
-	       <td> [[!FIPS-180-4]] </td>
-	  </tr>
-	  <tr> <td>Algorithm Analysis Document(s)</td>
-	       <td>[[SP800-107r1]]</td>
-	  </tr>
-	</tbody>
-      </table>
-    </p>
+<table class="def">
+<tbody>
+    <tr> <td>Algorithm Name</td>                   <td>"S384"</td> </tr>
+    <tr> <td>Algorithm Description</td>            <td>The SHA384 hash algorithm.</td> </tr>
+    <tr> <td>Algorithm Usage Location(s)</td>      <td>"alg", i.e. used with JWS.</td> </tr>
+    <tr> <td>JOSE Implementation Requirements</td> <td>Optional</td> </tr>
+    <tr> <td>Change Controller</td>                <td><a href='https://fidoalliance.org/contact/'>FIDO Alliance</a></td> </tr>
+    <tr> <td>Specification Documents</td>          <td>[[!FIPS-180-4]] </td> </tr>
+    <tr> <td>Algorithm Analysis Document(s)</td>   <td>[[SP800-107r1]]</td> </tr>
+</tbody>
+</table>
 
-    <p>
-      <table class="def">
-	<tbody>
-	  <tr> <td>Algorithm Name</td>
-	       <td>"SM3"</td>
-	  </tr>
-	  <tr> <td>Algorithm Description</td>
-	       <td>The SM3 hash algorithm.</td>
-	  </tr>
-	  <tr> <td>Algorithm Usage Location(s)</td>
-	       <td>"alg", i.e. used with JWS.</td>
-	  </tr>
-	  <tr> <td>JOSE Implementation Requirements</td>
-	       <td>Optional</td>
-	  </tr>
-	  <tr> <td>Change Controller</td>
-	       <td>FIDO Alliance, <a href='https://fidoalliance.org/contact/'>Contact Us</a></td>
-	  </tr>
-	  <tr> <td>Specification Documents</td>
-	       <td> [[!OSCCA-SM3]] </td>
-	  </tr>
-	  <tr> <td>Algorithm Analysis Document(s)</td>
-	       <td>N/A</td>
-	  </tr>
-	</tbody>
-      </table>
-    </p>
+<table class="def">
+<tbody>
+    <tr> <td>Algorithm Name</td>                   <td>"S512"</td> </tr>
+    <tr> <td>Algorithm Description</td>            <td>The SHA512 hash algorithm.</td> </tr>
+    <tr> <td>Algorithm Usage Location(s)</td>      <td>"alg", i.e. used with JWS.</td> </tr>
+    <tr> <td>JOSE Implementation Requirements</td> <td>Optional+</td> </tr>
+    <tr> <td>Change Controller</td>                <td><a href='https://fidoalliance.org/contact/'>FIDO Alliance</a></td> </tr>
+    <tr> <td>Specification Documents</td>          <td>[[!FIPS-180-4]] </td> </tr>
+    <tr> <td>Algorithm Analysis Document(s)</td>   <td>[[SP800-107r1]]</td> </tr>
+</tbody>
+</table>
+
+<table class="def">
+<tbody>
+    <tr> <td>Algorithm Name</td>                   <td>"SM3"</td> </tr>
+    <tr> <td>Algorithm Description</td>            <td>The SM3 hash algorithm.</td> </tr>
+    <tr> <td>Algorithm Usage Location(s)</td>      <td>"alg", i.e. used with JWS.</td> </tr>
+    <tr> <td>JOSE Implementation Requirements</td> <td>Optional</td> </tr>
+    <tr> <td>Change Controller</td>                <td><a href='https://fidoalliance.org/contact/'>FIDO Alliance</a></td> </tr>
+    <tr> <td>Specification Documents</td>          <td>[[!OSCCA-SM3]] </td> </tr>
+    <tr> <td>Algorithm Analysis Document(s)</td>   <td>N/A</td> </tr>
+</tbody>
+</table>
+
 
 # Sample scenarios # {#sample-scenarios}
 
-  <em>This section is not normative.</em>
+[INFORMATIVE]
 
-  <p>In this section, we walk through some events in the lifecycle of a scoped credential, along with the corresponding sample code for using this API. Note that this is an example flow, and does not limit the scope of how the API can be used.</p>
+In this section, we walk through some events in the lifecycle of a scoped credential, along with the corresponding sample code
+for using this API. Note that this is an example flow, and does not limit the scope of how the API can be used.
 
-  <p>As was the case in earlier sections, this flow focuses on a use case involving an external first-factor <a>authenticator</a> with its own display. One example of such an authenticator would be a smart phone. Other authenticator types are also supported by this API, subject to implementation by the platform. For instance, this flow also works without modification for the case of an authenticator that is embedded in the client platform. The flow also works for the case of an external authenticator without its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the client platform needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the client platform to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.</p>
+As was the case in earlier sections, this flow focuses on a use case involving an external first-factor <a>authenticator</a>
+with its own display. One example of such an authenticator would be a smart phone. Other authenticator types are also supported
+by this API, subject to implementation by the platform. For instance, this flow also works without modification for the case of
+an authenticator that is embedded in the client platform. The flow also works for the case of an external authenticator without
+its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the client platform
+needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the client
+platform to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.
+
 
 ## Registration ## {#sample-registration}
 
-    <p>This is the first time flow, when a new credential is created and registered with the server.
-    </p>
+This is the first time flow, when a new credential is created and registered with the server.
 
-    <ol type="1">
-      <li>The user visits example.com, which serves up a script. At this point, the user must already be logged in using a legacy username and password, or additional authenticator, or other means acceptable to the Relying Party.</li>
-      <li>The Relying Party script runs the code snippet below.
-      <li>The client platform searches for and locates the external authenticator.</li>
-      <li>The client platform connects to the external authenticator, performing any pairing actions if necessary.</li>
-      <li>The external authenticator shows appropriate UI for the user to select the authenticator on which the new credential will be created, and obtains a biometric or other authorization gesture from the user.</li>
-      <li>The external authenticator returns a response to the client platform, which in turn returns a response to the Relying Party script. If the user declined to select an authenticator or provide authorization, an appropriate error is returned.</li>
-      <li>If a new credential was created,
-      <ol type="a">
-        <li>The Relying Party script sends the newly generated public key to the server, along with additional information about public key such as attestation that it is held in trusted hardware.</li>
-        <li>The server stores the public key in its database and associates it with the user as well as with the strength of authentication indicated by attestation, also storing a friendly name for later use.</li>
-        <li>The script may store data such as the credential ID in local storage, to improve future UX by narrowing the choice of credential for the user.</li>
-      </ol>
-      </li>
-    </ol>
+1. The user visits example.com, which serves up a script. At this point, the user must already be logged in using a legacy
+    username and password, or additional authenticator, or other means acceptable to the [RP].
 
-    <p>The sample code for generating and registering a new key follows:</p>
+2. The [RP] script runs the code snippet below.
 
+3. The client platform searches for and locates the external authenticator.
 
-    <pre class="example highlight">
+4. The client platform connects to the external authenticator, performing any pairing actions if necessary.
+
+5. The external authenticator shows appropriate UI for the user to select the authenticator on which the new credential will be
+    created, and obtains a biometric or other authorization gesture from the user.
+
+6. The external authenticator returns a response to the client platform, which in turn returns a response to the [RP] script. If
+    the user declined to select an authenticator or provide authorization, an appropriate error is returned.
+
+7. If a new credential was created,
+    - The [RP] script sends the newly generated public key to the server, along with additional information about public key
+        such as attestation that it is held in trusted hardware.
+    - The server stores the public key in its database and associates it with the user as well as with the strength of
+        authentication indicated by attestation, also storing a friendly name for later use.
+    - The script may store data such as the credential ID in local storage, to improve future UX by narrowing the choice of
+        credential for the user.
+
+The sample code for generating and registering a new key follows:
+
+<pre class="example highlight">
     var webauthnAPI = window.webauthn;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
     var userAccountInformation = {
-      rpDisplayName: "Acme",
-      displayName: "John P. Smith",
-      name: "johnpsmith@example.com",
-      id: "1098237235409872",
-      imageURL: "https://pics.acme.com/00/p/aBjjjpqPb.png"
+        rpDisplayName: "Acme",
+        displayName: "John P. Smith",
+        name: "johnpsmith@example.com",
+        id: "1098237235409872",
+        imageURL: "https://pics.acme.com/00/p/aBjjjpqPb.png"
     };
 
     // This Relying Party will accept either an ES256 or RS256 credential, but
     // prefers an ES256 credential.
     var cryptoParams = [
-      {
-        type: "ScopedCred",
-        algorithm: "ES256"
-      },
-      {
-        type: "ScopedCred",
-        algorithm: "RS256"
-      }
+        {
+            type: "ScopedCred",
+            algorithm: "ES256"
+        },
+        {
+            type: "ScopedCred",
+            algorithm: "RS256"
+        }
     ];
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
@@ -2193,40 +1817,54 @@ typedef DOMString AAGUID;
 
     // Note: The following call will cause the authenticator to display UI.
     webauthnAPI.makeCredential(userAccountInformation, cryptoParams, challenge,
-                           timeoutSeconds, blacklist, extensions)
-      .then(function (newCredentialInfo) {
+                               timeoutSeconds, blacklist, extensions)
+        .then(function (newCredentialInfo) {
         // Send new credential info to server for verification and registration.
     }).catch(function (err) {
         // No acceptable authenticator or user refused consent. Handle appropriately.
     });
-    </pre>
+</pre>
+
 
 ## Authentication ## {#sample-authentication}
 
-    <p>This is the flow when a user with an already registered credential visits a website and wants to authenticate using the credential.</p>
+This is the flow when a user with an already registered credential visits a website and wants to authenticate using the
+credential.
 
-    <ol type ="1">
-      <li>The user visits example.com, which serves up a script.</li>
-      <li>The script asks the client platform for a WebAuthn identity assertion, providing as much information as possible to narrow the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after registration, or by other means such as prompting the user for a username.</li>
-      <li>The <a>WebAuthn Relying Party</a> script runs one of the code snippets below.</li>
-      <li>The client platform searches for and locates the external authenticator.</li>
-      <li>The client platform connects to the external authenticator, performing any pairing actions if necessary.</li>
-      <li>The <a>external authenticator</a> presents the user with a notification that their attention is required. On opening the notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided when creating the credentials, along with some information on the origin that is requesting these keys.</li>
-      <li>The authenticator obtains a biometric or other authorization gesture from the user.</li>
-      <li>The external authenticator returns a response to the client platform, which in turn returns a response to the Relying Party script. If the user declined to select a credential or provide an authorization, an appropriate error is returned.</li>
-      <li>If an assertion was successfully generated and returned,
-      <ol type="a">
-        <li>The script sends the assertion to the server.</li>
-        <li>The server examines the assertion and validates that it was correctly generated. If so, it looks up the identity associated with the associated public key; that identity is now authenticated. If the public key is not recognized by the server (e.g., deregistered by server due to inactivity) then the authentication has failed; each Relying Party will handle this in its own way.</li>
-        <li>The server now does whatever it would otherwise do upon successful authentication &mdash; return a success page, set authentication cookies, etc.</li>
-      </ol>
-      </li>
-    </ol>
+1. The user visits example.com, which serves up a script.
 
+2. The script asks the client platform for a WebAuthn identity assertion, providing as much information as possible to narrow
+    the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after
+    registration, or by other means such as prompting the user for a username.
 
-    <p>If the Relying Party script does not have any hints available (e.g., from locally stored data) to help it narrow the list of credentials, then the sample code for performing such an authentication might look like this:</p>
+3. The <a>[RP]</a> script runs one of the code snippets below.
 
-    <pre class="example highlight">
+4. The client platform searches for and locates the external authenticator.
+
+5. The client platform connects to the external authenticator, performing any pairing actions if necessary.
+
+6. The <a>external authenticator</a> presents the user with a notification that their attention is required. On opening the
+    notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided
+    when creating the credentials, along with some information on the origin that is requesting these keys.
+
+7. The authenticator obtains a biometric or other authorization gesture from the user.
+
+8. The external authenticator returns a response to the client platform, which in turn returns a response to the [RP] script.
+    If the user declined to select a credential or provide an authorization, an appropriate error is returned.
+
+9. If an assertion was successfully generated and returned,
+    - The script sends the assertion to the server.
+    - The server examines the assertion and validates that it was correctly generated. If so, it looks up the identity
+        associated with the associated public key; that identity is now authenticated. If the public key is not recognized by
+        the server (e.g., deregistered by server due to inactivity) then the authentication has failed; each [RP] will handle
+        this in its own way.
+    - The server now does whatever it would otherwise do upon successful authentication -- return a success page, set
+        authentication cookies, etc.
+
+If the [RP] script does not have any hints available (e.g., from locally stored data) to help it narrow the list of credentials,
+then the sample code for performing such an authentication might look like this:
+
+<pre class="example highlight">
     var webauthnAPI = window.webauthn;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
@@ -2236,16 +1874,18 @@ typedef DOMString AAGUID;
     var whitelist = [{ type: "ScopedCred" }];
 
     webauthnAPI.getAssertion(challenge, timeoutSeconds, whitelist)
-      .then(function (assertion) {
+        .then(function (assertion) {
         // Send assertion to server for verification
     }).catch(function (err) {
         // No acceptable credential or user refused consent. Handle appropriately.
     });
-    </pre>
+</pre>
 
-    <p>On the other hand, if the Relying Party script has some hints to help it narrow the list of credentials, then the sample code for performing such an authentication might look like the following. Note that this sample also demonstrates how to use the extension for transaction authorization.</p>
+On the other hand, if the [RP] script has some hints to help it narrow the list of credentials, then the sample code for
+performing such an authentication might look like the following. Note that this sample also demonstrates how to use the
+extension for transaction authorization.
 
-    <pre class="example highlight">
+<pre class="example highlight">
     var webauthnAPI = window.webauthn;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
@@ -2253,81 +1893,74 @@ typedef DOMString AAGUID;
     var challenge = "Y2xpbWIgYSBtb3VudGFpbg";
     var timeoutSeconds = 300;  // 5 minutes
     var acceptableCredential1 = {
-      type: "ScopedCred",
-      id: "ISEhISEhIWhpIHRoZXJlISEhISEhIQo="
+        type: "ScopedCred",
+        id: "ISEhISEhIWhpIHRoZXJlISEhISEhIQo="
     };
     var acceptableCredential2 = {
-      type: "ScopedCred",
-      id: "cm9zZXMgYXJlIHJlZCwgdmlvbGV0cyBhcmUgYmx1ZQo="
+        type: "ScopedCred",
+        id: "cm9zZXMgYXJlIHJlZCwgdmlvbGV0cyBhcmUgYmx1ZQo="
     };
     var whitelist = [acceptableCredential1, acceptableCredential2];
     var extensions = { 'webauthn.txauth.simple':
                        "Wave your hands in the air like you just don't care" };
 
     webauthnAPI.getAssertion(challenge, timeoutSeconds, whitelist, extensions)
-      .then(function (assertion) {
+        .then(function (assertion) {
         // Send assertion to server for verification
     }).catch(function (err) {
         // No acceptable credential or user refused consent. Handle appropriately.
     });
-    </pre>
+</pre>
 
 
 ## Decommissioning ## {#sample-decommissioning}
 
-    <p>The following are possible situations in which decommissioning a credential might be desired. Note that all of these are handled on the server side and do not need support from the API specified here.</p>
+The following are possible situations in which decommissioning a credential might be desired. Note that all of these are
+handled on the server side and do not need support from the API specified here.
 
-    <ul>
-      <li>
-        Possibility #1 &mdash; user reports the credential as lost.
-        <ul>
-          <li>User goes to server.example.net, authenticates and follows a link to report a lost/stolen device.</li>
-          <li>Server returns a page showing the list of registered credentials with friendly names as configured during registration.</li>
-          <li>User selects a credential and the server deletes it from its database.</li>
-          <li>In future, the <a>WebAuthn Relying Party</a>a> script does not specify this credential in any list of acceptable credentials, and assertions signed by this credential are rejected.</li>
-        </ul>
-      </li>
+- Possibility #1 -- user reports the credential as lost.
+    * User goes to server.example.net, authenticates and follows a link to report a lost/stolen device.
+    * Server returns a page showing the list of registered credentials with friendly names as configured during registration.
+    * User selects a credential and the server deletes it from its database.
+    * In future, the <a>[RP]</a> script does not specify this credential in any list of acceptable credentials, and assertions
+        signed by this credential are rejected.
 
-      <li>
-        Possibility #2 &mdash; server deregisters the credential due to inactivity.
-        <ul>
-          <li>Server deletes credential from its database during maintenance activity.</li>
-          <li>In the future, the Relying Party script does not specify this credential in any list of acceptable credentials, and assertions signed by this credential are rejected.</li>
-        </ul>
-      </li>
+- Possibility #2 -- server deregisters the credential due to inactivity.
+    * Server deletes credential from its database during maintenance activity.
+    * In the future, the [RP] script does not specify this credential in any list of acceptable credentials, and assertions
+        signed by this credential are rejected.
 
-      <li>
-        Possibility #3 &mdash; user deletes the credential from the device.
-        <ul>
-          <li>User employs a device-specific method (e.g., device settings UI) to delete a credential from their device.</li>
-          <li>From this point on, this credential will not appear in any selection prompts, and no assertions can be generated with it.</li>
-          <li>Sometime later, the server deregisters this credential due to inactivity.</li>
-        </ul>
-      </li>
-    </ul>
+- Possibility #3 -- user deletes the credential from the device.
+    * User employs a device-specific method (e.g., device settings UI) to delete a credential from their device.
+    * From this point on, this credential will not appear in any selection prompts, and no assertions can be generated with it.
+    * Sometime later, the server deregisters this credential due to inactivity.
+
 
 # Terminology # {#terminology}
 
-  : <dfn>Attestation Certificate</dfn>
-  :: A X.509 Certificate for a keypair used by an <a>Authenticator</a> to attest to its manufacture and capabilities.
+: <dfn>Attestation Certificate</dfn>
+:: A X.509 Certificate for a keypair used by an <a>Authenticator</a> to attest to its manufacture and capabilities.
 
-  : <dfn>Authenticator</dfn>
-  :: The device used by the user agent to authenticate with the Relying Party. These can be <a>Embedded Authenticators</a> or <a>External Authenticators</a>.
+: <dfn>Authenticator</dfn>
+:: The device used by the user agent to authenticate with the [RP]. These can be <a>Embedded Authenticators</a> or
+    <a>External Authenticators</a>.
 
-  : <dfn>Client</dfn>
-  : <dfn>WebAuthn Client</dfn>
-  :: See <a>Conforming User Agent</a>.
+: <dfn>Client</dfn>
+: <dfn>WebAuthn Client</dfn>
+:: See <a>Conforming User Agent</a>.
 
-  : <dfn>Conforming User Agent</dfn>
-  :: A user agent which implements algorithms given in this specification, and handles communication between the <a>Authenticator</a> and the <a>WebAuthn Relying Party</a>.
+: <dfn>Conforming User Agent</dfn>
+:: A user agent which implements algorithms given in this specification, and handles communication between the
+    <a>Authenticator</a> and the <a>[RP]</a>.
 
-  : <dfn>eTLD+1</dfn>
-  :: The effective top-level domain, plus the first label. Also known as a Registered Domain. See <a href="https://publicsuffix.org/">https://publicsuffix.org/</a>.
+: <dfn>eTLD+1</dfn>
+:: The effective top-level domain, plus the first label. Also known as a Registered Domain. See
+    [publicsuffix.org](https://publicsuffix.org/).
 
-  : <dfn>Relying Party</dfn>
-  : <dfn>WebAuthn Relying Party</dfn>
-  :: The entity which needs to rely in the authentication provided by the WebAuthn specification. When the registration concludes, the Relying Party has the public key that was created by the Authenticator.
+: <dfn>[RP]</dfn>
+:: The entity which needs to rely in the authentication provided by the WebAuthn specification. When registration concludes,
+    the [RP] has the public key that was created by the Authenticator.
+
 
 # Acknowledgements # {#acknowledgements}
-  <p>We would like to thank the following for their contributions to, and thorough review of, this specification: Jing Jin, Michael B. Jones, Rolf Lindemann.
-  </p>
+We would like to thank the following for their contributions to, and thorough review of, this specification: Jing Jin.

--- a/index.src.html
+++ b/index.src.html
@@ -1080,8 +1080,9 @@ TPM <a>attestation certificate</a> MUST have the following fields/extensions:
 
 #### Android Attestation #### {#android-attestation}
 
- When the <a>Authenticator</a> in question is a platform-provided Authenticator on the Android platform, the attestation
-statement is based on the [SafetyNet API](https://developer.android.com/training/safetynet/index.html#compat-check-response).
+When the <a>Authenticator</a> in question is a platform-provided Authenticator on the Android platform, the attestation
+statement is based on the <a href="https://developer.android.com/training/safetynet/index.html#compat-check-response">SafetyNet
+API</a>.
 
 Android attestation statement MUST always be used in conjunction with the more specific `AndroidAttestationClientData` (see
 [[#sec-android-attestationclientdata]]) in order to let the [RP] App store the public key in the attestation object.
@@ -1090,7 +1091,7 @@ Android attestation statement MUST always be used in conjunction with the more s
 ##### Attestation rawData (type="android") ##### {#sec-attestation-android}
 
 Android SafetyNet returns a JWS [[RFC7515]] object (see
-[SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response))
+<a href="https://developer.android.com/training/safetynet/index.html#compat-check-response">SafetyNet online documentation</a>)
 in Compact Serialization. A JWS in Compact Serialization consists of three segments (each a base64url-encoded string) separated
 by a dot ("."). The `rawData` object is the concatenation of:
 
@@ -1224,8 +1225,8 @@ Upon receiving an attestation statement, the [RP] shall:
     - Verify that the attestation certificate has the right Extended Key Usage (EKU) based on the WebAuthn Authenticator type
         (as denoted by the `header.type` member). In case of a type="tpm", this EKU shall be OID "2.23.133.8.3".
     - If the attestation type is "android", verify that the attestation certificate is issued to the hostname
-        "attest.android.com" (see
-        [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response)).
+        "attest.android.com" (see <a href="https://developer.android.com/training/safetynet/index.html#compat-check-response">
+        SafetyNet online documentation</a>).
     - Verify that all issuing CA certificates in the chain are valid and not revoked.
     - Verify the `signature` on `core.rawData` using the attestation certificate public key and algorithm as identified by
         `header.alg`.
@@ -1688,7 +1689,8 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
 This specification registers the algorithm names "S256", "S384", "S512", and "SM3" with the IANA JSON Web Algorithms registry as
 defined in section "Cryptographic Algorithms for Digital Signatures and MACs" in [[RFC7518]].
 
-These names follow the naming strategy in [draft-ietf-oauth-spop-15](https://tools.ietf.org/html/draft-ietf-oauth-spop-15).
+These names follow the naming strategy in <a href="https://tools.ietf.org/html/draft-ietf-oauth-spop-15">
+draft-ietf-oauth-spop-15</a>.
 
 <table class="def">
 <tbody>
@@ -1954,8 +1956,7 @@ handled on the server side and do not need support from the API specified here.
     <a>Authenticator</a> and the <a>[RP]</a>.
 
 : <dfn>eTLD+1</dfn>
-:: The effective top-level domain, plus the first label. Also known as a Registered Domain. See
-    [publicsuffix.org](https://publicsuffix.org/).
+:: The effective top-level domain, plus the first label. Also known as a Registered Domain. See [[PSL]].
 
 : <dfn>[RP]</dfn>
 :: The entity which needs to rely in the authentication provided by the WebAuthn specification. When registration concludes,


### PR DESCRIPTION
No changes to substance here. Goal of this change is to make the spec
easier to work on, not to fix the content.

- Wrap all lines at 128 chars (wide enough for modern screens, small
enough to fit in most commonly-sized windows)
- Remove extraneous HTML tags
- Convert HTML tags to Markdown equivalents
- Define macros for a couple of commonly used phrases so it's easier to
type and to keep consistency throughout the spec