### PR TITLE
Renamed MakeCredentialOptions to MakePublicKeyCredentialOptions and parameters to pubKeyCredParams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -488,7 +488,7 @@ the {{CredentialCreationOptions}} dictionary as follows:
 
 <pre class="idl">
     partial dictionary CredentialCreationOptions {
-        MakeCredentialOptions      publicKey;
+        MakePublicKeyCredentialOptions      publicKey;
     };
 </pre>
 
@@ -522,7 +522,7 @@ This method accepts a single argument:
 <dl dfn-type="argument" dfn-for="PublicKeyCredential/[[Create]](options)">
     :   <dfn>options</dfn>
     ::  This argument is a {{CredentialCreationOptions}} object whose
-        <code>|options|.{{CredentialCreationOptions/publicKey}}</code> member contains a {{MakeCredentialOptions}} object
+        <code>|options|.{{CredentialCreationOptions/publicKey}}</code> member contains a {{MakePublicKeyCredentialOptions}} object
         specifying the desired attributes of the to-be-created [=public key credential=].
 </dl>
 
@@ -532,15 +532,15 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
-1. If any of the {{PublicKeyCredentialEntity/name}} member of |options|.{{MakeCredentialOptions/rp}}, the
-    {{PublicKeyCredentialEntity/name}} member of |options|.{{MakeCredentialOptions/user}},
-    the {{PublicKeyCredentialUserEntity/displayName}} member of |options|.{{MakeCredentialOptions/user}},
+1. If any of the {{PublicKeyCredentialEntity/name}} member of |options|.{{MakePublicKeyCredentialOptions/rp}}, the
+    {{PublicKeyCredentialEntity/name}} member of |options|.{{MakePublicKeyCredentialOptions/user}},
+    the {{PublicKeyCredentialUserEntity/displayName}} member of |options|.{{MakePublicKeyCredentialOptions/user}},
     or the {{PublicKeyCredentialEntity/id}}
-    member of |options|.{{MakeCredentialOptions/user}} are [=present|not present=], return a {{TypeError}} [=simple exception=].
+    member of |options|.{{MakePublicKeyCredentialOptions/user}} are [=present|not present=], return a {{TypeError}} [=simple exception=].
 
-1. If the {{MakeCredentialOptions/timeout}} member of |options| is [=present=], check if its value lies within a
+1. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present=], check if its value lies within a
     reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set
-    |adjustedTimeout| to this adjusted value. If the {{MakeCredentialOptions/timeout}} member of |options| is [=present|not
+    |adjustedTimeout| to this adjusted value. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present|not
     present=], then set |adjustedTimeout| to a platform-specific default.
 
 1. Let |global| be the {{PublicKeyCredential}}'s [=interface object=]'s [=global object|environment settings object's global
@@ -562,24 +562,24 @@ When this method is invoked, the user agent MUST execute the following algorithm
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to compile w/o errors
 -->
     <li id='CreateCred-DetermineRpId'>
-       If |options|.{{MakeCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}} is [=present=]:
+       If |options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}} is [=present=]:
 
-        1. If |options|.{{MakeCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}} [=is not a registrable domain suffix of 
+        1. If |options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}} [=is not a registrable domain suffix of 
             and is not equal to=] |effectiveDomain|, return a {{DOMException}} whose name is "{{SecurityError}}", and terminate
             this algorithm.
 
-        1. Set |rpId| to |options|.{{MakeCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}}.
+        1. Set |rpId| to |options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}}.
 
             Note: |rpId| represents the caller's [=RP ID=]. The [=RP ID=] defaults to being the caller's [=environment settings
             object/origin=]'s [=effective domain=] unless the caller has explicitly set
-            |options|.{{MakeCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}} when calling
+            |options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialEntity/id}} when calling
             {{CredentialsContainer/create()}}.
     </li>
 
 1. Let |normalizedParameters| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and a
     [=dictionary=] type (as returned by [=normalizing an algorithm=]).
 
-1. [=list/For each=] |current| of |options|.{{MakeCredentialOptions/parameters}}:
+1. [=list/For each=] |current| of |options|.{{MakePublicKeyCredentialOptions/pubKeyCredParams}}:
     1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
         by this implementation, then [=continue=].
     1. Let |normalizedAlgorithm| be the result of [=normalizing an algorithm=] [[!WebCryptoAPI]], with |alg| set to
@@ -588,14 +588,14 @@ When this method is invoked, the user agent MUST execute the following algorithm
     1. [=list/Append=] the pair of <code>|current|.{{PublicKeyCredentialParameters/type}}</code> and |normalizedAlgorithm| to
         |normalizedParameters|.
 
-1. If |normalizedParameters| [=list/is empty=] and |options|.{{MakeCredentialOptions/parameters}} [=list/is not empty=],
+1. If |normalizedParameters| [=list/is empty=] and |options|.{{MakePublicKeyCredentialOptions/pubKeyCredParams}} [=list/is not empty=],
     cancel the timer started in step 2, return a {{DOMException}} whose name is "{{NotSupportedError}}", and terminate this
     algorithm.
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
 
-1. If the {{MakeCredentialOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
-    |extensionId| → |clientExtensionInput| of <code>|options|.{{MakeCredentialOptions/extensions}}</code>:
+1. If the {{MakePublicKeyCredentialOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
+    |extensionId| → |clientExtensionInput| of <code>|options|.{{MakePublicKeyCredentialOptions/extensions}}</code>:
     1. If |extensionId| is not supported by this client platform or is not a [=registration extension=], then [=continue=].
 
     1. [=map/Set=] |clientExtensions|[|extensionId|] to |clientExtensionInput|.
@@ -609,7 +609,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |collectedClientData| be a new {{CollectedClientData}} instance whose fields are:
     : {{CollectedClientData/challenge}}
-    :: The [=base64url encoding=] of |options|.{{MakeCredentialOptions/challenge}}.
+    :: The [=base64url encoding=] of |options|.{{MakePublicKeyCredentialOptions/challenge}}.
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/hashAlgorithm}}
@@ -634,7 +634,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 1. If |currentlyAvailableAuthenticators| [=list/is empty=], return a {{DOMException}} whose name is
     "{{NotFoundError}}", and terminate this algorithm.
 
-1. If |options|.{{MakeCredentialOptions/authenticatorSelection}} is [=present|present=], iterate through
+1. If |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} is [=present|present=], iterate through
         |currentlyAvailableAuthenticators| and do the following [=set/for each=] |authenticator|:
     1. If {{AuthenticatorSelectionCriteria/attachment}} is [=present|present=] and its value is not equal
         to |authenticator|'s attachment modality, [=iteration/continue=].
@@ -649,12 +649,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. [=set/For each=] |authenticator| in |currentlyAvailableAuthenticators|:
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
-    1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakeCredentialOptions/excludeCredentials}}</code>:
+    1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakePublicKeyCredentialOptions/excludeCredentials}}</code>:
         1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
             mentioned in <code>|C|.{{transports}}</code>, the client MAY [=continue=].
         1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
     1. [=In parallel=], invoke the [=authenticatorMakeCredential=] operation on |authenticator| with |rpId|,
-        |clientDataHash|, |options|.{{MakeCredentialOptions/rp}}, |options|.{{MakeCredentialOptions/user}},
+        |clientDataHash|, |options|.{{MakePublicKeyCredentialOptions/rp}}, |options|.{{MakePublicKeyCredentialOptions/user}},
         |normalizedParameters|, |excludeCredentialDescriptorList|, and |authenticatorExtensions| as parameters.
     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
@@ -1027,15 +1027,15 @@ optionally evidence of [=user consent=] to a specific transaction.
         a message to the authenticator, which may be sent over a low-bandwidth link.
 </div>
 
-## Options for Credential Creation (dictionary <dfn dictionary>MakeCredentialOptions</dfn>) ## {#dictionary-makecredentialoptions}
+## Options for Credential Creation (dictionary <dfn dictionary>MakePublicKeyCredentialOptions</dfn>) ## {#dictionary-makecredentialoptions}
 
 <xmp class="idl">
-    dictionary MakeCredentialOptions {
+    dictionary MakePublicKeyCredentialOptions {
         required PublicKeyCredentialEntity           rp;
         required PublicKeyCredentialUserEntity       user;
 
         required BufferSource                             challenge;
-        required sequence<PublicKeyCredentialParameters>  parameters;
+        required sequence<PublicKeyCredentialParameters>  pubKeyCredParams;
 
         unsigned long                                timeout;
         sequence<PublicKeyCredentialDescriptor>      excludeCredentials = [];
@@ -1043,7 +1043,7 @@ optionally evidence of [=user consent=] to a specific transaction.
         AuthenticationExtensions                     extensions;
     };
 </xmp>
-<div dfn-type="dict-member" dfn-for="MakeCredentialOptions">
+<div dfn-type="dict-member" dfn-for="MakePublicKeyCredentialOptions">
     :   <dfn>rp</dfn>
     ::  This member contains data about the [=[RP]=] responsible for the request.
 
@@ -1072,7 +1072,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     ::  This member contains a challenge intended to be used for generating the newly created credential's [=attestation
         object=].
 
-    :   <dfn>parameters</dfn>
+    :   <dfn>pubKeyCredParams</dfn>
     ::  This member contains information about the desired properties of the credential to be created. The sequence is ordered
         from most preferred to least preferred. The platform makes a best-effort to create the most preferred credential that it
         can.
@@ -1555,7 +1555,7 @@ input parameters:
 - An optional list of {{PublicKeyCredentialDescriptor}} objects provided by the [=[RP]=] with the intention that, if any of
     these are known to the authenticator, it should not create a new credential.
 - Extension data created by the client based on the extensions requested by the [=[RP]=], if any.
-- The |requireResidentKey| parameter of the |options|.{{MakeCredentialOptions/authenticatorSelection}} dictionary.
+- The |requireResidentKey| parameter of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
 
 When this operation is invoked, the authenticator must perform the following procedure:
 - Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
@@ -1575,8 +1575,8 @@ When this operation is invoked, the authenticator must perform the following pro
     - Generate an identifier for this credential, such that this identifier is globally unique with high probability across all
         credentials with the same type across all authenticators.
     - Associate the credential with the specified [=RP ID=] and the user's account identifier
-        {{MakeCredentialOptions/user}}.{{PublicKeyCredentialEntity/id}}.
-    - Delete any older credentials with the same [=RP ID=] and {{MakeCredentialOptions/user}}.{{PublicKeyCredentialEntity/id}}
+        {{MakePublicKeyCredentialOptions/user}}.{{PublicKeyCredentialEntity/id}}.
+    - Delete any older credentials with the same [=RP ID=] and {{MakePublicKeyCredentialOptions/user}}.{{PublicKeyCredentialEntity/id}}
         that are stored locally by the [=authenticator=].
 - If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
@@ -1985,7 +1985,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 
 13. If the attestation statement |attStmt| verified successfully and is found to be trustworthy, then register the new
     credential with the account that was denoted in the
-    {{PublicKeyCredential/[[Create]](options)/options}}.{{MakeCredentialOptions/user}} passed to
+    {{PublicKeyCredential/[[Create]](options)/options}}.{{MakePublicKeyCredentialOptions/user}} passed to
     {{CredentialsContainer/create()}}, by associating it with the credential ID and credential public key contained in
     |authData|'s [=attestation data=], as appropriate for the [=[RP]=]'s systems.
 
@@ -2620,7 +2620,7 @@ while the [=CBOR=] <dfn>authenticator extension input</dfn> is
 passed from the client to the authenticator for [=authenticator extensions=] during the processing of these calls.
 
 A [=[RP]=] simultaneously requests the use of an extension and sets its [=client extension input=] by including an entry in the
-{{MakeCredentialOptions/extensions}} option to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} call.
+{{MakePublicKeyCredentialOptions/extensions}} option to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} call.
 The entry key is the [=extension identifier=] and the value is the [=client extension input=].
 
 <pre class="example" highlight="js">
@@ -3244,7 +3244,7 @@ The sample code for generating and registering a new key follows:
 
       // This Relying Party will accept either an ES256 or RS256 credential, but
       // prefers an ES256 credential.
-      parameters: [
+      pubKeyCredParams: [
         {
           type: "public-key",
           algorithm: "ES256",
@@ -3252,7 +3252,7 @@ The sample code for generating and registering a new key follows:
         {
           type: "public-key",
           algorithm: "RS256",
-        },
+        }
       ],
 
       timeout: 60000,  // 1 minute


### PR DESCRIPTION
This fixes issue #473 and issue #488 .


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/selfissued/webauthn/mbj-MakeCredentialOptions-renaming.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/4e273b5...selfissued:a816b35.html)