### PR TITLE
Renamed AlgorithmIdentifier to COSEAlgorithmIdentifier to fix name conflict with WebCrypto

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -603,7 +603,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     </li>
 
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
-    an {{AlgorithmIdentifier}}.
+    an {{COSEAlgorithmIdentifier}}.
 
 1. [=list/For each=] |current| of |options|.{{MakePublicKeyCredentialOptions/pubKeyCredParams}}:
     1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
@@ -1068,7 +1068,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 <pre class="idl">
     dictionary PublicKeyCredentialParameters {
         required PublicKeyCredentialType      type;
-        required AlgorithmIdentifier          alg;
+        required COSEAlgorithmIdentifier      alg;
     };
 </pre>
 
@@ -1435,14 +1435,14 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
 </div>
 
 
-### Cryptographic Algorithm Identifier (typedef <dfn>AlgorithmIdentifier</dfn>) ### {#alg-identifier}
+### Cryptographic Algorithm Identifier (typedef <dfn>COSEAlgorithmIdentifier</dfn>) ### {#alg-identifier}
 
 <pre class="idl">
-    typedef long AlgorithmIdentifier;
+    typedef long COSEAlgorithmIdentifier;
 </pre>
 
-<div dfn-type="typedef" dfn-for="AlgorithmIdentifier">
-    An {{AlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
+<div dfn-type="typedef" dfn-for="COSEAlgorithmIdentifier">
+    An {{COSEAlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
     The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>
@@ -1629,7 +1629,7 @@ input parameters:
 - The [=hash of the serialized client data=], provided by the client.
 - The [=[RP]=]'s {{PublicKeyCredentialEntity}}.
 - The user account's {{PublicKeyCredentialUserEntity}}.
-- A sequence of pairs of {{PublicKeyCredentialType}} and {{AlgorithmIdentifier}} requested by the [=[RP]=].
+- A sequence of pairs of {{PublicKeyCredentialType}} and {{COSEAlgorithmIdentifier}} requested by the [=[RP]=].
     This sequence is ordered from most preferred to least
     preferred. The platform makes a best-effort to create the most preferred credential that it can.
 - An optional list of {{PublicKeyCredentialDescriptor}} objects provided by the [=[RP]=] with the intention that, if any of
@@ -1813,7 +1813,7 @@ credential. It has the following format:
         <td>
             The [=credential public key=] encoded in COSE_Key format, as defined in Section 7 of [[!RFC8152]].
 	        The encoded [=credential public key=] MUST contain the "alg" parameter and MUST NOT contain any other optional
-	        parameters. The "alg" parameter MUST contain an {{AlgorithmIdentifier}} value.
+	        parameters. The "alg" parameter MUST contain an {{COSEAlgorithmIdentifier}} value.
         </td>
     </tr>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -603,7 +603,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     </li>
 
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
-    an {{COSEAlgorithmIdentifier}}.
+    a {{COSEAlgorithmIdentifier}}.
 
 1. [=list/For each=] |current| of |options|.{{MakePublicKeyCredentialOptions/pubKeyCredParams}}:
     1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
@@ -1442,7 +1442,7 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
 </pre>
 
 <div dfn-type="typedef" dfn-for="COSEAlgorithmIdentifier">
-    An {{COSEAlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
+    A {{COSEAlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
     The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>
@@ -1813,7 +1813,7 @@ credential. It has the following format:
         <td>
             The [=credential public key=] encoded in COSE_Key format, as defined in Section 7 of [[!RFC8152]].
 	        The encoded [=credential public key=] MUST contain the "alg" parameter and MUST NOT contain any other optional
-	        parameters. The "alg" parameter MUST contain an {{COSEAlgorithmIdentifier}} value.
+	        parameters. The "alg" parameter MUST contain a {{COSEAlgorithmIdentifier}} value.
         </td>
     </tr>
 </table>


### PR DESCRIPTION
Fixes issue #526


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/selfissued/webauthn/mbj-AlgorithmIdentifier.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/4902a80...selfissued:9d6ea5e.html)