### PR TITLE
Highlight the examples as JavaScript and remove non-functional .highlight classes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2085,7 +2085,7 @@ A [RP] simultaneously requests the use of an extension and sets its client argum
 {{ScopedCredentialOptions/extensions}} option to the {{makeCredential()}} or {{getAssertion()}} call. The entry key MUST be the
 extension identifier, and the value MUST be the <a>client argument</a>.
 
-<pre class="example highlight">
+<pre class="example" highlight="js">
     var assertionPromise = credentials.getAssertion(..., /* extensions */ {
         "webauthnExample_foobar": 42
     });
@@ -2142,7 +2142,7 @@ The extension identifier is chosen as `webauthnExample_geo`. The client argument
 extension does not require the <a>[RP]</a> to pass any particular information to the client, other than that it requests the use
 of the extension. The [RP] sets this value in its request for an assertion:
 
-<pre class="highlight">
+<pre highlight="js">
     var assertionPromise =
         credentials.getAssertion("SGFuIFNvbG8gc2hvdCBmaXJzdC4",
             {}, /* Empty filter */
@@ -2152,7 +2152,7 @@ of the extension. The [RP] sets this value in its request for an assertion:
 The extension defines the additional client data to be the client's location, if known, as a GeoJSON [[GeoJSON]] point. The
 client constructs the following client data:
 
-<pre class="highlight">
+<pre highlight="js">
     {
         ...,
         'extensions': {
@@ -2171,7 +2171,7 @@ e.g. specifies that the location shall be encoded as a two-element array of floa
 authenticator does this by including it in the <a>authenticatorData</a>. As an example, authenticator data may be as follows
 (notation taken from [[RFC7049]]):
 
-<pre class="highlight">
+<pre>
     81 (hex)                                    -- Flags, ED and TUP both set.
     20 05 58 1F                                 -- Signature counter
     A1                                          -- CBOR map of one element
@@ -2299,7 +2299,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
 
     An AAGUID is defined as an array containing the globally unique identifier of the authenticator model being sought.
 
-    <pre class="idl highlight">
+    <pre class="idl">
         typedef BufferSource AAGUID;
     </pre>
 
@@ -2372,7 +2372,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
     Servers supporting UVI extensions MUST support a length of up to 32 bytes for the UVI value.
 
     Example for <a>authenticatorData</a> containing one UVI extension
-    <pre class="highlight">
+    <pre>
         ...                                         -- RP ID hash (32 bytes)
         81                                          -- TUP and ED set
         00 00 00 01                                 -- (initial) signature counter
@@ -2415,7 +2415,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
     coordinate representation defined in
     [The W3C Geolocation API Specification](https://dev.w3.org/geo/api/spec-source.html#coordinates_interface).
 
-    <pre class="highlight">
+    <pre>
         ...                                         -- RP ID hash (32 bytes)
         81                                          -- TUP and ED set
         00 00 00 01                                 -- (initial) signature counter
@@ -2484,7 +2484,7 @@ credential. It is intended primarily for [RPS] that wish to tightly control the 
     will be most relevant to the Server to include in the UVM.
 
     Example for <a>authenticatorData</a> containing one UVM extension for a multi-factor authentication instance where 2 factors were used:
-    <pre class="highlight">
+    <pre>
         ...                    -- RP ID hash (32 bytes)
         81                     -- TUP and ED set
         00 00 00 01            -- (initial) signature counter
@@ -2605,7 +2605,7 @@ This is the first-time flow, in which a new credential is created and registered
 
 The sample code for generating and registering a new key follows:
 
-<pre class="example highlight">
+<pre class="example" highlight="js">
     var webauthnAPI = navigator.authentication;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
@@ -2687,7 +2687,7 @@ credential.
 If the [RP] script does not have any hints available (e.g., from locally stored data) to help it narrow the list of credentials,
 then the sample code for performing such an authentication might look like this:
 
-<pre class="example highlight">
+<pre class="example" highlight="js">
     var webauthnAPI = navigator.authentication;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }
@@ -2710,7 +2710,7 @@ On the other hand, if the [RP] script has some hints to help it narrow the list 
 performing such an authentication might look like the following. Note that this sample also demonstrates how to use the
 extension for transaction authorization.
 
-<pre class="example highlight">
+<pre class="example" highlight="js">
     var webauthnAPI = navigator.authentication;
 
     if (!webauthnAPI) { /* Platform not capable. Handle error. */ }


### PR DESCRIPTION
Bikeshed needs a `highlight=language` attribute to highlight code, not just a `class=highlight`.