### PR TITLE
Plumb User ID through

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -459,7 +459,7 @@ that are returned to the caller when a new credential is created, or a new asser
     [SecureContext]
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
-        [SameObject] readonly attribute AuthenticatorResponse    response;
+	[SameObject] readonly attribute AuthenticatorResponse    response;
         [SameObject] readonly attribute AuthenticationExtensions clientExtensionResults;
     };
 </xmp>
@@ -941,6 +941,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 : {{AuthenticatorAssertionResponse/signature}}
                 :: A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of the returned
                     {{signature}}
+		: {{AuthenticatorAssertionResponse/userId}}
+                :: A new {{DOMString}} containing the user ID returned from the successful [=authenticatorGetAssertion=] operation, 
+			as defined in [[#op-get-assertion]].   
             :   {{PublicKeyCredential/clientExtensionResults}}
             ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
                 entries created by running each extension's [=client extension processing=] algorithm to create the [=client
@@ -1058,7 +1061,8 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
-    };
+	[SameObject] readonly attribute DOMString	 userId;
+	};
 </pre>
 <div dfn-type="attribute" dfn-for="AuthenticatorAssertionResponse">
     :   {{AuthenticatorResponse/clientDataJSON}}
@@ -1721,6 +1725,7 @@ On successful completion, the authenticator returns to the user agent:
 - The identifier of the credential (credential ID) used to generate the [=assertion signature=].
 - The [=authenticator data=] used to generate the [=assertion signature=].
 - The [=assertion signature=].
+- The user id associated with the credential used to generate the [=assertion signature=].
 
 If the authenticator cannot find any credential corresponding to the specified [=[RP]=] that matches the specified criteria, it
 terminates the operation and returns an error.

--- a/index.bs
+++ b/index.bs
@@ -943,7 +943,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     {{signature}}
                 : {{AuthenticatorAssertionResponse/userId}}
                 :: A new {{DOMString}} containing the user ID returned from the successful [=authenticatorGetAssertion=] operation, 
-                   as defined in [[#op-get-assertion]].   
+                    as defined in [[#op-get-assertion]].   
             :   {{PublicKeyCredential/clientExtensionResults}}
             ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
                 entries created by running each extension's [=client extension processing=] algorithm to create the [=client

--- a/index.bs
+++ b/index.bs
@@ -459,7 +459,7 @@ that are returned to the caller when a new credential is created, or a new asser
     [SecureContext]
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
-	[SameObject] readonly attribute AuthenticatorResponse    response;
+        [SameObject] readonly attribute AuthenticatorResponse    response;
         [SameObject] readonly attribute AuthenticationExtensions clientExtensionResults;
     };
 </xmp>

--- a/index.bs
+++ b/index.bs
@@ -1061,8 +1061,8 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
-        [SameObject] readonly attribute DOMString	 userId;
-        };
+        [SameObject] readonly attribute DOMString        userId;
+    };
 </pre>
 <div dfn-type="attribute" dfn-for="AuthenticatorAssertionResponse">
     :   {{AuthenticatorResponse/clientDataJSON}}

--- a/index.bs
+++ b/index.bs
@@ -943,7 +943,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     {{signature}}
                 : {{AuthenticatorAssertionResponse/userId}}
                 :: A new {{DOMString}} containing the user ID returned from the successful [=authenticatorGetAssertion=] operation, 
-		   as defined in [[#op-get-assertion]].   
+	           as defined in [[#op-get-assertion]].   
             :   {{PublicKeyCredential/clientExtensionResults}}
             ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
                 entries created by running each extension's [=client extension processing=] algorithm to create the [=client

--- a/index.bs
+++ b/index.bs
@@ -942,7 +942,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 :: A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of the returned
                     {{signature}}
                 : {{AuthenticatorAssertionResponse/userId}}
-                :: A new {{DOMString}} containing the user ID returned from the successful [=authenticatorGetAssertion=] operation, 
+                :: A new {{DOMString}} containing the user handle returned from the successful [=authenticatorGetAssertion=] operation, 
                     as defined in [[#op-get-assertion]].   
             :   {{PublicKeyCredential/clientExtensionResults}}
             ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
@@ -1725,7 +1725,7 @@ On successful completion, the authenticator returns to the user agent:
 - The identifier of the credential (credential ID) used to generate the [=assertion signature=].
 - The [=authenticator data=] used to generate the [=assertion signature=].
 - The [=assertion signature=].
-- The user id associated with the credential used to generate the [=assertion signature=].
+- The user handle associated with the credential used to generate the [=assertion signature=].
 
 If the authenticator cannot find any credential corresponding to the specified [=[RP]=] that matches the specified criteria, it
 terminates the operation and returns an error.

--- a/index.bs
+++ b/index.bs
@@ -1061,8 +1061,8 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
-	[SameObject] readonly attribute DOMString	 userId;
-	};
+        [SameObject] readonly attribute DOMString	 userId;
+        };
 </pre>
 <div dfn-type="attribute" dfn-for="AuthenticatorAssertionResponse">
     :   {{AuthenticatorResponse/clientDataJSON}}

--- a/index.bs
+++ b/index.bs
@@ -943,7 +943,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     {{signature}}
 		: {{AuthenticatorAssertionResponse/userId}}
                 :: A new {{DOMString}} containing the user ID returned from the successful [=authenticatorGetAssertion=] operation, 
-			as defined in [[#op-get-assertion]].   
+		   as defined in [[#op-get-assertion]].   
             :   {{PublicKeyCredential/clientExtensionResults}}
             ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
                 entries created by running each extension's [=client extension processing=] algorithm to create the [=client

--- a/index.bs
+++ b/index.bs
@@ -941,7 +941,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 : {{AuthenticatorAssertionResponse/signature}}
                 :: A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of the returned
                     {{signature}}
-		: {{AuthenticatorAssertionResponse/userId}}
+                : {{AuthenticatorAssertionResponse/userId}}
                 :: A new {{DOMString}} containing the user ID returned from the successful [=authenticatorGetAssertion=] operation, 
 		   as defined in [[#op-get-assertion]].   
             :   {{PublicKeyCredential/clientExtensionResults}}

--- a/index.bs
+++ b/index.bs
@@ -943,7 +943,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     {{signature}}
                 : {{AuthenticatorAssertionResponse/userId}}
                 :: A new {{DOMString}} containing the user ID returned from the successful [=authenticatorGetAssertion=] operation, 
-	           as defined in [[#op-get-assertion]].   
+                   as defined in [[#op-get-assertion]].   
             :   {{PublicKeyCredential/clientExtensionResults}}
             ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
                 entries created by running each extension's [=client extension processing=] algorithm to create the [=client


### PR DESCRIPTION
We need to plumb the custom user id that the RP gave the authenticator during MakeCredential back through to the RP when doing getAssertion.
Closes #556


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/christiaanbrand/webauthn/patch-2.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/14c2733...christiaanbrand:e63537f.html)