### PR TITLE
Typo: Fix a linking error after DAA merge.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1558,7 +1558,7 @@ in several ways, including:
     master attestation key (and certificate), and combined with a cloud operated privacy CA, can dynamically generate per origin
     attestation keys and attestation certificates.
 
-- A WebAuthn Authenticator can implement [=direct anonymous attestation=] (see [[FIDOEcdaaAlgorithm]]).  Using this scheme,
+- A WebAuthn Authenticator can implement [=Elliptic Curve based direct anonymous attestation=] (see [[FIDOEcdaaAlgorithm]]).  Using this scheme,
     the authenticator generates a blinded attestation signature.  This allows the [RP] to verify the signature using the [=ECDAA-Issuer public key=], 
     but the attestation signature doesn't serve as a global correlation handle.
 


### PR DESCRIPTION
@equalsJeffH, WDYT? This is currently throwing a linker warning.