### PR TITLE
Omitted default abstract header

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -37,7 +37,7 @@ Abstract: This specification defines an API enabling the creation and use of str
  [=Authenticators=] provide cryptographic proof of their properties to [=relying parties=] via [=attestation=]. This
  specification also describes the functional model for WebAuthn conformant [=authenticators=], including their signature and
  [=attestation=] functionality.
-Boilerplate: omit conformance, omit feedback-header
+Boilerplate: omit conformance, omit feedback-header, omit abstract-header
 Markup Shorthands: css off, markdown on
 </pre>
 


### PR DESCRIPTION
Default abstract header causes two abstract headers to appear.
![issue](https://cloud.githubusercontent.com/assets/1636116/26789083/4e8dfee8-4a63-11e7-9981-63c844c48dd7.png)

Added omit to boilerplate options.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/herrjemand/webauthn/ommited-default-abstract-header.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/46b3933...herrjemand:174656d.html)