### PR TITLE
add requireResidentKey param to the invocation step of authenticatorMakeCredential

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,8 @@ bikeshed echidna --u USERNAME --p PASSWORD --d DECISION_URL
 This will create a tarball of the HTML and images, and upload to Echidna. Status of the request can be tracked through the W3C API [as described in the Echidna documentation](https://github.com/w3c/echidna/wiki/How-to-use-Echidna). Note that on Windows, this will give an error about failing to delete a temporary file because it is in use by a different process. This error is harmless; it happens after the submission has completed.
 
 Overall info on echidna is here: https://github.com/w3c/echidna/wiki and here https://labs.w3.org/echidna/.
+
+# Taking meeting minutes
+
+* [Scribe instructions from the W3C Guidebook](https://www.w3.org/2008/04/scribe.html)
+* [Alternate instructions from the XML Security WG](https://www.w3.org/2008/xmlsec/Group/Scribe-Instructions.html)

--- a/index.bs
+++ b/index.bs
@@ -1555,8 +1555,8 @@ input parameters:
     preferred. The platform makes a best-effort to create the most preferred credential that it can.
 - An optional list of {{PublicKeyCredentialDescriptor}} objects provided by the [=[RP]=] with the intention that, if any of
     these are known to the authenticator, it should not create a new credential.
-- Extension data created by the client based on the extensions requested by the [=[RP]=], if any.
 - The |requireResidentKey| parameter of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
+- Extension data created by the client based on the extensions requested by the [=[RP]=], if any.
 
 When this operation is invoked, the authenticator must perform the following procedure:
 - Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code


### PR DESCRIPTION
fixes https://github.com/w3c/webauthn/issues/485


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/AngeloKai/webauthn/angelo-addParam.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/119dd51...AngeloKai:369cab2.html)