### PR TITLE
using descriptive names for authenticator selection criteria

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -661,11 +661,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. If |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} is [=present|present=], iterate through
         |currentlyAvailableAuthenticators| and do the following [=set/for each=] |authenticator|:
-    1. If {{AuthenticatorSelectionCriteria/aa}} is [=present|present=] and its value is not equal
+    1. If {{AuthenticatorSelectionCriteria/authenticatorAttachment}} is [=present|present=] and its value is not equal
         to |authenticator|'s attachment modality, [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/rk}} is set to |true| and the |authenticator|
+    1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to |true| and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/uv}} is set to |true| and the
+    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to |true| and the
         |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
     1. [=set/Append=] |authenticator| to |selectedAuthenticators|.
 
@@ -682,7 +682,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
     1. [=In parallel=], invoke the [=authenticatorMakeCredential=] operation on |authenticator| with |rpId|,
         |clientDataHash|, |options|.{{MakePublicKeyCredentialOptions/rp}}, |options|.{{MakePublicKeyCredentialOptions/user}},
-        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/rk}}</code>,
+        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
         |credTypesAndPubKeyAlgs|, |excludeCredentialDescriptorList|, and |authenticatorExtensions| as parameters.
     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
@@ -1217,30 +1217,27 @@ attributes.
 
 <xmp class="idl">
     dictionary AuthenticatorSelectionCriteria {
-        AuthenticatorAttachment      aa;         // authenticatorAttachment
-        boolean                      rk = false; // requireResidentKey
-        boolean                      uv = false; // requireUserVerification
+        AuthenticatorAttachment      authenticatorAttachment;
+        boolean                      requireResidentKey = false;
+        boolean                      requireUserVerification = false;
     };
 </xmp>
 
 <div dfn-type="dict-member" dfn-for="AuthenticatorSelectionCriteria">
-    :   <dfn>aa</dfn> (authenticatorAttachment)
+    :   <dfn>authenticatorAttachment</dfn>
     ::  If this member is [=present|present=], eligible authenticators are filtered to only authenticators attached with the
         specified [[#attachment]].
 
-    :   <dfn>rk</dfn> (requireResidentKey)
+    :   <dfn>requireResidentKey</dfn>
     ::  This member describes the [=[RPS]=]' requirements regarding availability of the [=Client-side-resident Credential
         Private Key=]. If the parameter is set to true, the authenticator MUST create a
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
-    :   <dfn>uv</dfn> (requireUserVerification)
+    :   <dfn>requireUserVerification</dfn>
     ::  This member describes the [=[RPS]=]' requirements regarding the authenticator being capable of performing user verification.
         If the parameter is set to true, the authenticator MUST perform user verification when performing
         the {{CredentialsContainer/create()}} operation and future [[#getAssertion]] operations when it is
         requested to verify the credential.
-
-    Note: These identifiers are intentionally short, rather than descriptive, because they will be serialized into
-        a message to the authenticator, which may be sent over a low-bandwidth link.
 </div>
 
 
@@ -1248,8 +1245,8 @@ attributes.
 
 <pre class="idl">
     enum AuthenticatorAttachment {
-        "plat",  // Platform attachment
-        "xplat"  // Cross-platform attachment
+        "platform",       // Platform attachment
+        "cross-platform"  // Cross-platform attachment
     };
 </pre>
 
@@ -1645,8 +1642,8 @@ input parameters:
     preferred. The platform makes a best-effort to create the most preferred credential that it can.
 - An optional list of {{PublicKeyCredentialDescriptor}} objects provided by the [=[RP]=] with the intention that, if any of
     these are known to the authenticator, it should not create a new credential.
-- The |rk| member of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
-- The |uv| member of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
+- The |requireResidentKey| member of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
+- The |requireUserVerification| member of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
 - Extension data created by the client based on the extensions requested by the [=[RP]=], if any.
 
 When this operation is invoked, the authenticator must perform the following procedure:
@@ -1656,9 +1653,9 @@ When this operation is invoked, the authenticator must perform the following pro
     If not, return an error code equivalent to "{{NotSupportedError}}" and terminate the operation.
 - Check if a credential matching any of the supplied {{PublicKeyCredential}} identifiers is present on this authenticator. If
     so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
-- If |rk| is |true| and the authenticator cannot store a [=Client-side-resident Credential
+- If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-- If |uv| is |true| and the authenticator cannot perform user verification,
+- If |requireUserVerification| is |true| and the authenticator cannot perform user verification,
     return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 - Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
     if it has its own output capability, or by the user agent otherwise. If the user denies consent, return an error code


### PR DESCRIPTION
Since we don't directly send the values of the AuthenticatorSelectionCriteria dictionary keys over the wire, it's ok to leave these values in a human-readable form.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/balfanz-patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/14c2733...df905a3.html)