### PR TITLE
Inline and clarify the "Relaxing the Same-Origin Restriction" algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -48,23 +48,24 @@ spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/; for: web
             text: tuple origin
             text: relaxing the same-origin restriction
             text: domain; url: origin-domain
+            text: active sandboxing flag set
     type: dfn
         urlPrefix: webappapis.html;
             text: current settings object; for:web; url:current-settings-object
             text: Navigator; for: interface; url:the-navigator-object
 
-spec: WebCryptoAPI; urlPrefix: https://www.w3.org/TR/WebCryptoAPI/; for: web 
+spec: WebCryptoAPI; urlPrefix: https://www.w3.org/TR/WebCryptoAPI/; for: web
     type: dfn
         text: normalizing an algorithm; url: dfn-normalize-an-algorithm
 
-<!-- spec: HTML; urlPrefix: https://url.spec.whatwg.org/ -->
 spec: URL; urlPrefix: https://url.spec.whatwg.org/; for: url
     type: dfn
-        text: host parser; url: concept-host-parser
+        text: host parser
         text: domain; url: concept-domain
-        text: host; url: origin-host
-        text: IPv4 address; url: concept-ipv4
-        text: IPv6 address; url: concept-ipv6
+
+spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/; for: webidl
+    type: dfn
+        text: securityerror
 </pre> <!-- class=anchors -->
 
 # Introduction # {#intro}
@@ -417,7 +418,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]],
         using {{ScopedCredentialOptions/rpId}}. If no errors are thrown, set |rpId| to the value of `host` as
         computed by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject
-        |promise| with a <a>DOMException</a> whose name is "SecurityError", and terminate this algorithm.
+        |promise| with a <a>DOMException</a> whose name is "<a>SecurityError</a>", and terminate this algorithm.
 
 4. Process each element of {{cryptoParameters}} using the following steps, to produce a new sequence |normalizedParameters|.
     - Let |current| be the currently selected element of {{cryptoParameters}}.
@@ -511,7 +512,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     - If the {{AssertionOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]], using
         {{AssertionOptions/rpId}} as the given value. If no errors are thrown, set |rpId| to the value of `host` as computed
         by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject |promise| with
-        a <a>DOMException</a> whose name is "SecurityError", and terminate this algorithm.
+        a <a>DOMException</a> whose name is "<a>SecurityError</a>", and terminate this algorithm.
 
 4. If the {{AssertionOptions/extensions}} member of {{options}} is <a>present</a>, process any extensions supported by this 
     client platform, to produce the extension data that needs to be sent to the authenticator. If an error is encountered while
@@ -1523,36 +1524,35 @@ should be specified in the attestation certificate itself, so that it can be ver
 
 ## Algorithm to Relax the Same-Origin Restriction ## {#algo-relax-same-origin-restriction}
 
-The same-origin policy prevents web applications from interacting, unless they both have the same origin. HTML5, via
-the `document.domain` attribute, permits "relaxing" this same-origin restriction under certain circumstances. This
-algorithm implements a similar procedure that of setting the `document.domain` attribute from [[!HTML51]], but without
-modifying the <a>Document</a> object:
+In general, the same-origin policy prevents web applications from interacting
+within user agents, unless they have the same origin. However, there are many
+specific facets and exceptions to this overall policy.
 
-1. If this <a>Document</a> object has no browsing context, throw a "SecurityError" <a>DOMException</a>.
-2. If this <a>Document</a> object’s active sandboxing flag set has its <a>sandboxed `document.domain` browsing context
-    flag</a> set, then throw a "SecurityError" <a>DOMException</a>.
-3. If the given value is the empty string, then throw a "SecurityError" <a>DOMException</a>.
-4. Let |host| be the result of parsing the given value.
-5. If |host| is failure, then throw a "SecurityError" <a>DOMException</a>.
-6. Let |originalDomain| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s original <a link-for='web'>`domain`</a>,
-    assigned when the <a>Document</a> is created.
+For example, cookies [[RFC6265]] have same-origin restrictions similar to those
+of the HTML `document.domain` attribute. Both permit <a>relaxing the same-origin
+restriction</a> in a particular fashion, under certain circumstances.
 
-    Note: The |originalDomain| should not be affected by prior calls to the <a>Document</a> object’s
-     <a link-for='web'>`domain`</a> setter.
+The below algorithm implements a same-origin relaxation in the same vein as
+cookies and `document.domain`, but without modifying the <a>Document</a> object.
 
-7. If |host| is not <a link-for='url'>equal</a> to |originalDomain|, then run these substeps:
-    1. If |host| or |originalDomain| is not a <a link-for='url'>`domain`</a>, then throw a "SecurityError" <a>DOMException</a>.
+1. If the given value is the empty string, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+2. Let |host| be the result of <a>parsing</a> the given value.
+3. If |host| is failure, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+4. If this <a>Document</a> object’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+5. Let |originalHost| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s <a link-for='url'>`host`</a>.
+6. If |host| is not <a link-for='url'>equal</a> to |originalHost|, then run these substeps:
+    1. If |host| or |originalHost| is not a <a link-for='url'>domain</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
 
-    Note: This is meant to exclude <a link-for='url'>hosts</a> that are an <a link-for='url'>IPv4 address</a> or an
-     <a link-for='url'>IPv6 address</a>.
+    Note: This is meant to exclude <a link-for='url'>hosts</a> that are an <a>IPv4 address</a> or an
+     <a>IPv6 address</a>.
 
-    2. If |host|, prefixed by a U+002E FULL STOP (.), does not exactly match the end of |originalDomain|, then throw a
-        "SecurityError" <a>DOMException</a>.
+    2. If |host|, prefixed by a U+002E FULL STOP (.), does not exactly match the end of |originalHost|, then throw a
+        "<a>SecurityError</a>" <a>DOMException</a>.
     3. If |host| matches a suffix in the Public Suffix List, or, if |host|, prefixed by a U+002E FULL STOP (.), matches the
-        end of a suffix in the Public Suffix List, then throw a "SecurityError" <a>DOMException</a>. [[!PSL]]
+        end of a suffix in the Public Suffix List, then throw a "<a>SecurityError</a>" <a>DOMException</a>. [[!PSL]]
 
         Suffixes must be compared after applying the <a link-for='url'>host parser</a> algorithm.
-8. Return |host|.
+7. Return |host|.
 
 # Defined Attestation Formats # {#defined-attestation-formats}
 

--- a/index.bs
+++ b/index.bs
@@ -412,10 +412,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
     terminate this algorithm. Otherwise,
     - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is not <a>present</a>, then set |rpId| to |callerOrigin|, 
         and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|.
-    - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]],
-        using {{ScopedCredentialOptions/rpId}}. If no errors are thrown, set |rpId| to the value of `host` as
+    - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]]
+        using these arugments: let |relaxingRpId| be {{ScopedCredentialOptions/rpId}}, and let |currentDocument| be the current <a>Document</a>. If no errors are thrown, set |rpId| to the value of `host` as
         computed by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject
-        |promise| with a <a>DOMException</a> whose name is "{{SecurityError}}", and terminate this algorithm.
+        |promise| with the thrown error, and terminate this algorithm.
 
 4. Process each element of {{cryptoParameters}} using the following steps, to produce a new sequence |normalizedParameters|.
     - Let |current| be the currently selected element of {{cryptoParameters}}.
@@ -506,10 +506,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
     terminate this algorithm. Otherwise,
     - If the {{AssertionOptions/rpId}} member of {{options}} is not <a>present</a>, then set |rpId| to |callerOrigin|, and 
         |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|.
-    - If the {{AssertionOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]], using
-        {{AssertionOptions/rpId}} as the given value. If no errors are thrown, set |rpId| to the value of `host` as computed
-        by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject |promise| with
-        a <a>DOMException</a> whose name is "{{SecurityError}}", and terminate this algorithm.
+    - If the {{AssertionOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]],
+        using these arugments: let |relaxingRpId| be {{ScopedCredentialOptions/rpId}}, and let |currentDocument| be the current <a>Document</a>. If no errors are thrown, set |rpId| to the value of `host` as computed
+        by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject
+        |promise| with the thrown error, and terminate this algorithm.
 
 4. If the {{AssertionOptions/extensions}} member of {{options}} is <a>present</a>, process any extensions supported by this 
     client platform, to produce the extension data that needs to be sent to the authenticator. If an error is encountered while
@@ -972,22 +972,22 @@ defined in [[!WebCryptoAPI]].
 
 ## Algorithm to Relax the Same-Origin Restriction ## {#algo-relax-same-origin-restriction}
 
-In general, the same-origin policy prevents web applications from interacting
-within user agents, unless they have the same origin. However, there are many
-specific facets and exceptions to this overall policy.
+In general, the same-origin policy prevents pages from different origins from
+interacting with each other. However, for payments we want to allow subdomains
+to create payment requests that look like they come from the main domain.
 
-For example, cookies [[RFC6265]] have same-origin restrictions similar to those
-of the HTML `document.domain` attribute. Both permit <a>relaxing the same-origin
-restriction</a> in a particular fashion, under certain circumstances.
+We want to allow an |rpId| to represent a parent domain, subject to constraints
+similar to those of cookies or `document.domain`.
 
-The below algorithm implements a same-origin relaxation in the same vein as
-cookies and `document.domain`, but without modifying the <a>Document</a> object.
+The below algorithm should be invoked with a <a>Document</a> |currentDocument| and a
+string |relaxingRpId|. It implements a same-origin relaxation in the same vein as
+cookies and `document.domain`, but without modifying the |currentDocument| argument.
 
-1. If the given value is the empty string, then throw a "{{SecurityError}}" <a>DOMException</a>.
-2. Let |host| be the result of <a link-for='url'>parsing</a> the given value.
+1. If |relaxingRpId| is the empty string, then throw a "{{SecurityError}}" <a>DOMException</a>.
+2. Let |host| be the result of <a link-for='url'>parsing</a> the |relaxingRpId|.
 3. If |host| is failure, then throw a "{{SecurityError}}" <a>DOMException</a>.
-4. If this <a>Document</a> object’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "{{SecurityError}}" <a>DOMException</a>.
-5. Let |originalHost| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s <a link-for='url'>host</a>.
+4. If |currentDocument|’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "{{SecurityError}}" <a>DOMException</a>.
+5. Let |originalHost| be |currentDocument|’s <a link-for='web'>origin</a>’s <a link-for='url'>host</a>.
 6. If |host| is not <a link-for='url'>equal</a> to |originalHost|, then run these substeps:
     1. If |host| or |originalHost| is not a <a link-for='url'>domain</a>, then throw a "{{SecurityError}}" <a>DOMException</a>.
 

--- a/index.bs
+++ b/index.bs
@@ -973,6 +973,39 @@ A string or dictionary identifying a cryptographic algorithm and optionally a se
 defined in [[!WebCryptoAPI]].
 
 
+## Algorithm to Relax the Same-Origin Restriction ## {#algo-relax-same-origin-restriction}
+
+In general, the same-origin policy prevents web applications from interacting
+within user agents, unless they have the same origin. However, there are many
+specific facets and exceptions to this overall policy.
+
+For example, cookies [[RFC6265]] have same-origin restrictions similar to those
+of the HTML `document.domain` attribute. Both permit <a>relaxing the same-origin
+restriction</a> in a particular fashion, under certain circumstances.
+
+The below algorithm implements a same-origin relaxation in the same vein as
+cookies and `document.domain`, but without modifying the <a>Document</a> object.
+
+1. If the given value is the empty string, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+2. Let |host| be the result of <a>parsing</a> the given value.
+3. If |host| is failure, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+4. If this <a>Document</a> object’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+5. Let |originalHost| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s <a link-for='url'>`host`</a>.
+6. If |host| is not <a link-for='url'>equal</a> to |originalHost|, then run these substeps:
+    1. If |host| or |originalHost| is not a <a link-for='url'>domain</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+
+    Note: This is meant to exclude <a link-for='url'>hosts</a> that are an <a>IPv4 address</a> or an
+     <a>IPv6 address</a>.
+
+    2. If |host|, prefixed by a U+002E FULL STOP (.), does not exactly match the end of |originalHost|, then throw a
+        "<a>SecurityError</a>" <a>DOMException</a>.
+    3. If |host| matches a suffix in the Public Suffix List, or, if |host|, prefixed by a U+002E FULL STOP (.), matches the
+        end of a suffix in the Public Suffix List, then throw a "<a>SecurityError</a>" <a>DOMException</a>. [[!PSL]]
+
+        Suffixes must be compared after applying the <a link-for='url'>host parser</a> algorithm.
+7. Return |host|.
+
+
 # WebAuthn Authenticator model # {#authenticator-model}
 
 The API defined in this specification implies a specific abstract functional model for an <a>authenticator</a>. This section
@@ -1522,37 +1555,6 @@ used to help facilitate isolating problems with a specific version of a device.
 If the attestation root certificate is not dedicated to a single WebAuthn Authenticator device line (i.e., AAGUID), the AAGUID
 should be specified in the attestation certificate itself, so that it can be verified against the <a>authenticatorData</a>.
 
-## Algorithm to Relax the Same-Origin Restriction ## {#algo-relax-same-origin-restriction}
-
-In general, the same-origin policy prevents web applications from interacting
-within user agents, unless they have the same origin. However, there are many
-specific facets and exceptions to this overall policy.
-
-For example, cookies [[RFC6265]] have same-origin restrictions similar to those
-of the HTML `document.domain` attribute. Both permit <a>relaxing the same-origin
-restriction</a> in a particular fashion, under certain circumstances.
-
-The below algorithm implements a same-origin relaxation in the same vein as
-cookies and `document.domain`, but without modifying the <a>Document</a> object.
-
-1. If the given value is the empty string, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
-2. Let |host| be the result of <a>parsing</a> the given value.
-3. If |host| is failure, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
-4. If this <a>Document</a> object’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
-5. Let |originalHost| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s <a link-for='url'>`host`</a>.
-6. If |host| is not <a link-for='url'>equal</a> to |originalHost|, then run these substeps:
-    1. If |host| or |originalHost| is not a <a link-for='url'>domain</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
-
-    Note: This is meant to exclude <a link-for='url'>hosts</a> that are an <a>IPv4 address</a> or an
-     <a>IPv6 address</a>.
-
-    2. If |host|, prefixed by a U+002E FULL STOP (.), does not exactly match the end of |originalHost|, then throw a
-        "<a>SecurityError</a>" <a>DOMException</a>.
-    3. If |host| matches a suffix in the Public Suffix List, or, if |host|, prefixed by a U+002E FULL STOP (.), matches the
-        end of a suffix in the Public Suffix List, then throw a "<a>SecurityError</a>" <a>DOMException</a>. [[!PSL]]
-
-        Suffixes must be compared after applying the <a link-for='url'>host parser</a> algorithm.
-7. Return |host|.
 
 # Defined Attestation Formats # {#defined-attestation-formats}
 

--- a/index.bs
+++ b/index.bs
@@ -48,7 +48,6 @@ spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/; for: web
             text: tuple origin
             text: relaxing the same-origin restriction
             text: domain; url: origin-domain
-            text: active sandboxing flag set
     type: dfn
         urlPrefix: webappapis.html;
             text: current settings object; for:web; url:current-settings-object
@@ -62,10 +61,6 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/; for: url
     type: dfn
         text: host parser
         text: domain; url: concept-domain
-
-spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/; for: webidl
-    type: dfn
-        text: securityerror
 </pre> <!-- class=anchors -->
 
 # Introduction # {#intro}
@@ -418,7 +413,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]],
         using {{ScopedCredentialOptions/rpId}}. If no errors are thrown, set |rpId| to the value of `host` as
         computed by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject
-        |promise| with a <a>DOMException</a> whose name is "<a>SecurityError</a>", and terminate this algorithm.
+        |promise| with a <a>DOMException</a> whose name is "{{SecurityError}}", and terminate this algorithm.
 
 4. Process each element of {{cryptoParameters}} using the following steps, to produce a new sequence |normalizedParameters|.
     - Let |current| be the currently selected element of {{cryptoParameters}}.
@@ -512,7 +507,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     - If the {{AssertionOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]], using
         {{AssertionOptions/rpId}} as the given value. If no errors are thrown, set |rpId| to the value of `host` as computed
         by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject |promise| with
-        a <a>DOMException</a> whose name is "<a>SecurityError</a>", and terminate this algorithm.
+        a <a>DOMException</a> whose name is "{{SecurityError}}", and terminate this algorithm.
 
 4. If the {{AssertionOptions/extensions}} member of {{options}} is <a>present</a>, process any extensions supported by this 
     client platform, to produce the extension data that needs to be sent to the authenticator. If an error is encountered while
@@ -986,21 +981,21 @@ restriction</a> in a particular fashion, under certain circumstances.
 The below algorithm implements a same-origin relaxation in the same vein as
 cookies and `document.domain`, but without modifying the <a>Document</a> object.
 
-1. If the given value is the empty string, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+1. If the given value is the empty string, then throw a "{{SecurityError}}" <a>DOMException</a>.
 2. Let |host| be the result of <a>parsing</a> the given value.
-3. If |host| is failure, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
-4. If this <a>Document</a> object’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
-5. Let |originalHost| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s <a link-for='url'>`host`</a>.
+3. If |host| is failure, then throw a "{{SecurityError}}" <a>DOMException</a>.
+4. If this <a>Document</a> object’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "{{SecurityError}}" <a>DOMException</a>.
+5. Let |originalHost| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s <a link-for='url'>host</a>.
 6. If |host| is not <a link-for='url'>equal</a> to |originalHost|, then run these substeps:
-    1. If |host| or |originalHost| is not a <a link-for='url'>domain</a>, then throw a "<a>SecurityError</a>" <a>DOMException</a>.
+    1. If |host| or |originalHost| is not a <a link-for='url'>domain</a>, then throw a "{{SecurityError}}" <a>DOMException</a>.
 
     Note: This is meant to exclude <a link-for='url'>hosts</a> that are an <a>IPv4 address</a> or an
      <a>IPv6 address</a>.
 
     2. If |host|, prefixed by a U+002E FULL STOP (.), does not exactly match the end of |originalHost|, then throw a
-        "<a>SecurityError</a>" <a>DOMException</a>.
+        "{{SecurityError}}" <a>DOMException</a>.
     3. If |host| matches a suffix in the Public Suffix List, or, if |host|, prefixed by a U+002E FULL STOP (.), matches the
-        end of a suffix in the Public Suffix List, then throw a "<a>SecurityError</a>" <a>DOMException</a>. [[!PSL]]
+        end of a suffix in the Public Suffix List, then throw a "{{SecurityError}}" <a>DOMException</a>. [[!PSL]]
 
         Suffixes must be compared after applying the <a link-for='url'>host parser</a> algorithm.
 7. Return |host|.

--- a/index.bs
+++ b/index.bs
@@ -59,7 +59,9 @@ spec: WebCryptoAPI; urlPrefix: https://www.w3.org/TR/WebCryptoAPI/; for: web
 
 spec: URL; urlPrefix: https://url.spec.whatwg.org/; for: url
     type: dfn
-        text: host parser
+        url: concept-host-parser
+            text: parsing
+            text: host parser
         text: domain; url: concept-domain
 </pre> <!-- class=anchors -->
 
@@ -982,7 +984,7 @@ The below algorithm implements a same-origin relaxation in the same vein as
 cookies and `document.domain`, but without modifying the <a>Document</a> object.
 
 1. If the given value is the empty string, then throw a "{{SecurityError}}" <a>DOMException</a>.
-2. Let |host| be the result of <a>parsing</a> the given value.
+2. Let |host| be the result of <a link-for='url'>parsing</a> the given value.
 3. If |host| is failure, then throw a "{{SecurityError}}" <a>DOMException</a>.
 4. If this <a>Document</a> object’s <a link-for='web'>origin</a> is an <a link-for='web'>opaque origin</a>, then throw a "{{SecurityError}}" <a>DOMException</a>.
 5. Let |originalHost| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s <a link-for='url'>host</a>.

--- a/index.bs
+++ b/index.bs
@@ -47,6 +47,7 @@ spec: HTML51; urlPrefix: http://www.w3.org/TR/html51/; for: web
             text: opaque origin; url: opaque-origin; for:web
             text: tuple origin
             text: relaxing the same-origin restriction
+            text: domain; url: origin-domain
     type: dfn
         urlPrefix: webappapis.html;
             text: current settings object; for:web; url:current-settings-object
@@ -56,8 +57,15 @@ spec: WebCryptoAPI; urlPrefix: https://www.w3.org/TR/WebCryptoAPI/; for: web
     type: dfn
         text: normalizing an algorithm; url: dfn-normalize-an-algorithm
 
+<!-- spec: HTML; urlPrefix: https://url.spec.whatwg.org/ -->
+spec: URL; urlPrefix: https://url.spec.whatwg.org/; for: url
+    type: dfn
+        text: host parser; url: concept-host-parser
+        text: domain; url: concept-domain
+        text: host; url: origin-host
+        text: IPv4 address; url: concept-ipv4
+        text: IPv6 address; url: concept-ipv6
 </pre> <!-- class=anchors -->
-
 
 # Introduction # {#intro}
 
@@ -201,8 +209,8 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
 : <dfn>Attestation</dfn>
 :: Generally, a statement that serves to bear witness, confirm, or authenticate.
     In the WebAuthn context, attestation is employed to attest to the provenance of an authenticator and the data it emits;
-    including, for example: credential IDs, credential key pairs, signature counters, etc. <dfn>Attestation information</dfn> is 
-    conveyed in <a>attestation statements</a>. 
+    including, for example: credential IDs, credential key pairs, signature counters, etc. <dfn>Attestation information</dfn> is
+    conveyed in <a>attestation statements</a>.
     See also <a>attestation format</a>, and <a>attestation type</a>.
 
 : <dfn>Attestation Certificate</dfn>
@@ -405,13 +413,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
     an <a link-for='web'>opaque origin</a>, reject |promise| with a <a>DOMException</a> whose name is "NotAllowedError", and
     terminate this algorithm. Otherwise,
     - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is not <a>present</a>, then set |rpId| to |callerOrigin|, 
-        and |rpIdHash| to the SHA-256 hash of |rpId|.
-    - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the procedure used for 
-        <a>relaxing the same-origin
-        restriction</a> by setting the `document.domain` attribute, using {{ScopedCredentialOptions/rpId}} as the given value
-        but without changing the current document's `domain`. If no errors are thrown, set |rpId| to the value of `host` as
-        computed by this procedure, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject |promise| with a
-        <a>DOMException</a> whose name is "SecurityError", and terminate this algorithm.
+        and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|.
+    - If the {{ScopedCredentialOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]],
+        using {{ScopedCredentialOptions/rpId}}. If no errors are thrown, set |rpId| to the value of `host` as
+        computed by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject
+        |promise| with a <a>DOMException</a> whose name is "SecurityError", and terminate this algorithm.
 
 4. Process each element of {{cryptoParameters}} using the following steps, to produce a new sequence |normalizedParameters|.
     - Let |current| be the currently selected element of {{cryptoParameters}}.
@@ -502,11 +508,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
     terminate this algorithm. Otherwise,
     - If the {{AssertionOptions/rpId}} member of {{options}} is not <a>present</a>, then set |rpId| to |callerOrigin|, and 
         |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|.
-    - If the {{AssertionOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the procedure used for <a>relaxing 
-        the same-origin restriction</a> by setting the `document.domain` attribute, using {{AssertionOptions/rpId}} as the given
-        value but without changing the current document's `domain`. If no errors are thrown, set |rpId| to the value of `host`
-        as computed by this procedure, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject 
-        |promise| with a <a>DOMException</a> whose name is "SecurityError", and terminate this algorithm.
+    - If the {{AssertionOptions/rpId}} member of {{options}} is <a>present</a>, then invoke the [[#algo-relax-same-origin-restriction]], using
+        {{AssertionOptions/rpId}} as the given value. If no errors are thrown, set |rpId| to the value of `host` as computed
+        by this algorithm, and |rpIdHash| to the SHA-256 hash of the UTF-8 encoding of |rpId|. Otherwise, reject |promise| with
+        a <a>DOMException</a> whose name is "SecurityError", and terminate this algorithm.
 
 4. If the {{AssertionOptions/extensions}} member of {{options}} is <a>present</a>, process any extensions supported by this 
     client platform, to produce the extension data that needs to be sent to the authenticator. If an error is encountered while
@@ -1516,7 +1521,38 @@ used to help facilitate isolating problems with a specific version of a device.
 If the attestation root certificate is not dedicated to a single WebAuthn Authenticator device line (i.e., AAGUID), the AAGUID
 should be specified in the attestation certificate itself, so that it can be verified against the <a>authenticatorData</a>.
 
+## Algorithm to Relax the Same-Origin Restriction ## {#algo-relax-same-origin-restriction}
 
+The same-origin policy prevents web applications from interacting, unless they both have the same origin. HTML5, via
+the `document.domain` attribute, permits "relaxing" this same-origin restriction under certain circumstances. This
+algorithm implements a similar procedure that of setting the `document.domain` attribute from [[!HTML51]], but without
+modifying the <a>Document</a> object:
+
+1. If this <a>Document</a> object has no browsing context, throw a "SecurityError" <a>DOMException</a>.
+2. If this <a>Document</a> object’s active sandboxing flag set has its <a>sandboxed `document.domain` browsing context
+    flag</a> set, then throw a "SecurityError" <a>DOMException</a>.
+3. If the given value is the empty string, then throw a "SecurityError" <a>DOMException</a>.
+4. Let |host| be the result of parsing the given value.
+5. If |host| is failure, then throw a "SecurityError" <a>DOMException</a>.
+6. Let |originalDomain| be this <a>Document</a> object’s <a link-for='web'>origin</a>’s original <a link-for='web'>`domain`</a>,
+    assigned when the <a>Document</a> is created.
+
+    Note: The |originalDomain| should not be affected by prior calls to the <a>Document</a> object’s
+     <a link-for='web'>`domain`</a> setter.
+
+7. If |host| is not <a link-for='url'>equal</a> to |originalDomain|, then run these substeps:
+    1. If |host| or |originalDomain| is not a <a link-for='url'>`domain`</a>, then throw a "SecurityError" <a>DOMException</a>.
+
+    Note: This is meant to exclude <a link-for='url'>hosts</a> that are an <a link-for='url'>IPv4 address</a> or an
+     <a link-for='url'>IPv6 address</a>.
+
+    2. If |host|, prefixed by a U+002E FULL STOP (.), does not exactly match the end of |originalDomain|, then throw a
+        "SecurityError" <a>DOMException</a>.
+    3. If |host| matches a suffix in the Public Suffix List, or, if |host|, prefixed by a U+002E FULL STOP (.), matches the
+        end of a suffix in the Public Suffix List, then throw a "SecurityError" <a>DOMException</a>. [[!PSL]]
+
+        Suffixes must be compared after applying the <a link-for='url'>host parser</a> algorithm.
+8. Return |host|.
 
 # Defined Attestation Formats # {#defined-attestation-formats}
 
@@ -2667,6 +2703,12 @@ Brad Hill, Jing Jin, Anne van Kesteren, Giridhar Mandyam, Axel Nennker, Yaron Sh
     "title": "FIDO Metadata Service v1.0",
     "href": "https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-metadata-service-v1.0-ps-20141208.html",
     "status": "FIDO Alliance Proposed Standard"
+  },
+
+  "PSL": {
+    "title": "Public Suffix List",
+    "publisher": "Mozilla Foundation",
+    "href": "https://publicsuffix.org/"
   },
 
   "TPMv1-2-Part2": {


### PR DESCRIPTION
Issue #256 notes that it is "not clear whether [we] actually want the interaction with sandboxing that the document.domain setter has", nor "whether [we] actually want the behavior to be affected by previous `document.domain` sets".

This patch offers a way to fix that, by:

1) Extracting the procedure from HTML51 into a forked algorithm
2) Adjusting said algorithm to operate on a Document's "original Domain" so as to be independent of previous `document.domain` set operations.
3) Keeping the sandboxing interactions, though I'm not entirely versed in  whether there are problematic corner cases here.

This spec necessarily adds normative reference to the PSL (which was transitively referenced via normative reference from HTML51 before), and also to the URL specification (also previously transitive from HTML51).