### PR TITLE
Fix #577 - CDDL for attStmtTemplate is ambiguous

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1919,7 +1919,9 @@ attObj = {
 
 attStmtTemplate = (
                       fmt: text,
-                      attStmt: bytes
+                      attStmt: {
+                        ; Map is filled in by each concrete attStmtType
+                      }
                   )
 
 ; Every attestation statement format must have the above fields

--- a/index.bs
+++ b/index.bs
@@ -1919,9 +1919,7 @@ attObj = {
 
 attStmtTemplate = (
                       fmt: text,
-                      attStmt: {
-                        ; Map is filled in by each concrete attStmtType
-                      }
+                      attStmt: { * tstr => any } ; Map is filled in by each concrete attStmtType
                   )
 
 ; Every attestation statement format must have the above fields


### PR DESCRIPTION
There are multiple definitions of `attStmtType`; the template defines it
to be `bytes`, while each concrete instance of the template defines it
as a map. This clarifies that it is always a map, since the ".within" control
operator for CDDL defines that the socket `$$attStmtType` to be the superset of
`attStmtTemplate`. [1]

[1] https://tools.ietf.org/html/draft-ietf-cbor-cddl-00#section-3.8.5


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/577-cddl_attStmt_type.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/67e922c...jcjones:5630b47.html)