### PR TITLE
Renaming WebAuthn -> Authentication

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -74,10 +74,10 @@ the existence, of credentials scoped to other [RPS].
 [RPS] employ the <a>Web Authentication API</a> during two distinct, but related, <a>ceremonies</a> involving a user. The first
 is <a>Registration</a>, where a <a>scoped credential</a> is created on an <a>authenticator</a>, and associated by a <a>[RP]</a>
 with the present user's account (the account may already exist or may be created at this time). The second is
-<a>Authentication</a>, where the <a>[RP]</a> is presented with a <em><a>WebAuthn Assertion</a></em> proving the presence and
-consent of the user who registered the <a>scoped credential</a>. Functionally, the <a>Web Authentication API</a> comprises two
-methods (along with associated data structures): <a>makeCredential()</a> and <a>getAssertion()</a>. The former is used during
-<a>Registration</a> and the latter during <a>Authentication</a>.
+<a>Authentication</a>, where the <a>[RP]</a> is presented with a <em><a>Authentication Assertion</a></em> proving the presence
+and consent of the user who registered the <a>scoped credential</a>. Functionally, the <a>Web Authentication API</a> comprises
+two methods (along with associated data structures): <a>makeCredential()</a> and <a>getAssertion()</a>. The former is used
+during <a>Registration</a> and the latter during <a>Authentication</a>.
 
 Broadly, compliant <a>authenticators</a> protect <a>scoped credentials</a>, and
 interact with user agents to implement the <a>Web Authentication API</a>. Some
@@ -196,7 +196,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
     the range U+0061 .. U+007A (i.e. LATIN SMALL LETTER A to LATIN SMALL LETTER Z) are also considered to match.
 
 : <dfn>Assertion</dfn>
-:: See <a>WebAuthn Assertion</a>.
+:: See <a>Authentication Assertion</a>.
 
 : <dfn>Attestation</dfn>
 :: Generally, a statement that serves to bear witness, confirm, or authenticate.
@@ -222,7 +222,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
 
 : <dfn>Authenticator</dfn>
 :: A cryptographic device used by a <a>[WAC]</a> to (i) generate a <a>scoped credential</a> and register it with a <a>[RP]</a>,
-	and (ii) subsequently used to cryptographically sign and return, in the form of an <a>WebAuthn Assertion</a>, a challenge
+	and (ii) subsequently used to cryptographically sign and return, in the form of an <a>Authentication Assertion</a>, a challenge
 	and other data presented by a <a>[RP]</a> (in concert with the <a>[WAC]</a>) in order to effect authentication.
 
 : <dfn>Authorization Gesture</dfn>
@@ -276,7 +276,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
     conjunction with the present user's account. The authenticator maps the private key to the [RP]'s <a>RP ID</a> and stores
     it. Subsequently, only that [RP], as identified by its <a>RP ID</a>, is able to employ the <a>scoped credential</a> in
 	<a>authentication</a> ceremonies, via the <a>getAssertion()</a> method. The [RP] uses its copy of the stored public key to
-    verify the resultant <a>WebAuthn Assertion</a>.
+    verify the resultant <a>Authentication Assertion</a>.
 
 
 : <dfn>User Consent</dfn>
@@ -289,7 +289,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
 	code, a password, a gesture (e.g., presenting a fingerprint), or other modality. Note that invocation of said operations
 	implies use of key material managed by the authenticator.
 
-: <dfn>WebAuthn Assertion</dfn>
+: <dfn>Authentication Assertion</dfn>
 :: The cryptographically signed {{AuthenticationAssertion}} object returned by an <a>authenticator</a> as the result of a
 	<a>authenticatorGetAssertion</a> operation.
 
@@ -765,7 +765,7 @@ user consent to a specific transaction. The structure of these signatures is def
 </div>
 
 
-## WebAuthn Assertion Extensions (dictionary <dfn dictionary>AuthenticationExtensions</dfn>) ## {#iface-assertion-extensions}
+## Authentication Assertion Extensions (dictionary <dfn dictionary>AuthenticationExtensions</dfn>) ## {#iface-assertion-extensions}
 
 <pre class="idl">
     dictionary AuthenticationExtensions {

--- a/index.bs
+++ b/index.bs
@@ -290,7 +290,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
 	implies use of key material managed by the authenticator.
 
 : <dfn>WebAuthn Assertion</dfn>
-:: The cryptographically signed {{WebAuthnAssertion}} object returned by an <a>authenticator</a> as the result of a
+:: The cryptographically signed {{AuthenticationAssertion}} object returned by an <a>authenticator</a> as the result of a
 	<a>authenticatorGetAssertion</a> operation.
 
 : <dfn>[WAC]</dfn>
@@ -348,9 +348,9 @@ The Web Authentication API is defined by the union of the Web IDL fragments pres
             optional ScopedCredentialOptions        options
         );
 
-        Promise < WebAuthnAssertion > getAssertion (
-            BufferSource               assertionChallenge,
-            optional AssertionOptions  options
+        Promise < AuthenticationAssertion > getAssertion (
+            BufferSource                    assertionChallenge,
+            optional AssertionOptions       options
         );
     };
 </pre>
@@ -543,7 +543,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     - If any authenticator returns an error status, delete the corresponding entry from |issuedRequests|.
     - If any authenticator returns success:
         - Remove this authenticator's entry from |issuedRequests|.
-        - Create a new {{WebAuthnAssertion}} object named |value| and populate its fields with the values returned from the
+        - Create a new {{AuthenticationAssertion}} object named |value| and populate its fields with the values returned from the
             authenticator as well as the <a>clientDataJSON</a> computed earlier.
         - For each remaining entry in |issuedRequests| invoke the <a>authenticatorCancel</a> operation on that authenticator and
             remove its entry from the list.
@@ -560,8 +560,8 @@ authorizing an authenticator with which to complete the operation.
 <pre class="idl">
     [SecureContext]
     interface ScopedCredentialInfo {
-        readonly attribute ScopedCredential     credential;
-        readonly attribute WebAuthnAttestation  attestation;
+        readonly attribute ScopedCredential           credential;
+        readonly attribute AuthenticationAttestation  attestation;
     };
 </pre>
 
@@ -640,7 +640,7 @@ authorizing an authenticator with which to complete the operation.
         USVString                               rpId;
         sequence < ScopedCredentialDescriptor > excludeList = [];
         Attachment                              attachment;
-        WebAuthnExtensions                      extensions;
+        AuthenticationExtensions                extensions;
     };
 </pre>
 
@@ -707,11 +707,11 @@ authorizing an authenticator with which to complete the operation.
 </div>
 
 
-## Web Authentication Assertion (interface <dfn interface>WebAuthnAssertion</dfn>) ## {#iface-assertion}
+## Web Authentication Assertion (interface <dfn interface>AuthenticationAssertion</dfn>) ## {#iface-assertion}
 
 <pre class="idl">
     [SecureContext]
-    interface WebAuthnAssertion {
+    interface AuthenticationAssertion {
         readonly attribute ScopedCredential  credential;
         readonly attribute ArrayBuffer       clientData;
         readonly attribute ArrayBuffer       authenticatorData;
@@ -722,7 +722,7 @@ authorizing an authenticator with which to complete the operation.
 Scoped credentials produce a cryptographic signature that provides proof of possession of a private key as well as evidence of
 user consent to a specific transaction. The structure of these signatures is defined as follows.
 
-<div dfn-for="WebAuthnAssertion">
+<div dfn-for="AuthenticationAssertion">
     The <dfn>credential</dfn> member represents the credential that was used to generate this assertion.
 
     The <dfn>clientData</dfn> member contains the parameters sent to the authenticator by the client, in serialized form. See
@@ -743,7 +743,7 @@ user consent to a specific transaction. The structure of these signatures is def
         unsigned long                           timeoutSeconds;
         USVString                               rpId;
         sequence < ScopedCredentialDescriptor > allowList = [];
-        WebAuthnExtensions                      extensions;
+        AuthenticationExtensions                extensions;
     };
 </pre>
 
@@ -765,10 +765,10 @@ user consent to a specific transaction. The structure of these signatures is def
 </div>
 
 
-## WebAuthn Assertion Extensions (dictionary <dfn dictionary>WebAuthnExtensions</dfn>) ## {#iface-assertion-extensions}
+## WebAuthn Assertion Extensions (dictionary <dfn dictionary>AuthenticationExtensions</dfn>) ## {#iface-assertion-extensions}
 
 <pre class="idl">
-    dictionary WebAuthnExtensions {
+    dictionary AuthenticationExtensions {
     };
 </pre>
 
@@ -780,11 +780,11 @@ If the caller wishes to pass extensions to the platform, it MUST do so by adding
 with the extension identifier as the key, and the extension's value as the value (see [[#extensions]] for details).
 
 
-## Credential Attestation Structure (interface <dfn interface>WebAuthnAttestation</dfn>) ## {#iface-attestation}
+## Credential Attestation Structure (interface <dfn interface>AuthenticationAttestation</dfn>) ## {#iface-attestation}
 
 <pre class="idl">
     [SecureContext]
-    interface WebAuthnAttestation {
+    interface AuthenticationAttestation {
         readonly    attribute USVString     format;
         readonly    attribute ArrayBuffer   clientData;
         readonly    attribute ArrayBuffer   authenticatorData;
@@ -799,7 +799,7 @@ certificate or similar information providing provenance information for the <a>a
 decision to be made. However, if an <a>attestation key pair</a> is not available, then the authenticator MUST perform <a>self
 attestation</a> of the <a>credential public key</a> with the corresponding <a>credential private key</a>.
 
-<div dfn-for="WebAuthnAttestation">
+<div dfn-for="AuthenticationAttestation">
     The <dfn>format</dfn> member specifies the format of attestation statement contained in this structure. Attestation formats
     are defined in [[#attestation-formats]]. This specification supports a number of attestation formats, in
     [[#defined-attestation-formats]]. Other attestation formats may be defined in later versions of this specification.
@@ -835,7 +835,7 @@ string-valued keys. Values may be any type that has a valid encoding in JSON. It
         required DOMString           origin;
         required AlgorithmIdentifier hashAlg;
         DOMString                    tokenBinding;
-        WebAuthnExtensions           extensions;
+        AuthenticationExtensions     extensions;
     };
 </pre>
 
@@ -1037,7 +1037,7 @@ When this operation is invoked, the authenticator must perform the following pro
 On successful completion of this operation, the authenticator must return the following to the client:
 - The type and unique identifier of the new credential.
 - The new <a>credential public key</a>.
-- The fields of the attestation structure {{WebAuthnAttestation}}, including information about the attestation format used.
+- The fields of the attestation structure {{AuthenticationAttestation}}, including information about the attestation format used.
 
 
 ### The <dfn>authenticatorGetAssertion</dfn> operation ### {#op-get-assertion}
@@ -1233,15 +1233,15 @@ A simple, undelimited concatenation is safe to use here because the <a>authentic
 
 The authenticator MUST return both the <a>authenticatorData</a> and the raw signature back to the client. The client, in turn,
 MUST return <a>clientDataJSON</a>, <a>authenticatorData</a> and the signature to the RP. The first two are returned in the
-`clientData` and `authenticatorData` members respectively of the {{WebAuthnAssertion}} and {{WebAuthnAttestation}} structures.
+`clientData` and `authenticatorData` members respectively of the {{AuthenticationAssertion}} and {{AuthenticationAttestation}} structures.
 
 ### Verifying a signature ### {#authenticator-signature-verification}
 
 This section specifies the algorithm for verifying a signature assertion.
 
-Upon receiving a signature assertion in the form of a {{WebAuthnAssertion}} structure, the [RP] shall:
+Upon receiving a signature assertion in the form of a {{AuthenticationAssertion}} structure, the [RP] shall:
 
-1. Perform JSON decoding to extract the {{ClientData}} used for the assertion from the {{WebAuthnAssertion/clientData}}.
+1. Perform JSON decoding to extract the {{ClientData}} used for the assertion from the {{AuthenticationAssertion/clientData}}.
 
 2. Verify that the {{ClientData/challenge}} in the {{ClientData}} matches the challenge that was sent to the authenticator.
 
@@ -1253,14 +1253,14 @@ Upon receiving a signature assertion in the form of a {{WebAuthnAssertion}} stru
 
 5. Verify that the {{ClientData/extensions}} in the {{ClientData}} is a proper subset of the extensions requested by the RP.
 
-6. Verify that the RP ID hash in the {{WebAuthnAssertion/authenticatorData}} is indeed the SHA-256 hash of the RP ID expected
+6. Verify that the RP ID hash in the {{AuthenticationAssertion/authenticatorData}} is indeed the SHA-256 hash of the RP ID expected
     by the RP.
 
-7. Compute the <a>clientDataHash</a>, i.e. hash of {{WebAuthnAssertion/clientData}}.
+7. Compute the <a>clientDataHash</a>, i.e. hash of {{AuthenticationAssertion/clientData}}.
 
 8. Look up the previously registered public key associated with the credential (see {{makeCredential()}}) and
-    verify the signature in {{WebAuthnAssertion/signature}} computed over the
-    binary concatenation of {{WebAuthnAssertion/authenticatorData}} and <a>clientDataHash</a>.
+    verify the signature in {{AuthenticationAssertion/signature}} computed over the
+    binary concatenation of {{AuthenticationAssertion/authenticatorData}} and <a>clientDataHash</a>.
 
 If all the above steps succeed, then the signature is valid, otherwise it is invalid.
 
@@ -1302,7 +1302,7 @@ Service [[FIDOMetadataService]] provides one way to access such information.
 As described above, an attestation format is a data format which represents a cryptographic signature by an authenticator over a
 set of contextual bindings. Each attestation format is defined by the following attributes:
 
-- The name of the format, used to identify it in a {{WebAuthnAttestation}} structure. This MUST be an ASCII string, and MUST
+- The name of the format, used to identify it in a {{AuthenticationAttestation}} structure. This MUST be an ASCII string, and MUST
     NOT be an <a>ASCII case-insensitive match</a> for the name of any other attestation format.
 
 - The set of attestation types supported by the format.
@@ -1418,9 +1418,9 @@ attestation format, with <a>attToBeSigned</a> as input.
 
 This section specifies the algorithm for verifying an attestation statement, independent of attestation format.
 
-Upon receiving an attestation statement in the form of a {{WebAuthnAttestation}} structure, the [RP] shall:
+Upon receiving an attestation statement in the form of a {{AuthenticationAttestation}} structure, the [RP] shall:
 
-1. Perform JSON decoding to extract the {{ClientData}} used for the attestation from the {{WebAuthnAttestation/clientData}}.
+1. Perform JSON decoding to extract the {{ClientData}} used for the attestation from the {{AuthenticationAttestation/clientData}}.
 
 2. Verify that the {{ClientData/challenge}} in the {{ClientData}} matches the challenge that was sent to the authenticator.
 
@@ -1431,18 +1431,18 @@ Upon receiving an attestation statement in the form of a {{WebAuthnAttestation}}
 
 5. Verify that the {{ClientData/extensions}} in the {{ClientData}} is a proper subset of the extensions requested by the RP.
 
-6. Verify that the RP ID hash in the {{WebAuthnAttestation/authenticatorData}} is indeed the SHA-256 hash of the RP ID expected
+6. Verify that the RP ID hash in the {{AuthenticationAttestation/authenticatorData}} is indeed the SHA-256 hash of the RP ID expected
     by the RP.
 
-7. Perform an <a>ASCII case-insensitive match</a> on {{WebAuthnAttestation/format}} to determine the attestation format.
+7. Perform an <a>ASCII case-insensitive match</a> on {{AuthenticationAttestation/format}} to determine the attestation format.
 
 8. Look up the attestation root certificate or DAA root key from a trusted source. For example, the FIDO Metadata Service
     [[FIDOMetadataService]] provides one way to access such information. The AAGUID in the
-    {{WebAuthnAssertion/authenticatorData}} can be used for this lookup.
+    {{AuthenticationAssertion/authenticatorData}} can be used for this lookup.
 
 9. Using the verification process for the above attestation format, validate that the attestation
-    {{WebAuthnAttestation/attestation}} is valid for the given {{WebAuthnAttestation/authenticatorData}},
-    {{WebAuthnAttestation/clientData}} and the above trust anchor.
+    {{AuthenticationAttestation/attestation}} is valid for the given {{AuthenticationAttestation/authenticatorData}},
+    {{AuthenticationAttestation/clientData}} and the above trust anchor.
 
 The [RP] MAY take any of the below actions when verification of an attestation statement fails, according to its policy:
 
@@ -1600,11 +1600,11 @@ elements).
     - Verify that {{PackedAttestation/alg}} is "ED256" or "ED512".
     - Perform DAA-Verify on {{PackedAttestation/signature}} (see [[!FIDOEcdaaAlgorithm]]).
     - If {{PackedAttestation/x5c}} contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify that
-        the value of this extension matches the AAGUID in the {{WebAuthnAttestation/authenticatorData}}.
+        the value of this extension matches the AAGUID in the {{AuthenticationAttestation/authenticatorData}}.
 
     If neither {{PackedAttestation/x5c}} nor {{PackedAttestation/daaKey}} is present, self attestation is in use.
     - Verify the signature using the <a>credential public key</a>.
-    - Validate that {{PackedAttestation/alg}} matches the algorithm in {{WebAuthnAttestation/authenticatorData}}.
+    - Validate that {{PackedAttestation/alg}} matches the algorithm in {{AuthenticationAttestation/authenticatorData}}.
 
 
 ### Packed attestation statement certificate requirements ### {#packed-attestation-cert-requirements}
@@ -1691,10 +1691,10 @@ This attestation format is generally used by authenticators that use a Trusted P
         {{TpmAttestation/x5c}} with the algorithm specified in {{TpmAttestation/alg}}.
     - If {{TpmAttestation/tpmVersion}} is "1.2", verify that the {{TpmAttestation/certifyInfo}} contains a TPM_CERTIFY_INFO
         or TPM_CERTIFY_INFO2 structure with the `data` field set to the SHA-1 hash of the concatenation of
-        {{WebAuthnAttestation/authenticatorData}} and  {{WebAuthnAttestation/clientData}}.
+        {{AuthenticationAttestation/authenticatorData}} and  {{AuthenticationAttestation/clientData}}.
     - If {{TpmAttestation/tpmVersion}} is "2.0", verify that {{TpmAttestation/certifyInfo}} is a TPMS_ATTEST structure with the
-        `extraData` field set to the concatenation of {{WebAuthnAttestation/authenticatorData}} and
-        {{WebAuthnAttestation/clientData}}.
+        `extraData` field set to the concatenation of {{AuthenticationAttestation/authenticatorData}} and
+        {{AuthenticationAttestation/clientData}}.
     - Verify that {{TpmAttestation/x5c}} correctly chains to the trust anchor provided.
     - Verify that {{TpmAttestation/x5c}} meets the requirements in [[#tpm-cert-requirements]].
 
@@ -1703,9 +1703,9 @@ This attestation format is generally used by authenticators that use a Trusted P
     - Perform DAA-Verify on {{TpmAttestation/signature}} to verify that it is over the {{TpmAttestation/certifyInfo}}
         (see [[!FIDOEcdaaAlgorithm]]).
     - Verify that {{TpmAttestation/certifyInfo}} is a TPMS_ATTEST structure with the `extraData` field set to the concatenation
-        of {{WebAuthnAttestation/authenticatorData}} and {{WebAuthnAttestation/clientData}}.
+        of {{AuthenticationAttestation/authenticatorData}} and {{AuthenticationAttestation/clientData}}.
     - If {{TpmAttestation/x5c}} contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify that the
-        value of this extension matches the AAGUID in the {{WebAuthnAttestation/authenticatorData}}.
+        value of this extension matches the AAGUID in the {{AuthenticationAttestation/authenticatorData}}.
 
 
 ### TPM attestation statement certificate requirements ### {#tpm-cert-requirements}

--- a/index.bs
+++ b/index.bs
@@ -74,7 +74,7 @@ the existence, of credentials scoped to other [RPS].
 [RPS] employ the <a>Web Authentication API</a> during two distinct, but related, <a>ceremonies</a> involving a user. The first
 is <a>Registration</a>, where a <a>scoped credential</a> is created on an <a>authenticator</a>, and associated by a <a>[RP]</a>
 with the present user's account (the account may already exist or may be created at this time). The second is
-<a>Authentication</a>, where the <a>[RP]</a> is presented with a <em><a>Authentication Assertion</a></em> proving the presence
+<a>Authentication</a>, where the <a>[RP]</a> is presented with an <em><a>Authentication Assertion</a></em> proving the presence
 and consent of the user who registered the <a>scoped credential</a>. Functionally, the <a>Web Authentication API</a> comprises
 two methods (along with associated data structures): <a>makeCredential()</a> and <a>getAssertion()</a>. The former is used
 during <a>Registration</a> and the latter during <a>Authentication</a>.
@@ -290,7 +290,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
 	implies use of key material managed by the authenticator.
 
 : <dfn>Authentication Assertion</dfn>
-:: The cryptographically signed {{AuthenticationAssertion}} object returned by an <a>authenticator</a> as the result of a
+:: The cryptographically signed {{AuthenticationAssertion}} object returned by an <a>authenticator</a> as the result of an
 	<a>authenticatorGetAssertion</a> operation.
 
 : <dfn>[WAC]</dfn>


### PR DESCRIPTION
In terms of these issues -- #288 #310 #311 -- regarding our having prefixed some interfaces and dicts with "WebAuthn", @zcorpan suggests [in this comment](https://github.com/w3c/webauthn/issues/311#issuecomment-269247084) to..
> ..[resolve] this by removing "Web" from all API names and spelling out "Authentication" everywhere. 

So, I have crafted up an example of doing that and that is what is in this PR.  

Additionally, a rendered text diff of the current state of this branch, from master, is available here in pdf..

http://kingsmountain.com/doc/diff/diff-webauthn-jeffh-renaming-intfs-dicts-288-2016-12-27-fbec0ac--from--master-491ae9a.pdf

Thoughts?
