### PR TITLE
remove "required" from PublicKeyCredentialDescriptor.id 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -646,7 +646,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
     1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakeCredentialOptions/excludeCredentials}}</code>:
         1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
             mentioned in <code>|C|.{{transports}}</code>, the client MAY [=continue=].
-        1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
+        1. If <code>|C|.{{type}}</code> is "public-key" and the <code>|C|.{{id}}</code> is present, [=list/Append=] |C| to 
+            |excludeCredentialDescriptorList|. 
     1. [=In parallel=], invoke the [=authenticatorMakeCredential=] operation on |authenticator| with |rpId|,
         |clientDataHash|, |options|.{{MakeCredentialOptions/rp}}, |options|.{{MakeCredentialOptions/user}},
         |normalizedParameters|, |excludeCredentialDescriptorList|, and |authenticatorExtensions| as parameters.
@@ -821,9 +822,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
         platform-specific procedure to determine which, if any, [=public key credentials=] described by
         <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are bound to this |authenticator|, by
         matching with |rpId|,
-        <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>, and
-        <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/type}}</code>.
-        Set |allowCredentialDescriptorList| to this filtered list.
+        <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/type}}</code>, and
+        <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>.
+        If the code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/type}}</code>
+        is "public-key", <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>
+        must be present. Set |allowCredentialDescriptorList| to this filtered list.
 
     1. If |allowCredentialDescriptorList| 
         <dl class="switch">
@@ -1302,7 +1305,7 @@ following Web IDL.
 <xmp class="idl">
     dictionary PublicKeyCredentialDescriptor {
         required PublicKeyCredentialType      type;
-        required BufferSource                 id;
+        BufferSource                          id;
         sequence<AuthenticatorTransport>      transports;
     };
 </xmp>
@@ -1314,7 +1317,8 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialDescriptor">
     The <dfn>type</dfn> member contains the type of the credential the caller is referring to.
 
-    The <dfn>id</dfn> member contains the identifier of the credential that the caller is referring to.
+    The <dfn>id</dfn> member contains the identifier of the credential that the caller is referring to. If the type of the
+        credential is "public-key", the id parameter is required. 
 </div>
 
 


### PR DESCRIPTION
Addresses https://github.com/w3c/webauthn/issues/245

1. Remove the "required" keyword from PublicKeyCredentialDescriptor.id, which is a member of the allowCredentials and excludeCredentials dictionary.
2. Add requirements to the algorithm that "if the credential type is 'PublicKeyCredential', the id is required."

The benefit of the PR is that we keep a door open for future credential types. If there are multiple credential types, the developer can select credentials based on types.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/AngeloKai/webauthn/angelo-removeRequired.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/119dd51...AngeloKai:495a464.html)