### PR TITLE
Restrict WebAuthn support to valid domains

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -550,12 +550,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
     object=]'s [=relevant settings object=]. If |callerOrigin| is an [=opaque origin=], return a {{DOMException}} whose name is
     "{{NotAllowedError}}", and terminate this algorithm.
 
-1. Let |effectiveDomain| be the |callerOrigin|'s [=effective domain=]. If |effectiveDomain| is null,
-    then return a {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
-<!-- PLACEHOLDER - https://github.com/w3c/webauthn/issues/474
-    Note: An [=effective domain=] MUST be a [=valid domain=]. Formats other than [=domain=] -- i.e., [=ipv4 address=],
+1. Let |effectiveDomain| be the |callerOrigin|'s [=effective domain=].
+    If [=effective domain=] is not a [=valid domain=], then return a
+    {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
+
+    Note: [=host=] formats other than [=domain=] -- i.e., [=ipv4 address=],
         [=ipv6 address=], [=opaque host=], or [=empty host=] -- are disallowed.
--->
 
 1. Let |rpId| be |effectiveDomain|.
 
@@ -755,12 +755,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
     object=]'s [=relevant settings object=]. If |callerOrigin| is an [=opaque origin=], return a {{DOMException}} whose name is
     "{{NotAllowedError}}", and terminate this algorithm.
 
-1. Let |effectiveDomain| be the |callerOrigin|'s [=effective domain=]. If |effectiveDomain| is null, then return a
+1. Let |effectiveDomain| be the |callerOrigin|'s [=effective domain=].
+    If [=effective domain=] is not a [=valid domain=], then return a
     {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
-<!-- PLACEHOLDER - see https://github.com/w3c/webauthn/issues/474
-    Note: An [=effective domain=] MUST be a [=valid domain=]. Formats other than [=domain=] -- i.e., [=ipv4 address=],
+
+    Note: [=host=] formats other than [=domain=] -- i.e., [=ipv4 address=],
         [=ipv6 address=], [=opaque host=], or [=empty host=] -- are disallowed.
--->
 
         <li id='GetAssn-DetermineRpId'>
             If |options|.{{PublicKeyCredentialRequestOptions/rpId}} is [=present|not present=], then set |rpId| to

--- a/index.bs
+++ b/index.bs
@@ -554,8 +554,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
     If [=effective domain=] is not a [=valid domain=], then return a
     {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
 
-    Note: [=host=] formats other than [=domain=] -- i.e., [=ipv4 address=],
-        [=ipv6 address=], [=opaque host=], or [=empty host=] -- are disallowed.
+    Note: An [=effective domain=] may resolve to a [=host=], which can be represented in various manners,
+        such as [=domain=], [=ipv4 address=], [=ipv6 address=], [=opaque host=], or [=empty host=].
+        Only the [=domain=] format of [=host=] is allowed here.
 
 1. Let |rpId| be |effectiveDomain|.
 
@@ -759,8 +760,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
     If [=effective domain=] is not a [=valid domain=], then return a
     {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
 
-    Note: [=host=] formats other than [=domain=] -- i.e., [=ipv4 address=],
-        [=ipv6 address=], [=opaque host=], or [=empty host=] -- are disallowed.
+    Note: An [=effective domain=] may resolve to a [=host=], which can be represented in various manners,
+        such as [=domain=], [=ipv4 address=], [=ipv6 address=], [=opaque host=], or [=empty host=].
+        Only the [=domain=] format of [=host=] is allowed here.
 
         <li id='GetAssn-DetermineRpId'>
             If |options|.{{PublicKeyCredentialRequestOptions/rpId}} is [=present|not present=], then set |rpId| to


### PR DESCRIPTION
This fixes #474 .


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/selfissued/webauthn/mbj-valid-domain.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/52b4422...selfissued:76b15b3.html)