### PR TITLE
Remove "proper subset" from extension algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2022,8 +2022,8 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 4. Verify that the {{CollectedClientData/tokenBindingId}} in |C| matches the [=Token Binding ID=] for the TLS connection over
     which the attestation was obtained.
 
-5. Verify that the {{CollectedClientData/clientExtensions}} in |C| is a proper subset of the extensions requested by the RP
-    and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a proper subset of the extensions requested by
+5. Verify that the {{CollectedClientData/clientExtensions}} in |C| is a subset of the extensions requested by the RP
+    and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions requested by
     the RP.
 
 6. Compute the hash of {{AuthenticatorResponse/clientDataJSON}} using the algorithm identified by
@@ -2104,8 +2104,8 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 6. Verify that the {{CollectedClientData/tokenBindingId}} member of |C| (if present) matches the [=Token Binding ID=] for the
     TLS connection over which the signature was obtained.
 
-7. Verify that the {{CollectedClientData/clientExtensions}} member of |C| is a proper subset of the extensions requested by the
-    [=[RP]=] and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a proper subset of the extensions
+7. Verify that the {{CollectedClientData/clientExtensions}} member of |C| is a subset of the extensions requested by the
+    [=[RP]=] and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions
     requested by the [=[RP]=].
 
 8. Verify that the [=RP ID=] hash in |aData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].


### PR DESCRIPTION
Fix issue https://github.com/w3c/webauthn/issues/541. This is really nitpick so please approve soon.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/AngeloKai/webauthn/extension-nit.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/5e0dbe0...AngeloKai:84c12bb.html)