### PR TITLE
Fix issue #418 - What extension data is in AuthenticatorAssertionResponse.authenticatorData?

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1283,7 +1283,7 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, as fol
         <td>variable (if present)</td>
         <td>
             Extension-defined [=authenticator data=]. This is a CBOR [[RFC7049]] map with [=extension identifiers=] as keys, and
-            [=authenticator extension inputs=] as values. See [[#extensions]] for details.
+            [=authenticator extension outputs=] as values. See [[#extensions]] for details.
         </td>
     </tr>
 </table>


### PR DESCRIPTION
This changes one word, correcting a single instance of "input" to "output".