### PR TITLE
Fix Android attestation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3193,7 +3193,7 @@ IANA "WebAuthn Attestation Statement Format Identifier" registry established by 
 - Specification Document: Section [[#tpm-attestation]] of this specification
     <br/><br/>
 - WebAuthn Attestation Statement Format Identifier: android-key
-- Description: Platform-provided authenticators based on s versions "N", and later, may provide this proprietary "hardware
+- Description: Platform-provided authenticators based on versions "N", and later, may provide this proprietary "hardware
     attestation" statement.
 - Specification Document: Section [[#android-key-attestation]] of this specification
     <br/><br/>

--- a/index.bs
+++ b/index.bs
@@ -2430,7 +2430,7 @@ the attestation=] is consistent with the fields of the attestation certificate's
     androidStmtFormat = {
                           alg: rsaAlgName / eccAlgName,
                           sig: bytes,
-			  x5c: [ credCert: bytes, * (caCert: bytes) ]
+                          x5c: [ credCert: bytes, * (caCert: bytes) ]
                         }
 
     ```

--- a/index.bs
+++ b/index.bs
@@ -2427,19 +2427,26 @@ the attestation=] is consistent with the fields of the attestation certificate's
                           attStmt: androidStmtFormat
                       )
 
-    androidStmtFormat = bytes
+    androidStmtFormat = {
+                          alg: rsaAlgName / eccAlgName,
+                          sig: bytes,
+			  x5c: [ credCert: bytes, * (caCert: bytes) ]
+                        }
+
     ```
 
 : Signing procedure
 :: Let |authenticatorData| denote the [=authenticator data for the attestation=], and let |clientDataHash| denote the
     [=hash of the serialized client data=].
 
-    Concatenate |authenticatorData| and |clientDataHash| to form |attToBeSigned|.
-
-    Request an Android Key Attestation by calling "keyStore.getCertificateChain(myKeyUUID)") providing |attToBeSigned| as the
+    Request an Android Key Attestation by calling "keyStore.getCertificateChain(myKeyUUID)") providing |clientDataHash| as the
     challenge value (e.g., by using <a
     href="https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder.html#setAttestationChallenge(byte%5B%5D)">
-    setAttestationChallenge</a>), and set the attestation statement to the returned value.
+    setAttestationChallenge</a>). Set x5c to the returned value.
+
+    The authenticator produces |sig| by concatenating |authenticatorData| and |clientDataHash|,
+    and signing the result using the credential private key. It sets |alg| to the algorithm of the signature format.
+    
 
 : Verification procedure
 :: Verification is performed as follows:
@@ -3186,7 +3193,7 @@ IANA "WebAuthn Attestation Statement Format Identifier" registry established by 
 - Specification Document: Section [[#tpm-attestation]] of this specification
     <br/><br/>
 - WebAuthn Attestation Statement Format Identifier: android-key
-- Description: Platform-provided authenticators based on Android versions "N", and later, may provide this proprietary "hardware
+- Description: Platform-provided authenticators based on s versions "N", and later, may provide this proprietary "hardware
     attestation" statement.
 - Specification Document: Section [[#android-key-attestation]] of this specification
     <br/><br/>


### PR DESCRIPTION
Android attestation had a circular dependency on the public key: The authenticatorData has a public key that was originally intended to be stuck in the ChallengeData for generating a new keypair. When calling this function the public key isn't available to us yet. We have made a change to bring this in line with other attestation formats (ie. packed attestation).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/christiaanbrand/webauthn/patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/14c2733...christiaanbrand:201a816.html)