### PR TITLE
Fix syntax errors in JavaScript examples.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3343,7 +3343,7 @@ The sample code for generating and registering a new key follows:
 
       // User:
       user: {
-        id: "1098237235409872"
+        id: "1098237235409872",
         name: "john.p.smith@example.com",
         displayName: "John P. Smith",
         icon: "https://pics.acme.com/00/p/aBjjjpqPb.png"
@@ -3497,9 +3497,9 @@ extension for transaction authorization.
     var options = {
                     challenge: encoder.encode("climb a mountain"),
                     timeout: 60000,  // 1 minute
-                    allowCredentials: [acceptableCredential1, acceptableCredential2];
+                    allowCredentials: [acceptableCredential1, acceptableCredential2],
                     extensions: { 'webauthn.txauth.simple':
-                       "Wave your hands in the air like you just don't care" };
+                       "Wave your hands in the air like you just don't care" }
                   };
 
     navigator.credentials.get({ "publicKey": options })


### PR DESCRIPTION
Fix syntax errors in JavaScript examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/futureimperfect/webauthn/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/67e922c...futureimperfect:4aa72b6.html)