### PR TITLE
API aesthetic updates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -126,7 +126,7 @@ or a combination of both.
 This specification relies on several other underlying specifications.
 
 : HTML5
-:: The concept of <dfn>origin</dfn> and the <dfn>Window</dfn> interface are defined in [[!HTML5]].
+:: The concept of <dfn>origin</dfn> and the <dfn>Navigator/dfn> interface are defined in [[!HTML5]].
 
 : Web IDL
 :: Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL-1]]. This updated version of
@@ -272,7 +272,7 @@ operation. Since this is an integral part of the WebAuthn security model, user a
 The API is defined by the following Web IDL fragment.
 
 <pre class="idl">
-    partial interface Window {
+    partial interface Navigator {
         readonly attribute WebAuthentication webauthn;
     };
 
@@ -1849,7 +1849,7 @@ This is the first time flow, when a new credential is created and registered wit
 The sample code for generating and registering a new key follows:
 
 <pre class="example highlight">
-    var webauthnAPI = window.webauthn;
+    var webauthnAPI = navigator.webauthn;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
@@ -1929,7 +1929,7 @@ If the [RP] script does not have any hints available (e.g., from locally stored 
 then the sample code for performing such an authentication might look like this:
 
 <pre class="example highlight">
-    var webauthnAPI = window.webauthn;
+    var webauthnAPI = navigator.webauthn;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
@@ -1950,7 +1950,7 @@ performing such an authentication might look like the following. Note that this 
 extension for transaction authorization.
 
 <pre class="example highlight">
-    var webauthnAPI = window.webauthn;
+    var webauthnAPI = navigator.webauthn;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 

--- a/index.bs
+++ b/index.bs
@@ -1451,14 +1451,12 @@ authenticator. Since all extensions are optional, this will not cause a function
 ## Extension identifiers ## {#extension-id}
 
 Extensions are identified by a string, chosen by the extension author. Extension identifiers should aim to be globally unique,
-e.g., by using reverse domain-name of the defining entity such as `com.example.webauthn.myextension`.
-
-Note: Use of dot-separated notation here does not imply an object hierarchy.
+e.g., by including the defining entity such as `myCompanyExtension`.
 
 Extensions that may exist in multiple versions should take care to include a version in their identifier. In effect, different
-versions are thus treated as different extensions, e.g., `mycompany-myextension_v01`
+versions are thus treated as different extensions, e.g., `myCompanyExtension01`
 
-Extensions defined in this specification use a fixed prefix of `webauthn.` for the extension identifiers. This prefix should not
+Extensions defined in this specification use a fixed prefix of `webauthn` for the extension identifiers. This prefix should not
 be used for extensions not defined by the W3C.
 
 
@@ -1487,7 +1485,7 @@ A [RP] simultaneously requests the use of an extension and sets its client argum
 
 <pre class="example highlight">
     var assertionPromise = credentials.getAssertion(..., /* extensions */ {
-        "webauthn-example.foobar": 42
+        "webauthnExampleFoobar": 42
     });
 </pre>
 
@@ -1537,7 +1535,7 @@ authenticator data value of each extension as the value.
 To illustrate the requirements above, consider a hypothetical extension "Geo". This extension, if supported, lets both clients
 and authenticators embed their geolocation in assertions.
 
-The extension identifier is chosen as `webauthn-example.geo`. The client argument is the constant value `true`, since the
+The extension identifier is chosen as `webauthnExampleGeo`. The client argument is the constant value `true`, since the
 extension does not require the <a>[RP]</a> to pass any particular information to the client, other than that it requests the use
 of the extension. The [RP] sets this value in its request for an assertion:
 
@@ -1545,7 +1543,7 @@ of the extension. The [RP] sets this value in its request for an assertion:
     var assertionPromise =
         credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
             {}, /* Empty filter */
-            { 'webauthn-example.geo': true });
+            { 'webauthnExampleGeo': true });
 </pre>
 
 The extension defines the additional client data to be the client's location, if known, as a GeoJSON [[GeoJSON]] point. The
@@ -1555,7 +1553,7 @@ client constructs the following client data:
     {
         ...,
         'extensions': {
-            'webauthn-example.geo': {
+            'webauthnExampleGeo': {
                 'type': 'Point',
                 'coordinates': [65.059962, -13.993041]
             }
@@ -1574,10 +1572,9 @@ authenticator does this by including it in the `authenticatorData`. As an exampl
     81 (hex)                                    -- Flags, ED and TUP both set.
     20 05 58 1F                                 -- Signature counter
     A1                                          -- CBOR map of one element
-        74                                      -- Key 1: CBOR text string of 20 bytes
-            77 65 62 61 75 74 68 6e 2d 65 78
-            61 6d 70 6c 65 2e 67 65 6f          -- "webauthn-example.geo" UTF-8 string
-
+        72                                      -- Key 1: CBOR text string of 18 bytes
+            77 65 62 61 75 74 68 6e 45 78 61
+            6d 70 6c 65 47 65 6f                -- "webauthnExampleGeo" UTF-8 string
         82                                      -- Value 1: CBOR array of two elements
             FA 42 82 1E B3                      -- Element 1: Latitude as CBOR encoded float
             FA C1 5F E3 7F                      -- Element 2: Longitude as CBOR encoded float
@@ -1596,7 +1593,7 @@ This authentication extension allows for a simple form of transaction authorizat
 intended for display on a trusted device on the authenticator.
 
 : Extension identifier
-:: `webauthn.txauth.simple`
+:: `webauthnTxAuthSimple`
 
 : Client argument
 :: A single UTF-8 encoded string prompt.
@@ -1618,7 +1615,7 @@ The generic version of this extension allows images to be used as prompts as wel
 rendering engine to be used and also supports a richer visual appearance.
 
 : Extension identifier
-:: `webauthn.txauth.generic`
+:: `webauthnTxAuthGeneric`
 
 : Client argument
 :: A CBOR map with one pair of data items (CBOR tagged as 0xa1). The pair of data items consists of
@@ -1647,7 +1644,7 @@ This registration extension allows a [RP] to guide the selection of the authenti
 credential. It is intended primarily for [RPS] that wish to tightly control the experience around credential creation.
 
 : Extension identifier
-:: `webauthn.authn-sel`
+:: `webauthnAuthnSel`
 
 : Client argument
 :: A sequence of AAGUIDs:
@@ -1682,7 +1679,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
 ## SupportedExtensions Extension ## {#supported-extensions-extension}
 
 : Extension identifier
-:: `webauthn.exts`
+:: `webauthnExts`
 
 : Client argument
 :: The Boolean value `true` to indicate that this extension is requested by the [RP].
@@ -1704,7 +1701,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
 ## User Verification Index (UVI) Extension ## {#uvi-extension}
 
 : Extension identifier
-:: `webauthn.uvi`
+:: `webauthnUvi`
 
 : Client argument
 :: The Boolean value `true` to indicate that this extension is requested by the [RP].
@@ -1741,8 +1738,8 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
         00 00 00 01                                 -- (initial) signature counter
         ...                                         -- all public key alg etc.
         A1                                          -- extension: CBOR map of one element
-            6C                                      -- Key 1: CBOR text string of 12 bytes
-                77 65 62 61 75 74 68 6E 2E 75 76 69 -- "webauthn.uvi" UTF-8 string
+            6B                                      -- Key 1: CBOR text string of 11 bytes
+                77 65 62 61 75 74 68 6E 55 76 69    -- "webauthnUvi" UTF-8 string
             58 20                                   -- Value 1: CBOR byte string with 0x20 bytes
                 00 43 B8 E3 BE 27 95 8C             -- the UVI value itself
                 28 D5 74 BF 46 8A 85 CF

--- a/index.bs
+++ b/index.bs
@@ -273,7 +273,7 @@ The API is defined by the following Web IDL fragment.
 
 <pre class="idl">
     partial interface Navigator {
-        readonly attribute WebAuthentication webauthn;
+        readonly attribute WebAuthentication authentication;
     };
 
     interface WebAuthentication {
@@ -1849,7 +1849,7 @@ This is the first time flow, when a new credential is created and registered wit
 The sample code for generating and registering a new key follows:
 
 <pre class="example highlight">
-    var webauthnAPI = navigator.webauthn;
+    var webauthnAPI = navigator.authentication;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
@@ -1929,7 +1929,7 @@ If the [RP] script does not have any hints available (e.g., from locally stored 
 then the sample code for performing such an authentication might look like this:
 
 <pre class="example highlight">
-    var webauthnAPI = navigator.webauthn;
+    var webauthnAPI = navigator.authentication;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 
@@ -1950,7 +1950,7 @@ performing such an authentication might look like the following. Note that this 
 extension for transaction authorization.
 
 <pre class="example highlight">
-    var webauthnAPI = navigator.webauthn;
+    var webauthnAPI = navigator.authentication;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
 

--- a/index.bs
+++ b/index.bs
@@ -1453,10 +1453,12 @@ authenticator. Since all extensions are optional, this will not cause a function
 Extensions are identified by a string, chosen by the extension author. Extension identifiers should aim to be globally unique,
 e.g., by using reverse domain-name of the defining entity such as `com.example.webauthn.myextension`.
 
-Extensions that may exist in multiple versions should take care to include a version in their identifier. In effect, different
-versions are thus treated as different extensions.
+Note: Use of dot-separated notation here does not imply an object hierarchy.
 
-Extensions defined in this specification use a fixed prefix of `webauthn` for the extension identifiers. This prefix should not
+Extensions that may exist in multiple versions should take care to include a version in their identifier. In effect, different
+versions are thus treated as different extensions, e.g., `mycompany-myextension_v01`
+
+Extensions defined in this specification use a fixed prefix of `webauthn.` for the extension identifiers. This prefix should not
 be used for extensions not defined by the W3C.
 
 
@@ -1485,7 +1487,7 @@ A [RP] simultaneously requests the use of an extension and sets its client argum
 
 <pre class="example highlight">
     var assertionPromise = credentials.getAssertion(..., /* extensions */ {
-        "com.example.webauthn.foobar": 42
+        "webauthn-example.foobar": 42
     });
 </pre>
 
@@ -1535,7 +1537,7 @@ authenticator data value of each extension as the value.
 To illustrate the requirements above, consider a hypothetical extension "Geo". This extension, if supported, lets both clients
 and authenticators embed their geolocation in assertions.
 
-The extension identifier is chosen as `com.example.webauthn.geo`. The client argument is the constant value `true`, since the
+The extension identifier is chosen as `webauthn-example.geo`. The client argument is the constant value `true`, since the
 extension does not require the <a>[RP]</a> to pass any particular information to the client, other than that it requests the use
 of the extension. The [RP] sets this value in its request for an assertion:
 
@@ -1543,7 +1545,7 @@ of the extension. The [RP] sets this value in its request for an assertion:
     var assertionPromise =
         credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
             {}, /* Empty filter */
-            { 'com.example.webauthn.geo': true });
+            { 'webauthn-example.geo': true });
 </pre>
 
 The extension defines the additional client data to be the client's location, if known, as a GeoJSON [[GeoJSON]] point. The
@@ -1553,7 +1555,7 @@ client constructs the following client data:
     {
         ...,
         'extensions': {
-            'com.example.webauthn.geo': {
+            'webauthn-example.geo': {
                 'type': 'Point',
                 'coordinates': [65.059962, -13.993041]
             }
@@ -1572,8 +1574,10 @@ authenticator does this by including it in the `authenticatorData`. As an exampl
     81 (hex)                                    -- Flags, ED and TUP both set.
     20 05 58 1F                                 -- Signature counter
     A1                                          -- CBOR map of one element
-        6C                                      -- Key 1: CBOR text string of 12 bytes
-            77 65 62 61 75 74 68 6E 2E 67 65 6F -- "webauthn.geo" UTF-8 string
+        74                                      -- Key 1: CBOR text string of 20 bytes
+            77 65 62 61 75 74 68 6e 2d 65 78
+            61 6d 70 6c 65 2e 67 65 6f          -- "webauthn-example.geo" UTF-8 string
+
         82                                      -- Value 1: CBOR array of two elements
             FA 42 82 1E B3                      -- Element 1: Latitude as CBOR encoded float
             FA C1 5F E3 7F                      -- Element 2: Longitude as CBOR encoded float

--- a/index.bs
+++ b/index.bs
@@ -139,6 +139,8 @@ This specification relies on several other underlying specifications.
 : Web Cryptography API
 :: The <dfn dictionary>AlgorithmIdentifier</dfn> type and the method for normalizing an algorithm are defined in
     [[WebCryptoAPI#algorithm-dictionary]].
+:: The <dfn dictionary>CryptoKey</dfn> type for representing cryptographic keys is defined in
+    [[WebCryptoAPI#cryptokey-interface]].
 :: The <dfn dictionary>JsonWebKey</dfn> dictionary for representing cryptographic keys is defined in
     [[WebCryptoAPI#JsonWebKey-dictionary]].
 
@@ -296,7 +298,7 @@ The API is defined by the following Web IDL fragment.
 
     interface ScopedCredentialInfo {
         readonly attribute Credential           credential;
-        readonly attribute any                  publicKey;
+        readonly attribute CryptoKey            publicKey;
         readonly attribute WebAuthnAttestation  attestation;
     };
 
@@ -505,8 +507,8 @@ authorizing an authenticator with which to complete the operation.
 
     The <dfn>credential</dfn> attribute contains a unique identifier for the credential represented by this object.
 
-    The <dfn>publicKey</dfn> attribute contains the public key associated with the credential, represented as a JsonWebKey
-    structure as defined in [[WebCryptoAPI#JsonWebKey-dictionary]].
+    The <dfn>publicKey</dfn> attribute contains the public key associated with the credential, represented as a
+    CryptoKey object as defined in [[WebCryptoAPI#cryptokey-interface]].
 
     The <dfn>attestation</dfn> attribute contains a key attestation statement returned by the authenticator. This provides
     information about the credential and the authenticator it is held in, such as the level of security assurance provided by

--- a/index.bs
+++ b/index.bs
@@ -1451,10 +1451,10 @@ authenticator. Since all extensions are optional, this will not cause a function
 ## Extension identifiers ## {#extension-id}
 
 Extensions are identified by a string, chosen by the extension author. Extension identifiers should aim to be globally unique,
-e.g., by including the defining entity such as `myCompanyExtension`.
+e.g., by including the defining entity such as `myCompany_extension`.
 
 Extensions that may exist in multiple versions should take care to include a version in their identifier. In effect, different
-versions are thus treated as different extensions, e.g., `myCompanyExtension01`
+versions are thus treated as different extensions, e.g., `myCompany_extension_01`
 
 Extensions defined in this specification use a fixed prefix of `webauthn` for the extension identifiers. This prefix should not
 be used for extensions not defined by the W3C.
@@ -1485,7 +1485,7 @@ A [RP] simultaneously requests the use of an extension and sets its client argum
 
 <pre class="example highlight">
     var assertionPromise = credentials.getAssertion(..., /* extensions */ {
-        "webauthnExampleFoobar": 42
+        "webauthnExample_foobar": 42
     });
 </pre>
 
@@ -1535,7 +1535,7 @@ authenticator data value of each extension as the value.
 To illustrate the requirements above, consider a hypothetical extension "Geo". This extension, if supported, lets both clients
 and authenticators embed their geolocation in assertions.
 
-The extension identifier is chosen as `webauthnExampleGeo`. The client argument is the constant value `true`, since the
+The extension identifier is chosen as `webauthnExample_geo`. The client argument is the constant value `true`, since the
 extension does not require the <a>[RP]</a> to pass any particular information to the client, other than that it requests the use
 of the extension. The [RP] sets this value in its request for an assertion:
 
@@ -1543,7 +1543,7 @@ of the extension. The [RP] sets this value in its request for an assertion:
     var assertionPromise =
         credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
             {}, /* Empty filter */
-            { 'webauthnExampleGeo': true });
+            { 'webauthnExample_geo': true });
 </pre>
 
 The extension defines the additional client data to be the client's location, if known, as a GeoJSON [[GeoJSON]] point. The
@@ -1553,7 +1553,7 @@ client constructs the following client data:
     {
         ...,
         'extensions': {
-            'webauthnExampleGeo': {
+            'webauthnExample_geo': {
                 'type': 'Point',
                 'coordinates': [65.059962, -13.993041]
             }
@@ -1572,9 +1572,9 @@ authenticator does this by including it in the `authenticatorData`. As an exampl
     81 (hex)                                    -- Flags, ED and TUP both set.
     20 05 58 1F                                 -- Signature counter
     A1                                          -- CBOR map of one element
-        72                                      -- Key 1: CBOR text string of 18 bytes
-            77 65 62 61 75 74 68 6e 45 78 61
-            6d 70 6c 65 47 65 6f                -- "webauthnExampleGeo" UTF-8 string
+        73                                      -- Key 1: CBOR text string of 19 bytes
+            77 65 62 61 75 74 68 6E 45 78 61
+            6D 70 6C 65 5F 67 65 6F             -- "webauthnExample_geo" UTF-8 string
         82                                      -- Value 1: CBOR array of two elements
             FA 42 82 1E B3                      -- Element 1: Latitude as CBOR encoded float
             FA C1 5F E3 7F                      -- Element 2: Longitude as CBOR encoded float
@@ -1593,7 +1593,7 @@ This authentication extension allows for a simple form of transaction authorizat
 intended for display on a trusted device on the authenticator.
 
 : Extension identifier
-:: `webauthnTxAuthSimple`
+:: `webauthn_txAuthSimple`
 
 : Client argument
 :: A single UTF-8 encoded string prompt.
@@ -1615,7 +1615,7 @@ The generic version of this extension allows images to be used as prompts as wel
 rendering engine to be used and also supports a richer visual appearance.
 
 : Extension identifier
-:: `webauthnTxAuthGeneric`
+:: `webauthn_txAuthGeneric`
 
 : Client argument
 :: A CBOR map with one pair of data items (CBOR tagged as 0xa1). The pair of data items consists of
@@ -1644,7 +1644,7 @@ This registration extension allows a [RP] to guide the selection of the authenti
 credential. It is intended primarily for [RPS] that wish to tightly control the experience around credential creation.
 
 : Extension identifier
-:: `webauthnAuthnSel`
+:: `webauthn_authnSel`
 
 : Client argument
 :: A sequence of AAGUIDs:
@@ -1679,7 +1679,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
 ## SupportedExtensions Extension ## {#supported-extensions-extension}
 
 : Extension identifier
-:: `webauthnExts`
+:: `webauthn_exts`
 
 : Client argument
 :: The Boolean value `true` to indicate that this extension is requested by the [RP].
@@ -1701,7 +1701,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
 ## User Verification Index (UVI) Extension ## {#uvi-extension}
 
 : Extension identifier
-:: `webauthnUvi`
+:: `webauthn_uvi`
 
 : Client argument
 :: The Boolean value `true` to indicate that this extension is requested by the [RP].
@@ -1738,8 +1738,8 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
         00 00 00 01                                 -- (initial) signature counter
         ...                                         -- all public key alg etc.
         A1                                          -- extension: CBOR map of one element
-            6B                                      -- Key 1: CBOR text string of 11 bytes
-                77 65 62 61 75 74 68 6E 55 76 69    -- "webauthnUvi" UTF-8 string
+            6C                                      -- Key 1: CBOR text string of 11 bytes
+                77 65 62 61 75 74 68 6E 5F 75 76 69 -- "webauthn_uvi" UTF-8 string
             58 20                                   -- Value 1: CBOR byte string with 0x20 bytes
                 00 43 B8 E3 BE 27 95 8C             -- the UVI value itself
                 28 D5 74 BF 46 8A 85 CF


### PR DESCRIPTION
These changes are also aesthetic, similar to PR #135, but in this case they are all related to API aesthetics. They are still, for the most part, editorial in nature. It'd be good to get some care in the review of the `makeCredential()` updates per the removal of `ScopedCredentialParameters`, though.

First, per Vijay's comment [on issue 60](https://github.com/w3c/webauthn/issues/60#issuecomment-230693738), moving the interface from the global window namespace to the navigator namespace to reduce pollution of the global namespace. This also makes semantic sense, as the HTML5 `window` object represents an open window in the browser, whereas the `navigator` object represents the browser itself. Since authenticators belong to the whole system, not one window, the object model makes more sense to be a property attached to `navigator`.

Second, I've renamed the factory object from `navigator.webauthn` to `navigator.authentication`. In general, web APIs shouldn't use the word "web" in their name. It's implicit. (I considered "authn" but I feel the verbosity here is justified -- most of the users will assign the object to a local variable for ease of use anyway, like our example code does.)

Third, I changed the type of `ScopedCredentialInfo.publicKey` from `any` to `CryptoKey`, referencing the WebCryptoAPI for the type information. This feels like a fairly substantial change, but it really isn't: javascript gets flexibility to ask for the pubkey in a variety of formats (including JsonWebKey), and we get a tighter (and more expected) type.

Fourth, I've removed the `ScopedCredentialParameters` tuple by unpairing the `type` and `algorithm` fields. `ScopedCredentialParameters` is used in the procedure for normalizing algorithms and types, but said procedure doesn't actually use the types! This changes the makeCredential() method to instead have a list of supported types and a list of supported algorithms, and perform its procedure that way.

Keeping these together in an object gives a kind of flexibility, but after consideration, I don't see much actual purpose in said flexibility. A RP can either handle an algorithm or not, and is either willing to handle an authenticator type or not -- particular combinations seem an unnecessary burden.

Fifth, in response to [Vijay's note about extension names](https://lists.w3.org/Archives/Public /public- webauthn/2016Jul/0046.html), I've renamed the example extensions (correcting a CBOR mismatch in the process). I also noted in section 7.1, Extension identifiers, that  "Use of dot-separated notation here does not imply an object hierarchy.", and provided a counterexample of a differently- separated, versioned id: `mycompany-myextension_v01`. None of the pre-defined extensions were modified.

