### PR TITLE
Remove UV bit from authenticatorData

### DIFF
--- a/images/fido-signature-formats-figure1.svg
+++ b/images/fido-signature-formats-figure1.svg
@@ -107,7 +107,7 @@
 	<line class="st0" x1="78.5" y1="42.5" x2="118.2" y2="68"/>
 	<line class="st0" x1="208.9" y1="42.5" x2="169.2" y2="68"/>
 	<text transform="matrix(1 0 0 1 75 12.5)" class="st1 st7">7</text>
-	<text transform="matrix(1 0 0 1 180.4563 31.03)" class="st1 st5">UV</text>
 	<text transform="matrix(1 0 0 1 166.6988 31.2833)" class="st1 st3">0</text>
+	<text transform="matrix(1 0 0 1 183.6988 31.2833)" class="st1 st3">0</text>
 </g>
 </svg>

--- a/index.bs
+++ b/index.bs
@@ -1305,8 +1305,7 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, as fol
         <td>
             Flags (bit 0 is the least significant bit):
             - Bit 0: [=Test of User Presence=] (`TUP`) result.
-            - Bit 1: [=User Verified=] (`UV`) result. 
-            - Bits 2-5: Reserved for future use (`RFU`).
+            - Bits 1-5: Reserved for future use (`RFU`).
             - Bit 6: [=Attestation data=] included (`AT`). Indicates whether the authenticator added [=attestation data=].
             - Bit 7: Extension data included (`ED`). Indicates if the [=authenticator data=] has extensions.
         </td>
@@ -1337,13 +1336,8 @@ does not change between operations but instead remains the same for the lifetime
 by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the RP ID associated with the
 requested credential exactly matches the RP ID supplied by the client.
 
-Bit 0: Test of User Presence (`TUP`) Flag. This flag bit is set if the [=authenticator=] obtained a positive [=Test of User Presence=] result during either an [=authenticatorMakeCredential=] or an [=authenticatorGetAssertion=] operation.
-
-Bit 1: User Verified (`UV`) Flag. This flag bit is set if the [=authenticator=] is both capable of [=user verification=], 
-and obtained a positive [=user verification=] result during either an [=authenticatorMakeCredential=] or an [=authenticatorGetAssertion=] operation. If the [=authenticator=]'s [=user verification=] procedure also obtained a positive 
-[=Test of User Presence] result, the `TUP` flag would be set as well. 
-
-Bit 2-5: RFU bits. The `RFU` bits SHALL be set to zero.
+The `TUP` flag SHALL be set if and only if the authenticator detected a user through an authenticator specific gesture. The `RFU` bits
+SHALL be set to zero.
 
 For attestation signatures, the authenticator MUST set the AT flag and include the [=attestation data=]. For authentication
 signatures, the AT flag MUST NOT be set and the [=attestation data=] MUST NOT be included.


### PR DESCRIPTION
This PR removes the UV bit from authenticatorData, reversing PR https://github.com/w3c/webauthn/pull/409