### PR TITLE
Remove ScopedCredentialParameters tuple (by unpairing type & algorithm)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -279,7 +279,8 @@ The API is defined by the following Web IDL fragment.
     interface WebAuthentication {
         Promise < ScopedCredentialInfo > makeCredential (
             Account                                 accountInformation,
-            sequence < ScopedCredentialParameters > cryptoParameters,
+            sequence < CredentialType >             supportedTypes,
+            sequence < AlgorithmIdentifier >        supportedAlgorithms,
             BufferSource                            attestationChallenge,
             optional unsigned long                  credentialTimeoutSeconds,
             optional sequence < Credential >        blacklist,
@@ -306,11 +307,6 @@ The API is defined by the following Web IDL fragment.
         DOMString          name;
         DOMString          id;
         DOMString          imageURL;
-    };
-
-    dictionary ScopedCredentialParameters {
-        required CredentialType        type;
-        required AlgorithmIdentifier   algorithm;
     };
 
     interface WebAuthnAssertion {
@@ -357,8 +353,8 @@ This method takes the following parameters:
 - The <dfn>accountInformation</dfn> parameter specifies information about the user account for which the credential is being
     created. This is meant for later use by the authenticator when it needs to prompt the user to select a credential.
 
-- The <dfn>cryptoParameters</dfn> parameter supplies information about the desired properties of the credential to be created.
-    The sequence is ordered from most preferred to least preferred. The platform makes a best effort to create the most
+- The <dfn>supportedAlgorithms</dfn> and <dfn>supportedTypes</dfn> parameters supply information about the desired properties of the credential to be created.
+    The sequence is ordered from most preferred to least preferred. The platform makes a best effort to create the most logical and
     preferred credential that it can.
 
 - The <dfn>attestationChallenge</dfn> parameter contains a challenge intended to be used for generating the attestation
@@ -392,15 +388,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 4. Initialize |issuedRequests| to an empty list.
 
-5. Process each element of <a>cryptoParameters</a> using the following steps, to produce a new sequence `normalizedParameters`:
-    - Let |current| be the currently selected element of <a>cryptoParameters</a>.
-    - If `current.type` does not contain a {{CredentialType}} supported by this implementation, then stop processing |current|
-        and move on to the next element in <a>cryptoParameters</a>.
+5. Process each element of <a>supportedAlgorithms</a> using the following steps, to produce a new sequence `normalizedAlgorithms`:
+    - Let |currentAlgorithm| be the currently selected element of <a>supportedAlgorithms</a>.
     - Let `normalizedAlgorithm` be the result of normalizing an algorithm using the procedure defined in [[!WebCryptoAPI]],
-        with |alg| set to `current.algorithm` and |op| set to 'generateKey'. If an error occurs during this procedure, then
-        stop processing |current| and move on to the next element in <a>cryptoParameters</a>.
-    - Add a new object of type {{ScopedCredentialParameters}} to `normalizedParameters`, with |type| set to `current.type` and
-        |algorithm| set to `normalizedAlgorithm`.
+        with |alg| set to `currentAlgorithm` and |op| set to 'generateKey'. If an error occurs during this procedure, then
+        stop processing |currentAlgorithm| and move on to the next element in <a>supportedAlgorithms</a>.
+    - Add `normalizedAlgorithm` to `normalizedAlgorithms`.
 
 6. If <a>blacklist</a> is undefined, set it to the empty list.
 
@@ -409,7 +402,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 8. For each authenticator currently available on this platform: asynchronously invoke the
     <a>authenticatorMakeCredential</a> operation on that authenticator with |callerOrigin|, |rpId|, <a>accountInformation</a>,
-    `normalizedParameters`, <a>blacklist</a>, <a>attestationChallenge</a> and |clientExtensions| as parameters. Add a
+    <a>supportedTypes</a>, `normalizedAlgorithms`, <a>blacklist</a>, <a>attestationChallenge</a> and |clientExtensions| as parameters. Add a
     corresponding entry to |issuedRequests|.
 
 9. While |issuedRequests| is not empty, perform the following actions depending upon the |adjustedTimeout| timer and responses
@@ -534,18 +527,6 @@ authorizing an authenticator with which to complete the operation.
 
     The <dfn>imageURL</dfn> member contains a URL that resolves to the user's account image. This may be a URL that can be used
     to retrieve an image containing the user's current avatar, or a data URI that contains the image data.
-</div>
-
-
-## Parameters for Credential Generation (dictionary <dfn dictionary>ScopedCredentialParameters</dfn>) ## {#credential-params}
-
-<div dfn-for="ScopedCredentialParameters">
-    This dictionary is used to supply additional parameters when creating a new credential.
-
-    The <dfn>type</dfn> member specifies the type of credential to be created.
-
-    The <dfn>algorithm</dfn> member specifies the cryptographic algorithm with which the newly generated credential will be
-    used.
 </div>
 
 


### PR DESCRIPTION
The procedure for normalizing algorithms and types doesn't actually use the
types. Keeping these together in an object gives a kind of flexibility, but
after consideration, I don't see much purpose in defining different algorithms
for specifically different authenticator types.

This changes the makeCredential() method to instead have a list of supported
types and a list of supported algorithms, and perform its procedure that way.

This was part of PR #142, but per comments (https://github.com/w3c/webauthn/pull/142#discussion_r70385289 and https://github.com/w3c/webauthn/pull/142#discussion_r70487176) is now its' own standalone PR. See prior discussion for background. 