### PR TITLE
PublicKeyCredentialParameters parameter name is alg - not algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3247,11 +3247,11 @@ The sample code for generating and registering a new key follows:
       pubKeyCredParams: [
         {
           type: "public-key",
-          algorithm: "ES256",
+          alg: "ES256",
         },
         {
           type: "public-key",
-          algorithm: "RS256",
+          alg: "RS256",
         }
       ],
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/selfissued/webauthn/mbj-algorithm-to-alg.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/50ea70c...selfissued:5067e9c.html)