### PR TITLE
Corrected inaccuracy in authenticator extension processing description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2761,8 +2761,8 @@ the process by which the [=CBOR=] [=authenticator extension output=] can be used
 
 ## <dfn>Authenticator extension processing</dfn> ## {#sctn-authenticator-extension-processing}
 
-As specified in [[#sec-authenticator-data]], the [=CBOR=] [=authenticator extension input=] value of each processed
-[=authenticator extension=] is included in the extensions data part of the [=authenticator data=]. This part is a CBOR map, with
+The [=CBOR=] [=authenticator extension input=] value of each processed
+[=authenticator extension=] is included in the extensions data part of the authenticator request. This part is a CBOR map, with
 [=CBOR=] [=extension identifier=] values as keys, and the [=CBOR=] [=authenticator extension input=] value of each extension as
 the value.
 


### PR DESCRIPTION
Fixes #548


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/selfissued/webauthn/mbj-extension-description-tweak.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/26552c4...selfissued:0141d97.html)