### PR TITLE
Proper origin terminology, references, and setting of callerOrigin 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -37,7 +37,8 @@ Markup Shorthands: css off, markdown on
 
 <pre class="anchors">
 
-spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
+<!-- spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/ -->
+spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/
     type: dfn
         urlPrefix: browsers.html; for: web
             text: origin
@@ -147,7 +148,7 @@ This specification relies on several other underlying specifications.
 <!-- , <a>opaque origin</a>, -->
 
 : HTML
-:: The concepts of <a for='web'>origin</a> and the <a>Navigator</a> interface are defined in [[!HTML]].
+:: The concepts of <a for='web'>origin</a> and the <a>Navigator</a> interface are defined in [[!HTML51]].
 
 : Web IDL
 :: Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL-1]]. This updated version of

--- a/index.bs
+++ b/index.bs
@@ -38,15 +38,16 @@ Markup Shorthands: css off, markdown on
 <pre class="anchors">
 
 <!-- spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/ -->
-spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/
+spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/; for: web
     type: dfn
-        urlPrefix: browsers.html; for: web
-            text: origin
+        urlPrefix: browsers.html
+            text: origin; url: concept-cross-origin
             text: opaque origin
             text: tuple origin
-            text: current settings object
+            text: relaxing the same-origin restriction
     type: dfn
         urlPrefix: webappapis.html; for: interface
+            text: current settings object; url:current-settings-object
             text: Navigator
     
 </pre>
@@ -149,7 +150,9 @@ This specification relies on several other underlying specifications.
 <!-- , <a>opaque origin</a>, -->
 
 : HTML
-:: The concepts of <a for='web'>origin</a> and the <a>Navigator</a> interface are defined in [[!HTML51]].
+:: The concepts of <a link-for='web'>current settings object</a>, |given value|, <a link-for='web'>opaque origin</a>, 
+    <a for='web'>origin</a>, the <a>Navigator</a> interface, and the 
+    <a link-for='web'>relaxing the same-origin restriction</a> "setting" algorithm are defined in [[!HTML51]].
 
 : Web IDL
 :: Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL-1]]. This updated version of
@@ -363,8 +366,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
 2. Let |promise| be a new <a data-lt="Promises">Promise</a>. Return |promise| and start a timer for |adjustedTimeout| seconds.
     Then asynchronously continue executing the following steps.
 
-3. Set |callerOrigin| to the <a link-for='web'>current settings object's</a> <a link-for='web'>origin</a>. If |callerOrigin|
-    is an <a link-for='web'>opaque origin</a>, reject |promise| with a <a>DOMException</a> whose name is "NotAllowedError", and terminate this algorithm. Otherwise, derive the RP ID from |callerOrigin| by computing the
+3. Set |callerOrigin| to the <a link-for='web'>current settings object</a>'s <a link-for='web'>origin</a>. If |callerOrigin| is
+    an <a link-for='web'>opaque origin</a>, reject |promise| with a <a>DOMException</a> whose name is "NotAllowedError", and
+    terminate this algorithm. 
+    Otherwise, apply the <a link-for='web'>relaxing the same-origin restriction</a> "setting" algorithm using |callerOrigin| as
+    the |given value|. 
+    If no errors are thrown, then derive the RP ID from |callerOrigin| by computing the
     "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>")
     part of |callerOrigin| [[PSL]]. Let |rpId| be the lowercase form of this RP ID. Set |rpIdHash| to the SHA-256 hash of the
     UTF-8 encoding of |rpId|.
@@ -440,8 +447,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
 2. Let |promise| be a new <a data-lt="Promises">Promise</a>. Return |promise| and start a timer for |adjustedTimeout| seconds.
     Then asynchronously continue executing the following steps.
 
-3. Set |callerOrigin| to the <a link-for='web'>current settings object's</a> <a link-for='web'>origin</a>. If |callerOrigin|
-    is an <a link-for='web'>opaque origin</a>, reject |promise| with a <a>DOMException</a> whose name is "NotAllowedError", and terminate this algorithm. Otherwise, derive the RP ID from |callerOrigin| by computing the
+3. Set |callerOrigin| to the <a link-for='web'>current settings object</a>'s <a link-for='web'>origin</a>. If |callerOrigin|
+    is an <a link-for='web'>opaque origin</a>, reject |promise| with a <a>DOMException</a> whose name is "NotAllowedError", and
+    terminate this algorithm.
+    Otherwise, apply the <a link-for='web'>relaxing the same-origin restriction</a> "setting" algorithm using |callerOrigin| as
+    the |given value|. 
+    If no errors are thrown, then derive the RP ID from |callerOrigin| by computing the
     "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>")
     part of |callerOrigin| [[PSL]]. Let |rpId| be the lowercase form of this RP ID. Set |rpIdHash| to the SHA-256 hash of the
     UTF-8 encoding of |rpId|.

--- a/index.bs
+++ b/index.bs
@@ -35,6 +35,20 @@ Boilerplate: omit conformance, omit feedback-header
 Markup Shorthands: css off, markdown on
 </pre>
 
+<pre class="anchors">
+
+spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
+    type: dfn
+        urlPrefix: browsers.html; for: web
+            text: origin
+            text: opaque origin
+            text: tuple origin
+    type: dfn
+        urlPrefix: webappapis.html; for: interface
+            text: Navigator
+    
+</pre>
+
 
 # Introduction # {#intro}
 
@@ -130,8 +144,10 @@ or a combination of both.
 
 This specification relies on several other underlying specifications.
 
-: HTML5
-:: The concept of <dfn for='web'>origin</dfn> and the <dfn>Navigator</dfn> interface are defined in [[!HTML5]].
+<!-- , <a>opaque origin</a>, -->
+
+: HTML
+:: The concepts of <a for='web'>origin</a> and the <a>Navigator</a> interface are defined in [[!HTML]].
 
 : Web IDL
 :: Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL-1]]. This updated version of
@@ -701,7 +717,7 @@ string-valued keys. Values may be any type that has a valid encoding in JSON. It
 <div dfn-for="ClientData">
     The <dfn>challenge</dfn> member contains the base64url encoding of the challenge provided by the RP.
 
-    The <dfn>origin</dfn> member contains the fully qualified web origin of the requester, as provided to the authenticator by
+    The <dfn for="ClientData">origin</dfn> member contains the fully qualified web origin of the requester, as provided to the authenticator by
     the client, in the syntax defined by [[RFC6454]].
 
     The <dfn>rpId</dfn> member contains the RP ID of the requester, as computed by the client.

--- a/index.bs
+++ b/index.bs
@@ -58,7 +58,7 @@ spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/
 This specification defines an API enabling the creation and use of strong, attested, cryptographic <em><a>scoped
 credentials</a></em> by web applications, for the purpose of strongly authenticating users. A <a>scoped credential</a> is
 created and stored by an <em><a>authenticator</a></em> at the behest of a <em><a>[RP]</a></em>, subject to <em><a>user
-consent</a></em>. Subsequently, the scoped credential can only be accessed by web origins belonging to that [RP].
+consent</a></em>. Subsequently, the scoped credential can only be accessed by origins belonging to that [RP].
 This scoping is enforced jointly by <em><a>conforming User Agents</a></em> and <em><a>authenticators</a></em>. 
 Additionally, privacy across <a>[RPS]</a> is maintained; [RPS] are not able to detect any properties, or even
 the existence, of credentials scoped to other [RPS].
@@ -239,7 +239,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
 
 : <dfn>Relying Party Identifier</dfn>
 : <dfn>RP ID</dfn>
-:: A Relying Party Identifier is derived from a <a>[RP]</a>'s web origin's hostname by computing the hostname's <a>eTLD+1</a>. 
+:: A Relying Party Identifier is derived from a <a>[RP]</a>'s origin's hostname by computing the hostname's <a>eTLD+1</a>. 
 
 : <dfn>Scoped Credential</dfn>
 :: Generically, a credential is data one entity presents to another in order to authenticate the former's identity [[RFC4949]].
@@ -285,7 +285,7 @@ and/or platform on the user's behalf. At no point does the script get access to 
 information about the credentials in the form of objects. 
 
 The security properties of this API are provided by the client and the authenticator working together. The authenticator, which
-holds and manages credentials, ensures that all operations are scoped to a particular web origin, and cannot be replayed against
+holds and manages credentials, ensures that all operations are scoped to a particular origin, and cannot be replayed against
 a different origin, by incorporating the origin in its responses. Specifically, as defined in [[#signature-format]], the full
 origin of the requester is included, and signed over, in the attestation statement produced when a new credential is created as
 well as in all assertions produced by WebAuthn credentials.
@@ -294,9 +294,9 @@ Additionally, to maintain user privacy and prevent malicious [RPS] from probing 
 other [RPS], each credential is also associated with a Relying Party Identifier, or RP ID. This RP ID is provided by the client
 to the authenticator for all operations, and the authenticator ensures that credentials created by a [RP] can only be used in
 operations requested by the same RP ID. Separating the origin from the RP ID in this way allows the API to be used in cases
-where a single [RP] maintains multiple web origins.
+where a single [RP] maintains multiple origins.
 
-The client facilitates these security measures by providing correct web origins and RP IDs to the authenticator for each
+The client facilitates these security measures by providing correct origins and RP IDs to the authenticator for each
 operation. Since this is an integral part of the WebAuthn security model, user agents MUST only expose this API to callers in
 <dfn>secure contexts</dfn>, as defined in [[secure-contexts]].
 
@@ -718,7 +718,7 @@ string-valued keys. Values may be any type that has a valid encoding in JSON. It
 <div dfn-for="ClientData">
     The <dfn>challenge</dfn> member contains the base64url encoding of the challenge provided by the RP.
 
-    The <dfn for="ClientData">origin</dfn> member contains the fully qualified web origin of the requester, as provided to the authenticator by
+    The <dfn for="ClientData">origin</dfn> member contains the fully qualified origin of the requester, as provided to the authenticator by
     the client, in the syntax defined by [[RFC6454]].
 
     The <dfn>rpId</dfn> member contains the RP ID of the requester, as computed by the client.

--- a/index.bs
+++ b/index.bs
@@ -44,6 +44,7 @@ spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/
             text: origin
             text: opaque origin
             text: tuple origin
+            text: current settings object
     type: dfn
         urlPrefix: webappapis.html; for: interface
             text: Navigator
@@ -362,7 +363,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 2. Let |promise| be a new <a data-lt="Promises">Promise</a>. Return |promise| and start a timer for |adjustedTimeout| seconds.
     Then asynchronously continue executing the following steps.
 
-3. Set |callerOrigin| to the <a link-for='web'>origin</a> of the caller. Derive the RP ID from |callerOrigin| by computing the
+3. Set |callerOrigin| to the <a link-for='web'>current settings object's</a> <a link-for='web'>origin</a>. If |callerOrigin|
+    is an <a link-for='web'>opaque origin</a>, reject |promise| with a <a>DOMException</a> whose name is "NotAllowedError", and terminate this algorithm. Otherwise, derive the RP ID from |callerOrigin| by computing the
     "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>")
     part of |callerOrigin| [[PSL]]. Let |rpId| be the lowercase form of this RP ID. Set |rpIdHash| to the SHA-256 hash of the
     UTF-8 encoding of |rpId|.
@@ -438,7 +440,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 2. Let |promise| be a new <a data-lt="Promises">Promise</a>. Return |promise| and start a timer for |adjustedTimeout| seconds.
     Then asynchronously continue executing the following steps.
 
-3. Set |callerOrigin| to the <a link-for='web'>origin</a> of the caller. Derive the RP ID from |callerOrigin| by computing the
+3. Set |callerOrigin| to the <a link-for='web'>current settings object's</a> <a link-for='web'>origin</a>. If |callerOrigin|
+    is an <a link-for='web'>opaque origin</a>, reject |promise| with a <a>DOMException</a> whose name is "NotAllowedError", and terminate this algorithm. Otherwise, derive the RP ID from |callerOrigin| by computing the
     "public suffix + 1" or "PS+1" (which is also referred to as the "Effective Top-Level Domain plus One" or "<a>eTLD+1</a>")
     part of |callerOrigin| [[PSL]]. Let |rpId| be the lowercase form of this RP ID. Set |rpIdHash| to the SHA-256 hash of the
     UTF-8 encoding of |rpId|.


### PR DESCRIPTION
This resolves several issues regarding "origin" and references into the HTML (html51) spec.  It needs to be composed with #198 to fully make sense. 
