### PR TITLE
Merge {#sample-scenarios} section with the {#usecase} section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -126,49 +126,176 @@ as Universal Serial Bus (USB), Bluetooth Low Energy (BLE) or Near Field Communic
 
 ## Use Cases ## {#use-cases}
 
-The below use case scenarios illustrate use of two very different types of [=authenticators=], as well as outline further
-scenarios. Additional scenarios, including sample code, are given later in [[#sample-scenarios]].
+The following use case scenarios illustrate a typical flow involving registration and authentication with the sample code 
+included. 
 
-### Registration ### {#usecase-registration}
+### Regirstration ### {#usecase-registration}
 
-- On a phone:
-    * User navigates to example.com in a browser and signs in to an existing account using whatever method they have been using
-        (possibly a legacy method such as a password), or creates a new account.
-    * The phone prompts, "Do you want to register this device with example.com?"
-    * User agrees.
-    * The phone prompts the user for a previously configured [=authorization gesture=] (PIN, biometric, etc.); the user
-        provides this.
-    * Website shows message, "Registration complete."
+This is the first-time flow, in which a new credential is created and registered with the server.
+
+1. The user visits example.com, which serves up a script. At this point, the user must already be logged in using a legacy
+    username and password, or additional authenticator, or other means acceptable to the [=[RP]=].
+
+2. The [=[RP]=] script runs the code snippet below.
+
+3. The client platform searches for and locates the authenticator.
+
+4. The client platform connects to the authenticator, performing any pairing actions if necessary.
+
+5. The authenticator shows appropriate UI for the user to select the authenticator on which the new credential will be
+    created, and obtains a biometric or other authorization gesture from the user.
+
+6. The authenticator returns a response to the client platform, which in turn returns a response to the [=[RP]=] script. If
+    the user declined to select an authenticator or provide authorization, an appropriate error is returned.
+
+7. If a new credential was created,
+    - The [=[RP]=] script sends the newly generated [=credential public key=] to the server, along with additional information
+        such as attestation regarding the provenance and characteristics of the authenticator.
+    - The server stores the [=credential public key=] in its database and associates it with the user as well as with the
+        characteristics of authentication indicated by attestation, also storing a friendly name for later use.
+    - The script may store data such as the credential ID in local storage, to improve future UX by narrowing the choice of
+        credential for the user.
+
+The sample code for generating and registering a new key follows:
+
+<pre class="example" highlight="js">
+    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+
+    var publicKey = {
+      challenge: Uint8Array.from(window.atob("PGifxAoBwCkWkm4b1CiIl5otCphiIh6MijdjbWFjomA="), c=>c.charCodeAt(0)),
+
+      // Relying Party:
+      rp: {
+        name: "Acme"
+      },
+
+      // User:
+      user: {
+        id: "1098237235409872"
+        name: "john.p.smith@example.com",
+        displayName: "John P. Smith",
+        icon: "https://pics.acme.com/00/p/aBjjjpqPb.png"
+      },
+
+      // This Relying Party will accept either an ES256 or RS256 credential, but
+      // prefers an ES256 credential.
+      parameters: [
+        {
+          type: "public-key",
+          algorithm: "ES256",
+        },
+        {
+          type: "public-key",
+          algorithm: "RS256",
+        },
+      ],
+
+      timeout: 60000,  // 1 minute
+      excludeCredentials: [], // No exclude list of PKCredDescriptors
+      extensions: {"webauthn.location": true}  // Include location information
+                                               // in attestation
+    };
+
+    // Note: The following call will cause the authenticator to display UI.
+    navigator.credentials.create({ publicKey })
+      .then(function (newCredentialInfo) {
+        // Send new credential info to server for verification and registration.
+      }).catch(function (err) {
+        // No acceptable authenticator or user refused consent. Handle appropriately.
+      });
+</pre>
 
 
 ### Authentication ### {#usecase-authentication}
 
-- On a laptop or desktop:
-    * User navigates to example.com in a browser, sees an option to "Sign in with your phone."
-    * User chooses this option and gets a message from the browser, "Please complete this action on your phone."
+This is the flow when a user with an already registered credential visits a website and wants to authenticate using the
+credential.
 
-- Next, on their phone:
-    * User sees a discrete prompt or notification, "Sign in to example.com."
-    * User selects this prompt / notification.
-    * User is shown a list of their example.com identities, e.g., "Sign in as Alice / Sign in as Bob."
-    * User picks an identity, is prompted for an [=authorization gesture=] (PIN, biometric, etc.) and provides this.
+1. The user visits example.com, which serves up a script.
 
-- Now, back on the laptop:
-    * Web page shows that the selected user is signed-in, and navigates to the signed-in page.
+2. The script asks the client platform for an Authentication Assertion, providing as much information as possible to narrow
+    the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after
+    registration, or by other means such as prompting the user for a username.
 
+3. The [=[RP]=] script runs one of the code snippets below.
 
-### Other use cases and configurations ### {#other-configurations}
+4. The client platform searches for and locates the authenticator.
 
-A variety of additional use cases and configurations are also possible, including (but not limited to):
+5. The client platform connects to the authenticator, performing any pairing actions if necessary.
 
-- A user navigates to example.com on their laptop, is guided through a flow to create and register a credential on their phone.
+6. The authenticator presents the user with a notification that their attention is required. On opening the
+    notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided
+    when creating the credentials, along with some information on the [=origin=] that is requesting these keys.
 
-- A user obtains an discrete, [=roaming authenticator=], such as a "fob" with USB or USB+NFC/BLE connectivity options, loads
-    example.com in their browser on a laptop or phone, and is guided though a flow to create and register a credential on the
-    fob.
+7. The authenticator obtains a biometric or other authorization gesture from the user.
 
-- A [=[RP]=] prompts the user for their [=authorization gesture=] in order to authorize a single transaction, such as a payment
-    or other financial transaction.
+8. The authenticator returns a response to the client platform, which in turn returns a response to the [=[RP]=] script.
+    If the user declined to select a credential or provide an authorization, an appropriate error is returned.
+
+9. If an assertion was successfully generated and returned,
+    - The script sends the assertion to the server.
+    - The server examines the assertion, extracts the credential ID, looks up the registered
+        credential public key it is database, and verifies the assertion's authentication signature.
+        If valid, it looks up the identity associated with the assertion's credential ID; that
+        identity is now authenticated. If the credential ID is not recognized by the server (e.g.,
+        it has been deregistered due to inactivity) then the authentication has failed; each [=[RP]=]
+        will handle this in its own way.
+    - The server now does whatever it would otherwise do upon successful authentication -- return a success page, set
+        authentication cookies, etc.
+
+If the [=[RP]=] script does not have any hints available (e.g., from locally stored data) to help it narrow the list of
+credentials, then the sample code for performing such an authentication might look like this:
+
+<pre class="example" highlight="js">
+    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+
+    var options = {
+                    challenge: new TextEncoder().encode("climb a mountain"),
+                    timeout: 60000,  // 1 minute
+                    allowCredentials: [{ type: "public-key" }]
+                  };
+
+    navigator.credentials.get({ "publicKey": options })
+        .then(function (assertion) {
+        // Send assertion to server for verification
+    }).catch(function (err) {
+        // No acceptable credential or user refused consent. Handle appropriately.
+    });
+</pre>
+
+On the other hand, if the [=[RP]=] script has some hints to help it narrow the list of credentials, then the sample code for
+performing such an authentication might look like the following. Note that this sample also demonstrates how to use the
+extension for transaction authorization.
+
+<pre class="example" highlight="js">
+    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+
+    var encoder = new TextEncoder();
+    var acceptableCredential1 = {
+        type: "public-key",
+        id: encoder.encode("!!!!!!!hi there!!!!!!!\n")
+    };
+    var acceptableCredential2 = {
+        type: "public-key",
+        id: encoder.encode("roses are red, violets are blue\n")
+    };
+
+    var options = {
+                    challenge: encoder.encode("climb a mountain"),
+                    timeout: 60000,  // 1 minute
+                    allowCredentials: [acceptableCredential1, acceptableCredential2];
+                    extensions: { 'webauthn.txauth.simple':
+                       "Wave your hands in the air like you just don't care" };
+                  };
+
+    navigator.credentials.get({ "publicKey": options })
+        .then(function (assertion) {
+        // Send assertion to server for verification
+    }).catch(function (err) {
+        // No acceptable credential or user refused consent. Handle appropriately.
+    });
+</pre>
+
 
 # Conformance # {#conformance}
 
@@ -3152,213 +3279,6 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
     The user verification method extension returns to the Webauthn relying party which user verification methods (factors) were
     used for the WebAuthn operation.
 - Specification Document: Section [[#sctn-uvm-extension]] of this specification
-
-# Sample scenarios # {#sample-scenarios}
-
-[INFORMATIVE]
-
-In this section, we walk through some events in the lifecycle of a [=public key credential=], along with the corresponding
-sample code for using this API. Note that this is an example flow, and does not limit the scope of how the API can be used.
-
-As was the case in earlier sections, this flow focuses on a use case involving an external first-factor [=authenticator=]
-with its own display. One example of such an authenticator would be a smart phone. Other authenticator types are also supported
-by this API, subject to implementation by the platform. For instance, this flow also works without modification for the case of
-an authenticator that is embedded in the client platform. The flow also works for the case of an authenticator without
-its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the client platform
-needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the client
-platform to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.
-
-
-## Registration ## {#sample-registration}
-
-This is the first-time flow, in which a new credential is created and registered with the server.
-
-1. The user visits example.com, which serves up a script. At this point, the user must already be logged in using a legacy
-    username and password, or additional authenticator, or other means acceptable to the [=[RP]=].
-
-2. The [=[RP]=] script runs the code snippet below.
-
-3. The client platform searches for and locates the authenticator.
-
-4. The client platform connects to the authenticator, performing any pairing actions if necessary.
-
-5. The authenticator shows appropriate UI for the user to select the authenticator on which the new credential will be
-    created, and obtains a biometric or other authorization gesture from the user.
-
-6. The authenticator returns a response to the client platform, which in turn returns a response to the [=[RP]=] script. If
-    the user declined to select an authenticator or provide authorization, an appropriate error is returned.
-
-7. If a new credential was created,
-    - The [=[RP]=] script sends the newly generated [=credential public key=] to the server, along with additional information
-        such as attestation regarding the provenance and characteristics of the authenticator.
-    - The server stores the [=credential public key=] in its database and associates it with the user as well as with the
-        characteristics of authentication indicated by attestation, also storing a friendly name for later use.
-    - The script may store data such as the credential ID in local storage, to improve future UX by narrowing the choice of
-        credential for the user.
-
-The sample code for generating and registering a new key follows:
-
-<pre class="example" highlight="js">
-    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
-
-    var publicKey = {
-      challenge: Uint8Array.from(window.atob("PGifxAoBwCkWkm4b1CiIl5otCphiIh6MijdjbWFjomA="), c=>c.charCodeAt(0)),
-
-      // Relying Party:
-      rp: {
-        name: "Acme"
-      },
-
-      // User:
-      user: {
-        id: "1098237235409872"
-        name: "john.p.smith@example.com",
-        displayName: "John P. Smith",
-        icon: "https://pics.acme.com/00/p/aBjjjpqPb.png"
-      },
-
-      // This Relying Party will accept either an ES256 or RS256 credential, but
-      // prefers an ES256 credential.
-      parameters: [
-        {
-          type: "public-key",
-          algorithm: "ES256",
-        },
-        {
-          type: "public-key",
-          algorithm: "RS256",
-        },
-      ],
-
-      timeout: 60000,  // 1 minute
-      excludeCredentials: [], // No exclude list of PKCredDescriptors
-      extensions: {"webauthn.location": true}  // Include location information
-                                               // in attestation
-    };
-
-    // Note: The following call will cause the authenticator to display UI.
-    navigator.credentials.create({ publicKey })
-      .then(function (newCredentialInfo) {
-        // Send new credential info to server for verification and registration.
-      }).catch(function (err) {
-        // No acceptable authenticator or user refused consent. Handle appropriately.
-      });
-</pre>
-
-
-## Authentication ## {#sample-authentication}
-
-This is the flow when a user with an already registered credential visits a website and wants to authenticate using the
-credential.
-
-1. The user visits example.com, which serves up a script.
-
-2. The script asks the client platform for an Authentication Assertion, providing as much information as possible to narrow
-    the choice of acceptable credentials for the user. This may be obtained from the data that was stored locally after
-    registration, or by other means such as prompting the user for a username.
-
-3. The [=[RP]=] script runs one of the code snippets below.
-
-4. The client platform searches for and locates the authenticator.
-
-5. The client platform connects to the authenticator, performing any pairing actions if necessary.
-
-6. The authenticator presents the user with a notification that their attention is required. On opening the
-    notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided
-    when creating the credentials, along with some information on the [=origin=] that is requesting these keys.
-
-7. The authenticator obtains a biometric or other authorization gesture from the user.
-
-8. The authenticator returns a response to the client platform, which in turn returns a response to the [=[RP]=] script.
-    If the user declined to select a credential or provide an authorization, an appropriate error is returned.
-
-9. If an assertion was successfully generated and returned,
-    - The script sends the assertion to the server.
-    - The server examines the assertion, extracts the credential ID, looks up the registered
-        credential public key it is database, and verifies the assertion's authentication signature.
-        If valid, it looks up the identity associated with the assertion's credential ID; that
-        identity is now authenticated. If the credential ID is not recognized by the server (e.g.,
-        it has been deregistered due to inactivity) then the authentication has failed; each [=[RP]=]
-        will handle this in its own way.
-    - The server now does whatever it would otherwise do upon successful authentication -- return a success page, set
-        authentication cookies, etc.
-
-If the [=[RP]=] script does not have any hints available (e.g., from locally stored data) to help it narrow the list of
-credentials, then the sample code for performing such an authentication might look like this:
-
-<pre class="example" highlight="js">
-    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
-
-    var options = {
-                    challenge: new TextEncoder().encode("climb a mountain"),
-                    timeout: 60000,  // 1 minute
-                    allowCredentials: [{ type: "public-key" }]
-                  };
-
-    navigator.credentials.get({ "publicKey": options })
-        .then(function (assertion) {
-        // Send assertion to server for verification
-    }).catch(function (err) {
-        // No acceptable credential or user refused consent. Handle appropriately.
-    });
-</pre>
-
-On the other hand, if the [=[RP]=] script has some hints to help it narrow the list of credentials, then the sample code for
-performing such an authentication might look like the following. Note that this sample also demonstrates how to use the
-extension for transaction authorization.
-
-<pre class="example" highlight="js">
-    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
-
-    var encoder = new TextEncoder();
-    var acceptableCredential1 = {
-        type: "public-key",
-        id: encoder.encode("!!!!!!!hi there!!!!!!!\n")
-    };
-    var acceptableCredential2 = {
-        type: "public-key",
-        id: encoder.encode("roses are red, violets are blue\n")
-    };
-
-    var options = {
-                    challenge: encoder.encode("climb a mountain"),
-                    timeout: 60000,  // 1 minute
-                    allowCredentials: [acceptableCredential1, acceptableCredential2];
-                    extensions: { 'webauthn.txauth.simple':
-                       "Wave your hands in the air like you just don't care" };
-                  };
-
-    navigator.credentials.get({ "publicKey": options })
-        .then(function (assertion) {
-        // Send assertion to server for verification
-    }).catch(function (err) {
-        // No acceptable credential or user refused consent. Handle appropriately.
-    });
-</pre>
-
-
-## Decommissioning ## {#sample-decommissioning}
-
-The following are possible situations in which decommissioning a credential might be desired. Note that all of these are
-handled on the server side and do not need support from the API specified here.
-
-- Possibility #1 -- user reports the credential as lost.
-    * User goes to server.example.net, authenticates and follows a link to report a lost/stolen device.
-    * Server returns a page showing the list of registered credentials with friendly names as configured during registration.
-    * User selects a credential and the server deletes it from its database.
-    * In future, the [=[RP]=] script does not specify this credential in any list of acceptable credentials, and assertions
-        signed by this credential are rejected.
-
-- Possibility #2 -- server deregisters the credential due to inactivity.
-    * Server deletes credential from its database during maintenance activity.
-    * In the future, the [=[RP]=] script does not specify this credential in any list of acceptable credentials, and assertions
-        signed by this credential are rejected.
-
-- Possibility #3 -- user deletes the credential from the device.
-    * User employs a device-specific method (e.g., device settings UI) to delete a credential from their device.
-    * From this point on, this credential will not appear in any selection prompts, and no assertions can be generated with it.
-    * Sometime later, the server deregisters this credential due to inactivity.
-
 
 
 


### PR DESCRIPTION
Addresses https://github.com/w3c/webauthn/issues/301. I removed a number of the use cases that aren't intended for Level 1 of the API. We can add an explainer-style document titled future use case to the spec for those use cases. The removal will clarify things for readers who aren't familiar with the API. 
