### PR TITLE
Register COSE Algorithm numbers for RSASSA-PKCS1-v1_5

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -108,11 +108,6 @@ spec:webidl; type:interface; text:Promise
         "href": "https://www.iana.org/assignments/cose/cose.xhtml#algorithms",
         "title": "IANA CBOR Object Signing and Encryption (COSE) Algorithms Registry",
         "publisher": "IANA"
-    },
-    "IANA-JOSE-ALGS-REG": {
-        "href": "https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms",
-        "title": "IANA JSON Object Signing and Encryption (JOSE) Web Signature and Encryption Algorithms Registry",
-        "publisher": "IANA"
     }
 }
 </pre>
@@ -1448,10 +1443,8 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
 
 <div dfn-type="typedef" dfn-for="AlgorithmIdentifier">
     An {{AlgorithmIdentifier}}'s value is a number or byte string identifying a cryptographic algorithm.
-    The algorithm identifiers MUST be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
-    when available, for instance, <code>-7</code> for "ES256".
-    For algorithms not present in the IANA COSE Algorithms registry, string values from the
-    JSON Web Signature and Encryption Algorithms registry [[!IANA-JOSE-ALGS-REG]] SHOULD be used, for instance "RS256".
+    The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
+    for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>
 
 # WebAuthn Authenticator model # {#authenticator-model}
@@ -3247,6 +3240,29 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
     used for the WebAuthn operation.
 - Specification Document: Section [[#sctn-uvm-extension]] of this specification
 
+## COSE Algorithm Registrations ## {#sctn-cose-alg-reg}
+
+This section registers identifiers for RSASSA-PKCS1-v1_5 [[RFC8017]] algorithms using SHA-2 hash functions in the
+IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]].
+
+- Name: RS256
+- Value: -257
+- Description: RSASSA-PKCS1-v1_5 w/ SHA-256
+- Reference: Section 8.2 of [[RFC8017]]
+- Recommended: No
+    <br/><br/>
+- Name: RS384
+- Value: -258
+- Description: RSASSA-PKCS1-v1_5 w/ SHA-384
+- Reference: Section 8.2 of [[RFC8017]]
+- Recommended: No
+    <br/><br/>
+- Name: RS512
+- Value: -259
+- Description: RSASSA-PKCS1-v1_5 w/ SHA-512
+- Reference: Section 8.2 of [[RFC8017]]
+- Recommended: No
+
 # Sample scenarios # {#sample-scenarios}
 
 [INFORMATIVE]
@@ -3322,7 +3338,7 @@ The sample code for generating and registering a new key follows:
         },
         {
           type: "public-key",
-          alg: "RS256" // Use the IANA JOSE algorithm identifier since "RS256" not in COSE Algorithms registry
+          alg: -257 // Value registered by this specification for "RS256"
         }
       ],
 

--- a/index.bs
+++ b/index.bs
@@ -1438,11 +1438,11 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
 ### Cryptographic Algorithm Identifier (typedef <dfn>AlgorithmIdentifier</dfn>) ### {#alg-identifier}
 
 <pre class="idl">
-    typedef (short or ByteString) AlgorithmIdentifier;
+    typedef long AlgorithmIdentifier;
 </pre>
 
 <div dfn-type="typedef" dfn-for="AlgorithmIdentifier">
-    An {{AlgorithmIdentifier}}'s value is a number or byte string identifying a cryptographic algorithm.
+    An {{AlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
     The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>


### PR DESCRIPTION
The Edge team had asked me if we could use all numeric algorithm identifiers, rather than having mixed numbers and strings.  This is a simplification that makes sense to me.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/selfissued/webauthn/mbj-RSASSA-PKCS1-v1_5.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/73d4461...selfissued:c79e35e.html)