### PR TITLE
Clarify excludeCredentialDescriptorList

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1641,7 +1641,8 @@ input parameters:
     This sequence is ordered from most preferred to least
     preferred. The platform makes a best-effort to create the most preferred credential that it can.
 - An optional list of {{PublicKeyCredentialDescriptor}} objects provided by the [=[RP]=] with the intention that, if any of
-    these are known to the authenticator, it should not create a new credential.
+    these are known to the authenticator, it should not create a new credential. |excludeCredentialDescriptorList| contains a 
+    list of known credentials.
 - The |requireResidentKey| member of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
 - The |requireUserVerification| member of the |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}} dictionary.
 - Extension data created by the client based on the extensions requested by the [=[RP]=], if any.


### PR DESCRIPTION
Add more clarity around the use of excludeCredentialDescriptorList. Closes #567.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/christiaanbrand/webauthn/patch-3.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/db1be80...christiaanbrand:a0df02e.html)