### PR TITLE
IDL cleanup: don't require callers to create Credential objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -314,9 +314,9 @@ The API is defined by the following Web IDL fragment.
     };
 
     dictionary CredentialOptions {
-        unsigned long            timeoutSeconds;
-        sequence < Credential >  excludeList;
-        WebAuthnExtensions       extensions;
+        unsigned long                       timeoutSeconds;
+        sequence < CredentialDescription >  excludeList;
+        WebAuthnExtensions                  extensions;
     };
 
     interface WebAuthnAssertion {
@@ -327,9 +327,9 @@ The API is defined by the following Web IDL fragment.
     };
 
     dictionary AssertionOptions {
-        unsigned long           timeoutSeconds;
-        sequence < Credential > allowList;
-        WebAuthnExtensions      extensions;
+        unsigned long                      timeoutSeconds;
+        sequence < CredentialDescription > allowList;
+        WebAuthnExtensions                 extensions;
     };
 
     dictionary WebAuthnExtensions {
@@ -347,7 +347,12 @@ The API is defined by the following Web IDL fragment.
 
     interface Credential {
         readonly attribute CredentialType type;
-        readonly attribute BufferSource   id;
+        readonly attribute ArrayBuffer    id;
+    };
+
+    dictionary CredentialDescription {
+        required CredentialType type;
+        required BufferSource   id;
     };
 </pre>
 
@@ -679,6 +684,18 @@ by the caller to select a credential for use.
     or length of this identifier, except that it must be sufficient for the platform to uniquely select a key. For example, an
     authenticator without on-board storage may create identifiers that consist of the key material wrapped with a key that is
     burned into the authenticator.
+</div>
+
+
+### Credential Descriptor (dictionary <dfn dictionary>CredentialDescription</dfn>) ### {#credential-dictionary}
+
+This dictionary contains the attributes that are specified by a caller when referring to a credential as an input parameter to
+the {{makeCredential()}} or {{getAssertion()}} method. It mirrors the fields of the {{Credential}} object returned by these methods.
+
+<div dfn-for="CredentialDescription">
+    The <dfn>type</dfn> attribute contains the type of the credential the caller is referring to.
+
+    The <dfn>id</dfn> attribute contains the identifier of the credential that the caller is referring to.
 </div>
 
 


### PR DESCRIPTION
This is the minimal version of the change required to fix the IDL issue
that @jcjones brought up regarding Credential objects. Unlike PR #158,
it retains the credential type and leaves the actual API surface and
samples unchanged.

If we pick this approach, PR #158 can be closed out and will no longer
be necessary.