### PR TITLE
Clarify Safetynet attestation return value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2496,7 +2496,7 @@ and the identity of the calling application.
     :: The version number of Google Play Services responsible for providing the SafetyNet API.
 
     : response
-    :: The value returned by the above SafetyNet API. This value is a JWS [[RFC7515]] object (see
+    :: The UTF8 encoded result of the getJwsResult() call of the SafetyNet API. This value is a JWS [[RFC7515]] object (see
         [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response))
         in Compact Serialization.
 

--- a/index.bs
+++ b/index.bs
@@ -2496,7 +2496,7 @@ and the identity of the calling application.
     :: The version number of Google Play Services responsible for providing the SafetyNet API.
 
     : response
-    :: The UTF8 encoded result of the getJwsResult() call of the SafetyNet API. This value is a JWS [[RFC7515]] object (see
+    :: The [=UTF-8 encoded=] result of the getJwsResult() call of the SafetyNet API. This value is a JWS [[RFC7515]] object (see
         [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response))
         in Compact Serialization.
 


### PR DESCRIPTION
Clarify the encoding of SafetyNet attestation as a UTF8 encoded string. Closes #563


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/christiaanbrand/webauthn/patch-4.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/db1be80...christiaanbrand:ee912ee.html)