### PR TITLE
Add displayName for the user account

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -478,7 +478,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 1. Let |options| be the value of |options|["{{CredentialRequestOptions/scoped}}"].
 
 1. If any of the {{ScopedCredentialEntity/name}} member of |options|.{{MakeCredentialOptions/rp}}, the
-    {{ScopedCredentialEntity/name}} member of |options|.{{MakeCredentialOptions/user}}, or the {{ScopedCredentialEntity/id}}
+    {{ScopedCredentialEntity/name}} member of |options|.{{MakeCredentialOptions/user}},
+    the {{ScopedCredentialUserEntity/detailedName}} member of |options|.{{MakeCredentialOptions/user}},
+    or the {{ScopedCredentialEntity/id}}
     member of |options|.{{MakeCredentialOptions/user}} are [=present|not present=], return a {{TypeError}} [=simple exception=].
 
 1. If the {{MakeCredentialOptions/timeout}} member of |options| is [=present=], check if its value lies within a
@@ -860,13 +862,27 @@ optionally evidence of [=user consent=] to a specific transaction.
     will be used, and thus also the type of asymmetric key pair to be generated, e.g., RSA or Elliptic Curve.
 </div>
 
+## User Account Parameters for Credential Generation (dictionary <dfn dictionary>ScopedCredentialUserEntity</dfn>) ## {#sctn-user-credential-params}
+
+<pre class="idl">
+    dictionary ScopedCredentialUserEntity : ScopedCredentialEntity {
+        DOMString detailedName;
+    };
+</pre>
+
+<div dfn-type="dict-member" dfn-for="ScopedCredentialUserEntity">
+    This dictionary is used to supply additional parameters about the user account when creating a new credential.
+
+    The <dfn>detailedName</dfn> member contains a detailed name for the user account (e.g., "john.p.smith@example.com").
+</div>
+
 
 ## Options for Credential Creation (dictionary <dfn dictionary>MakeCredentialOptions</dfn>) ## {#dictionary-makecredentialoptions}
 
 <xmp class="idl">
     dictionary MakeCredentialOptions {
         required ScopedCredentialEntity rp;
-        required ScopedCredentialEntity user;
+        required ScopedCredentialUserEntity user;
 
         required BufferSource                         challenge;
         required sequence<ScopedCredentialParameters> parameters;
@@ -892,8 +908,9 @@ optionally evidence of [=user consent=] to a specific transaction.
     :   <dfn>user</dfn>
     ::  This member contains data about the user account for which the [=relying party=] is requesting attestation.
 
-        Its value's {{ScopedCredentialEntity/name}} member is required, and contains a friendly name for the user account (e.g.
-        "john.p.smith@example.com", or "John P. Smith").
+        Its value's {{ScopedCredentialEntity/name}} member is required, and contains a friendly name for the user account (e.g. "John P. Smith").
+
+        Its value's {{ScopedCredentialEntity/detailedName}} member is required, and contains a detailed name for the user account (e.g., "john.p.smith@example.com").
 
         Its value's {{ScopedCredentialEntity/id}} member is required, and contains an identifier for the account, specified by
         the [=relying party=]. This is not meant to be displayed to the user, but is used by the relying party to control the
@@ -2989,6 +3006,7 @@ The sample code for generating and registering a new key follows:
       user: {
         id: "1098237235409872"
         name: "John P. Smith",
+	detailedName: "john.p.smith@example.com",
         icon: "https://pics.acme.com/00/p/aBjjjpqPb.png"
       },
 

--- a/index.bs
+++ b/index.bs
@@ -479,7 +479,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. If any of the {{ScopedCredentialEntity/name}} member of |options|.{{MakeCredentialOptions/rp}}, the
     {{ScopedCredentialEntity/name}} member of |options|.{{MakeCredentialOptions/user}},
-    the {{ScopedCredentialUserEntity/detailedName}} member of |options|.{{MakeCredentialOptions/user}},
+    the {{ScopedCredentialUserEntity/displayName}} member of |options|.{{MakeCredentialOptions/user}},
     or the {{ScopedCredentialEntity/id}}
     member of |options|.{{MakeCredentialOptions/user}} are [=present|not present=], return a {{TypeError}} [=simple exception=].
 
@@ -866,14 +866,14 @@ optionally evidence of [=user consent=] to a specific transaction.
 
 <pre class="idl">
     dictionary ScopedCredentialUserEntity : ScopedCredentialEntity {
-        DOMString detailedName;
+        DOMString displayName;
     };
 </pre>
 
 <div dfn-type="dict-member" dfn-for="ScopedCredentialUserEntity">
     This dictionary is used to supply additional parameters about the user account when creating a new credential.
 
-    The <dfn>detailedName</dfn> member contains a detailed name for the user account (e.g., "john.p.smith@example.com").
+    The <dfn>displayName</dfn> member contains a friendly name for the user account (e.g., "John P. Smith").
 </div>
 
 
@@ -908,9 +908,10 @@ optionally evidence of [=user consent=] to a specific transaction.
     :   <dfn>user</dfn>
     ::  This member contains data about the user account for which the [=relying party=] is requesting attestation.
 
-        Its value's {{ScopedCredentialEntity/name}} member is required, and contains a friendly name for the user account (e.g. "John P. Smith").
+        Its value's {{ScopedCredentialEntity/name}} member is required, and contains a name for the user account 
+        (e.g., "john.p.smith@example.com" or "+14255551234").
 
-        Its value's {{ScopedCredentialEntity/detailedName}} member is required, and contains a detailed name for the user account (e.g., "john.p.smith@example.com").
+        Its value's {{ScopedCredentialEntity/displayName}} member is required, and contains a friendly name for the user account (e.g., "John P. Smith").
 
         Its value's {{ScopedCredentialEntity/id}} member is required, and contains an identifier for the account, specified by
         the [=relying party=]. This is not meant to be displayed to the user, but is used by the relying party to control the
@@ -3005,8 +3006,8 @@ The sample code for generating and registering a new key follows:
       // User:
       user: {
         id: "1098237235409872"
-        name: "John P. Smith",
-	detailedName: "john.p.smith@example.com",
+        name: "john.p.smith@example.com",
+        displayName: "John P. Smith",
         icon: "https://pics.acme.com/00/p/aBjjjpqPb.png"
       },
 


### PR DESCRIPTION
This addresses the missing displayName issue being discussed in issue #413 .  The `name` is actually the display name, so isn't missing.  It's the detailed name that was missing.  This PR restores it.