### PR TITLE
Sign counter alg 507 alternative: optional sig counter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2221,6 +2221,9 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
     and signing the result using the credential private key. It sets |alg| to the algorithm of the credential private key, and
     omits the other fields.
 
+    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as
+    response to authenticatorMakeCredential as required here.
+
 : Verification procedure
 :: Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
 
@@ -2347,6 +2350,9 @@ engine.
     Set the |pubArea| field to the public area of the credential public key, the |certInfo| field to the output parameter of the
     same name, and the |sig| field to the signature obtained from the above procedure.
 
+    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as required here as
+    response to authenticatorMakeCredential.
+
 : Verification procedure
 :: Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
 
@@ -2441,6 +2447,9 @@ the attestation=] is consistent with the fields of the attestation certificate's
     href="https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder.html#setAttestationChallenge(byte%5B%5D)">
     setAttestationChallenge</a>), and set the attestation statement to the returned value.
 
+    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as
+    response to authenticatorMakeCredential as required here.
+
 : Verification procedure
 :: Verification is performed as follows:
     - Let |authenticatorData| denote the [=authenticator data claimed to have been used for the attestation=], and let
@@ -2505,6 +2514,9 @@ and the identity of the calling application.
     Request a SafetyNet attestation, providing |attToBeSigned| as the nonce value. Set |response| to the result, and |ver| to
     the version of Google Play Services running in the authenticator.
 
+    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as
+    response to authenticatorMakeCredential as required here.
+
 : Verification procedure
 :: Verification is performed as follows:
     - Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
@@ -2553,15 +2565,16 @@ This attestation statement format is used with FIDO U2F authenticators using the
 
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
-    The authenticator returns a cryptographically signed (raw) registration response message that has a different format
-    than the one expected for |authenticatorData|.  As a consequence, the platform needs to synthesize the
-    |authenticatorData| based on the (raw) U2F registration response message (u2fresp).
-
     Let |authenticatorData| denote the [=authenticator data for the attestation=], and let |clientDataHash| denote the
     [=hash of the serialized client data=].
 
     If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256 hash of
     |clientDataHash|.
+
+    The authenticator returns a cryptographically signed (raw) 
+    registration response message that has a different format
+    than the one expected for |authenticatorData|.  As a consequence, the platform needs to synthesize the
+    |authenticatorData| based on the (raw) U2F registration response message (u2fresp).
 
     Let the authenticator generate a signed object as specified in [[FIDO-U2F-Message-Formats]] 
     section 4.3, with the application parameter set to the SHA-256 hash of the [=RP ID=] 
@@ -3667,6 +3680,13 @@ Axel Nennker, Kimberly Paulhamus, Adam Powers, Yaron Sheffer, Mike West, Jeffrey
     "title": "FIDO U2F Raw Message Formats",
     "href": "https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html",
     "status": "FIDO Alliance Implementation Draft"
+  },
+
+  "FIDO-CTAP": {
+    "authors": ["R. Lindemann", "V. Bharadwaj", "A. Czeskis", "M. B. Jones"],
+    "title": "FIDO 2.0: Client to Authenticator Protocol",
+    "href": "",
+    "status": "FIDO Alliance Working Draft"
   },
 
   "CDDL": {

--- a/index.bs
+++ b/index.bs
@@ -2611,7 +2611,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
 
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
-    Let |authenticatorData| denote the [=authenticator data for the attestation=], and let |clientDataHash| denote the
+    Otherwise, let |authenticatorData| denote the [=authenticator data for the attestation=], and let |clientDataHash| denote the
     [=hash of the serialized client data=].
 
     If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256 hash of
@@ -2628,7 +2628,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     parameter set to the credential ID of the given credential. 
 
     Let the platform generate |authenticatorData| as follows:
-    1. Set RP ID hash to the SHA-256 hash of the [=RP ID=]
+    1. Set |RP ID hash| to the SHA-256 hash of the [=RP ID=]
     2. Set Flags to <code>u2fresp.reserved_byte</code>.
     3. Set counter to all zeros.
     4. Let the platform populate the |authenticatorData|'s [=attestation data=] as follows:
@@ -2643,19 +2643,26 @@ This attestation statement format is used with FIDO U2F authenticators using the
 
 : Verification procedure
 :: Verification is performed as follows:
-    - Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
-    - If |x5c| is not a certificate for an ECDSA public key over the P-256 curve, stop verification and return an error.
-    - Let |authenticatorData| denote the [=authenticator data claimed to have been used for the attestation=], and let
+    1. Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
+    2. Verify that |fmt| is "fido-u2f", fail otherwise.
+    3. Verify that the SHA-256 hash of the passed [=RP ID=] matches with |authenticatorData|’s |RP ID hash| field.
+    4. If |x5c| is not a certificate for an ECDSA public key over the P-256 curve, stop verification and return an error.
+    5. Extract the |public key| from the (leaf) certificate contained in |x5c|.
+    6. Let |authenticatorData| denote the [=authenticator data claimed to have been used for the attestation=], and let
         |clientDataHash| denote the [=hash of the serialized client data=].
-    - If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256
+    7. From |authenticatorData|, extract the claimed [=RP ID=] hash, the claimed credential ID and the claimed credential public k
+    8. If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256
         hash of |clientDataHash|.
-    - From |authenticatorData|, extract the claimed [=RP ID=] hash, the claimed credential ID and the claimed credential public key.
-    - Generate the claimed to-be-signed data as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with the application
-        parameter set to the claimed [=RP ID=] hash, the challenge parameter set to |tbsHash|, the key handle parameter set to the
-        claimed credential ID of the given credential, and the user public key parameter set to the claimed credential public
-        key.
-    - Verify that the |sig| is a valid ECDSA P-256 signature over the to-be-signed data constructed above.
-    - If successful, return attestation type Basic with the trust path set to |x5c|.
+    9. Convert the COSE_KEY formatted credential public key to CTAP1/U2F public Key format.
+        - Let publicKeyU2F represents converted CTAP1/U2F public representation of 
+          COSE_KEY and set first byte as 0x04 which signifies uncompressed ECC key format
+        - Extract "-2" (representing x coordinate) from COSE_KEY representation, 
+          confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
+        - Extract "-3" (representing y coordinate) from COSE_KEY representation, 
+          confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
+    10. Calculate SHA-256 (0x00 | SHA-256([=RP ID=]) | |tbsHash| | CredentialID | publicKeyU2F).
+    11. Verify attestationStatement signature |sig| using above hash and |public key|.
+    12. If successful, return attestation type Basic with the trust path set to |x5c|.
 
 
 # WebAuthn Extensions # {#extensions}

--- a/index.bs
+++ b/index.bs
@@ -2633,10 +2633,9 @@ This attestation statement format is used with FIDO U2F authenticators using the
     If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256 hash of
     |clientDataHash|.
 
-    Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with 
-    the application parameter set to the SHA-256 hash of the [=RP ID=] associated with the given credential, 
-    the challenge parameter set to |tbsHash|, and the key handle parameter set to the credential ID of the 
-    given credential. Set the raw signature part of this Registration Response Message (i.e., without the user public key,
+    Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with the application parameter set to the
+    SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |tbsHash|, and the key handle
+    parameter set to the credential ID of the given credential. Set the raw signature part of this Registration Response Message (i.e., without the user public key,
     key handle, and attestation certificates) as |sig| and set the attestation certificates of
     the attestation public key as |x5c|.
 

--- a/index.bs
+++ b/index.bs
@@ -2629,29 +2629,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256 hash of
     |clientDataHash|.
 
-    The authenticator returns a cryptographically signed (raw) 
-    registration response message [[!FIDO-U2F-Message-Formats]] that has a different format
-    than the one expected for |authenticatorData|.  As a consequence, the platform needs to synthesize the
-    |authenticatorData| based on the (raw) U2F registration response message (u2fresp).
-
-    Let the authenticator generate a signed object as specified in [[!FIDO-U2F-Message-Formats]] 
-    section 4.3, with the application parameter set to the SHA-256 hash of the [=RP ID=] 
-    associated with the given credential, the challenge parameter set to |tbsHash|, and the key handle
-    parameter set to the credential ID of the given credential. 
-
-    Let the platform generate |authenticatorData| as follows:
-    1. Set |RP ID hash| to the SHA-256 hash of the [=RP ID=]
-    2. Set Flags to <code>u2fresp.reserved_byte</code>.
-    3. Set counter to all zeros.
-    4. Let the platform populate the |authenticatorData|'s [=attestation data=] as follows:
-         1. Set AAGUID to all zeros
-         2. Set L the length of credential ID to length of <code>u2fresp.keyHandle</code>
-         3. Set credentialID to <code>u2fresp.keyHandle</code>
-         4. Set credentialPublicKey to <code>u2fresp.userPublicKey</code>
-    5. Let the platform set the fields in u2fStmtFormat:
-         1. Set |x5c| to <code>u2fresp.attestationCertificate</code>.
-         2. Set |sig| to <code>u2fresp.signature</code>.
-
+    Follow the procedure described in section 7.1. in [[!FIDO-CTAP]].   
 
 : Verification procedure
 :: Verification is performed as follows:

--- a/index.bs
+++ b/index.bs
@@ -2644,24 +2644,25 @@ This attestation statement format is used with FIDO U2F authenticators using the
 : Verification procedure
 :: Verification is performed as follows:
     1. Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
-    2. Verify that |fmt| is "fido-u2f", fail otherwise.
+    2. Verify that |fmt| is "fido-u2f", stop verification and return an error.
     3. Verify that the SHA-256 hash of the passed [=RP ID=] matches with |authenticatorData|’s |RP ID hash| field.
     4. If |x5c| is not a certificate for an ECDSA public key over the P-256 curve, stop verification and return an error.
-    5. Extract the |public key| from the (leaf) certificate contained in |x5c|.
+    5. Extract the |certificate public key| from the (leaf) certificate contained in |x5c|.
     6. Let |authenticatorData| denote the [=authenticator data claimed to have been used for the attestation=], and let
         |clientDataHash| denote the [=hash of the serialized client data=].
-    7. From |authenticatorData|, extract the claimed [=RP ID=] hash, the claimed credential ID and the claimed credential public k
+    7. From |authenticatorData|, extract the claimed [=RP ID=] hash, the claimed |CredentialID| 
+        and the claimed |credential public key|
     8. If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256
         hash of |clientDataHash|.
-    9. Convert the COSE_KEY formatted credential public key to CTAP1/U2F public Key format.
-        - Let publicKeyU2F represents converted CTAP1/U2F public representation of 
+    9. Convert the COSE_KEY formatted |credential public key| to CTAP1/U2F public Key format.
+        - Let |publicKeyU2F| represent converted CTAP1/U2F public representation of 
             COSE_KEY and set first byte as 0x04 which signifies uncompressed ECC key format
         - Extract "-2" (representing x coordinate) from COSE_KEY representation, 
-            confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
+            confirm its size to be of 32 bytes and concatenate it with |publicKeyU2F|
         - Extract "-3" (representing y coordinate) from COSE_KEY representation, 
-            confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
-    10. Calculate SHA-256 (0x00 | SHA-256([=RP ID=]) | |tbsHash| | CredentialID | publicKeyU2F).
-    11. Verify attestationStatement signature |sig| using above hash and |public key|.
+            confirm its size to be of 32 bytes and concatenate it with |publicKeyU2F|
+    10. Calculate SHA-256 (0x00 | SHA-256([=RP ID=]) | |tbsHash| | |CredentialID| | |publicKeyU2F|).
+    11. Verify attestationStatement signature |sig| using above hash and |certificate public key|.
     12. If successful, return attestation type Basic with the trust path set to |x5c|.
 
 

--- a/index.bs
+++ b/index.bs
@@ -977,6 +977,16 @@ Based on the result, the [=[RP]=] can take further actions to guide the user to 
 
 This method has no arguments and returns a boolean value.
 
+If the promise will return <i>False</i>,
+the [=client=] SHOULD wait a fixed period of time from the invocation of the method before returning <i>False</i>.
+This is done so that callers can not distinguish between
+the case where the user was unwilling to create a credential using one of the available [=platform authenticators=] and
+the case where no [=platform authenticator=] exists.
+Trying to make these cases indistinguishable is done in an attempt to not provide additional information that could be used for fingerprinting.
+A timeout value on the order of 10 minutes is recommended;
+this is enough time for successful user interactions to be performed
+but short enough that the dangling promise will still be resolved in a reasonably timely fashion.
+
 <pre class="idl">
     [SecureContext]
     partial interface PublicKeyCredential {
@@ -3362,7 +3372,9 @@ The sample code for generating and registering a new key follows:
 This is flow for when the [=[RP]=] is specifically interested in creating a public key credential with
 a [=platform authenticator=].
 
-1. The user visits example.com. At this point, the user is likely already logged in.
+1. The user visits example.com and clicks on the login button, which redirects the user to login.example.com.
+
+1. The user enters a username and password to log in. After successful login, the user is redirected back to example.com.
 
 1. The [=[RP]=] script runs the code snippet below.
 
@@ -3376,7 +3388,7 @@ a [=platform authenticator=].
 <pre class="example" highlight="js">
     if (!PublicKeyCredential) { /* Platform not capable of the API. Handle error. */ }
 
-    navigator.credentials.isPlatformAuthenticatorAvailable()
+    PublicKeyCredential.isPlatformAuthenticatorAvailable()
         .then(function (userIntent) {
 
             // If the user has affirmed willingness to register with RP using an available platform authenticator
@@ -3385,9 +3397,12 @@ a [=platform authenticator=].
 
                 // Create and register credentials.
                 return navigator.credentials.create({ "publicKey": publicKeyOptions });
+            } else {
+
+                // Record that the user does not intend to use a platform authenticator
+                // and default the user to a password-based flow in the future.
             }
 
-            // If user is not interested, don't ask the user to register.
         }).then(function (newCredentialInfo) {
             // Send new credential info to server for verification and registration.
         }).catch( function(err) {

--- a/index.bs
+++ b/index.bs
@@ -2267,9 +2267,6 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
     and signing the result using the credential private key. It sets |alg| to the algorithm of the credential private key, and
     omits the other fields.
 
-    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as
-    response to authenticatorMakeCredential as required here.
-
 : Verification procedure
 :: Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
 
@@ -2396,9 +2393,6 @@ engine.
     Set the |pubArea| field to the public area of the credential public key, the |certInfo| field to the output parameter of the
     same name, and the |sig| field to the signature obtained from the above procedure.
 
-    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as required here as
-    response to authenticatorMakeCredential.
-
 : Verification procedure
 :: Verify that the given attestation statement is valid CBOR conforming to the syntax defined above.
 
@@ -2493,9 +2487,6 @@ the attestation=] is consistent with the fields of the attestation certificate's
     href="https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder.html#setAttestationChallenge(byte%5B%5D)">
     setAttestationChallenge</a>), and set the attestation statement to the returned value.
 
-    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as
-    response to authenticatorMakeCredential as required here.
-
 : Verification procedure
 :: Verification is performed as follows:
     - Let |authenticatorData| denote the [=authenticator data claimed to have been used for the attestation=], and let
@@ -2559,9 +2550,6 @@ and the identity of the calling application.
 
     Request a SafetyNet attestation, providing |attToBeSigned| as the nonce value. Set |response| to the result, and |ver| to
     the version of Google Play Services running in the authenticator.
-
-    When connected through [[FIDO-CTAP]], the authenticator returns the attestation Statement as
-    response to authenticatorMakeCredential as required here.
 
 : Verification procedure
 :: Verification is performed as follows:

--- a/index.bs
+++ b/index.bs
@@ -108,11 +108,6 @@ spec:webidl; type:interface; text:Promise
         "href": "https://www.iana.org/assignments/cose/cose.xhtml#algorithms",
         "title": "IANA CBOR Object Signing and Encryption (COSE) Algorithms Registry",
         "publisher": "IANA"
-    },
-    "IANA-JOSE-ALGS-REG": {
-        "href": "https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms",
-        "title": "IANA JSON Object Signing and Encryption (JOSE) Web Signature and Encryption Algorithms Registry",
-        "publisher": "IANA"
     }
 }
 </pre>
@@ -1443,15 +1438,13 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
 ### Cryptographic Algorithm Identifier (typedef <dfn>AlgorithmIdentifier</dfn>) ### {#alg-identifier}
 
 <pre class="idl">
-    typedef (short or ByteString) AlgorithmIdentifier;
+    typedef long AlgorithmIdentifier;
 </pre>
 
 <div dfn-type="typedef" dfn-for="AlgorithmIdentifier">
-    An {{AlgorithmIdentifier}}'s value is a number or byte string identifying a cryptographic algorithm.
-    The algorithm identifiers MUST be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
-    when available, for instance, <code>-7</code> for "ES256".
-    For algorithms not present in the IANA COSE Algorithms registry, string values from the
-    JSON Web Signature and Encryption Algorithms registry [[!IANA-JOSE-ALGS-REG]] SHOULD be used, for instance "RS256".
+    An {{AlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
+    The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
+    for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>
 
 # WebAuthn Authenticator model # {#authenticator-model}
@@ -3247,6 +3240,29 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
     used for the WebAuthn operation.
 - Specification Document: Section [[#sctn-uvm-extension]] of this specification
 
+## COSE Algorithm Registrations ## {#sctn-cose-alg-reg}
+
+This section registers identifiers for RSASSA-PKCS1-v1_5 [[RFC8017]] algorithms using SHA-2 hash functions in the
+IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]].
+
+- Name: RS256
+- Value: -257
+- Description: RSASSA-PKCS1-v1_5 w/ SHA-256
+- Reference: Section 8.2 of [[RFC8017]]
+- Recommended: No
+    <br/><br/>
+- Name: RS384
+- Value: -258
+- Description: RSASSA-PKCS1-v1_5 w/ SHA-384
+- Reference: Section 8.2 of [[RFC8017]]
+- Recommended: No
+    <br/><br/>
+- Name: RS512
+- Value: -259
+- Description: RSASSA-PKCS1-v1_5 w/ SHA-512
+- Reference: Section 8.2 of [[RFC8017]]
+- Recommended: No
+
 # Sample scenarios # {#sample-scenarios}
 
 [INFORMATIVE]
@@ -3322,7 +3338,7 @@ The sample code for generating and registering a new key follows:
         },
         {
           type: "public-key",
-          alg: "RS256" // Use the IANA JOSE algorithm identifier since "RS256" not in COSE Algorithms registry
+          alg: -257 // Value registered by this specification for "RS256"
         }
       ],
 

--- a/index.bs
+++ b/index.bs
@@ -2597,7 +2597,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     : sig
     :: The [=attestation signature=].  
         The signature was calculated over the (raw) U2F registration response message [[!FIDO-U2F-Message-Formats]]
-	received by the platform from the authenticator.
+        received by the platform from the authenticator.
 
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.

--- a/index.bs
+++ b/index.bs
@@ -2072,7 +2072,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 
 15. If verification of the attestation statement failed, the [=[RP]=] MUST fail the registration ceremony.
 
-16. Store the public key and the signature counter for this authenticator.
+16. Store the public key and the signature counter included in the attestation statement for this authenticator.
 
 Verification of [=attestation objects=] requires that the [=[RP]=] has a trusted method of determining acceptable trust anchors
 in step 11 above. Also, if certificates are being used, the [=[RP]=] must have access to certificate status information for the

--- a/index.bs
+++ b/index.bs
@@ -2595,7 +2595,9 @@ This attestation statement format is used with FIDO U2F authenticators using the
         The attestation certificate must be the first element in the array.
 
     : sig
-    :: The [=attestation signature=].  It contains the (raw) U2F registration response message [[!FIDO-U2F-Message-Formats]].
+    :: The [=attestation signature=].  
+        The signature was calculated over the (raw) U2F registration response message [[!FIDO-U2F-Message-Formats]]
+	received by the platform from the authenticator.
 
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.

--- a/index.bs
+++ b/index.bs
@@ -2072,6 +2072,8 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 
 15. If verification of the attestation statement failed, the [=[RP]=] MUST fail the registration ceremony.
 
+16. Store the public key and the signature counter for this authenticator.
+
 Verification of [=attestation objects=] requires that the [=[RP]=] has a trusted method of determining acceptable trust anchors
 in step 11 above. Also, if certificates are being used, the [=[RP]=] must have access to certificate status information for the
 intermediate CA certificates. The [=[RP]=] must also be able to build the attestation certificate chain if the client did not
@@ -2116,7 +2118,9 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 10. Using the credential public key looked up in step 1, verify that |sig| is a valid signature over the binary concatenation of
     |aData| and |hash|.
 
-11. If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the
+11. Verify that the signature counter value is either (a) greater than the value stored or (b) it is equal to the value stored and the value stored is 0. 
+
+12. If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the
     authentication ceremony.
 
 

--- a/index.bs
+++ b/index.bs
@@ -2655,11 +2655,11 @@ This attestation statement format is used with FIDO U2F authenticators using the
         hash of |clientDataHash|.
     9. Convert the COSE_KEY formatted credential public key to CTAP1/U2F public Key format.
         - Let publicKeyU2F represents converted CTAP1/U2F public representation of 
-          COSE_KEY and set first byte as 0x04 which signifies uncompressed ECC key format
+            COSE_KEY and set first byte as 0x04 which signifies uncompressed ECC key format
         - Extract "-2" (representing x coordinate) from COSE_KEY representation, 
-          confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
+            confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
         - Extract "-3" (representing y coordinate) from COSE_KEY representation, 
-          confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
+            confirm its size to be of 32 bytes and concatenate it with publicKeyU2F
     10. Calculate SHA-256 (0x00 | SHA-256([=RP ID=]) | |tbsHash| | CredentialID | publicKeyU2F).
     11. Verify attestationStatement signature |sig| using above hash and |public key|.
     12. If successful, return attestation type Basic with the trust path set to |x5c|.

--- a/index.bs
+++ b/index.bs
@@ -1691,7 +1691,7 @@ When this operation is invoked, the authenticator must perform the following pro
 - If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
 - Process all the supported extensions requested by the client.
-- If the authenticator support a signature counter <i>per credential</i>, then initialize this counter with 0.  
+- If the authenticator supports a signature counter <i>per credential</i>, then initialize this counter with 0.  
     (Alternatively, the authenticator might support a global signature counter).
 - Generate the [=authenticator data=] with
     [=attestation data=] as specified in [[#sec-authenticator-data]]. Use this [=authenticator data=] and the

--- a/index.bs
+++ b/index.bs
@@ -2572,11 +2572,11 @@ This attestation statement format is used with FIDO U2F authenticators using the
     |clientDataHash|.
 
     The authenticator returns a cryptographically signed (raw) 
-    registration response message that has a different format
+    registration response message [[!FIDO-U2F-Message-Formats]] that has a different format
     than the one expected for |authenticatorData|.  As a consequence, the platform needs to synthesize the
     |authenticatorData| based on the (raw) U2F registration response message (u2fresp).
 
-    Let the authenticator generate a signed object as specified in [[FIDO-U2F-Message-Formats]] 
+    Let the authenticator generate a signed object as specified in [[!FIDO-U2F-Message-Formats]] 
     section 4.3, with the application parameter set to the SHA-256 hash of the [=RP ID=] 
     associated with the given credential, the challenge parameter set to |tbsHash|, and the key handle
     parameter set to the credential ID of the given credential. 

--- a/index.bs
+++ b/index.bs
@@ -2549,10 +2549,13 @@ This attestation statement format is used with FIDO U2F authenticators using the
         The attestation certificate must be the first element in the array.
 
     : sig
-    :: The [=attestation signature=].
+    :: The [=attestation signature=].  It contains the (raw) U2F registration response message [[!FIDO-U2F-Message-Formats]].
 
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
+    The authenticator returns a cryptographically signed (raw) registration response message that has a different format
+    than the one expected for |authenticatorData|.  As a consequence, the platform needs to synthesize the
+    |authenticatorData| based on the (raw) U2F registration response message (u2fresp).
 
     Let |authenticatorData| denote the [=authenticator data for the attestation=], and let |clientDataHash| denote the
     [=hash of the serialized client data=].
@@ -2560,10 +2563,24 @@ This attestation statement format is used with FIDO U2F authenticators using the
     If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256 hash of
     |clientDataHash|.
 
-    Generate a signature as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with the application parameter set to the
-    SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |tbsHash|, and the key handle
-    parameter set to the credential ID of the given credential. Set this as |sig| and set the attestation certificate of
-    the attestation public key as |x5c|.
+    Let the authenticator generate a signed object as specified in [[FIDO-U2F-Message-Formats]] 
+    section 4.3, with the application parameter set to the SHA-256 hash of the [=RP ID=] 
+    associated with the given credential, the challenge parameter set to |tbsHash|, and the key handle
+    parameter set to the credential ID of the given credential. 
+
+    Let the platform generate |authenticatorData| as follows:
+    1. Set RP ID hash to the SHA-256 hash of the [=RP ID=]
+    2. Set Flags to <code>u2fresp.reserved_byte</code>.
+    3. Set counter to all zeros.
+    4. Set attestationData.AAGUID to all zeros
+    5. Set length L of credential ID to length of <code>u2fresp.keyHandle</code>
+    6. Set credential ID to <code>u2fresp.keyHandle</code>
+    7. Set credential public key to <code>u2fresp.userPublicKey</code>
+
+    Let the platform set:
+    1. |x5c| to <code>u2fresp.attestationCertificate</code>.
+    2. |sig| to <code>u2fresp.signature</code>.
+
 
 : Verification procedure
 :: Verification is performed as follows:

--- a/index.bs
+++ b/index.bs
@@ -2633,7 +2633,12 @@ This attestation statement format is used with FIDO U2F authenticators using the
     If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256 hash of
     |clientDataHash|.
 
-    Follow the procedure described in section 7.1. in [[!FIDO-CTAP]].   
+    Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with 
+    the application parameter set to the SHA-256 hash of the [=RP ID=] associated with the given credential, 
+    the challenge parameter set to |tbsHash|, and the key handle parameter set to the credential ID of the 
+    given credential. Set the raw signature part of this Registration Response Message (i.e., without the user public key,
+    key handle, and attestation certificates) as |sig| and set the attestation certificates of
+    the attestation public key as |x5c|.
 
 : Verification procedure
 :: Verification is performed as follows:

--- a/index.bs
+++ b/index.bs
@@ -603,7 +603,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     </li>
 
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
-    an {{AlgorithmIdentifier}}.
+    a {{COSEAlgorithmIdentifier}}.
 
 1. [=list/For each=] |current| of |options|.{{MakePublicKeyCredentialOptions/pubKeyCredParams}}:
     1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
@@ -1068,7 +1068,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 <pre class="idl">
     dictionary PublicKeyCredentialParameters {
         required PublicKeyCredentialType      type;
-        required AlgorithmIdentifier          alg;
+        required COSEAlgorithmIdentifier      alg;
     };
 </pre>
 
@@ -1435,14 +1435,14 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
 </div>
 
 
-### Cryptographic Algorithm Identifier (typedef <dfn>AlgorithmIdentifier</dfn>) ### {#alg-identifier}
+### Cryptographic Algorithm Identifier (typedef <dfn>COSEAlgorithmIdentifier</dfn>) ### {#alg-identifier}
 
 <pre class="idl">
-    typedef long AlgorithmIdentifier;
+    typedef long COSEAlgorithmIdentifier;
 </pre>
 
-<div dfn-type="typedef" dfn-for="AlgorithmIdentifier">
-    An {{AlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
+<div dfn-type="typedef" dfn-for="COSEAlgorithmIdentifier">
+    A {{COSEAlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
     The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>
@@ -1629,7 +1629,7 @@ input parameters:
 - The [=hash of the serialized client data=], provided by the client.
 - The [=[RP]=]'s {{PublicKeyCredentialEntity}}.
 - The user account's {{PublicKeyCredentialUserEntity}}.
-- A sequence of pairs of {{PublicKeyCredentialType}} and {{AlgorithmIdentifier}} requested by the [=[RP]=].
+- A sequence of pairs of {{PublicKeyCredentialType}} and {{COSEAlgorithmIdentifier}} requested by the [=[RP]=].
     This sequence is ordered from most preferred to least
     preferred. The platform makes a best-effort to create the most preferred credential that it can.
 - An optional list of {{PublicKeyCredentialDescriptor}} objects provided by the [=[RP]=] with the intention that, if any of
@@ -1813,7 +1813,7 @@ credential. It has the following format:
         <td>
             The [=credential public key=] encoded in COSE_Key format, as defined in Section 7 of [[!RFC8152]].
 	        The encoded [=credential public key=] MUST contain the "alg" parameter and MUST NOT contain any other optional
-	        parameters. The "alg" parameter MUST contain an {{AlgorithmIdentifier}} value.
+	        parameters. The "alg" parameter MUST contain a {{COSEAlgorithmIdentifier}} value.
         </td>
     </tr>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -1723,7 +1723,7 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     this [=public key credential|credential=]. The prompt for obtaining this [=user consent|consent=] may be shown by the
     [=authenticator=] if it has its own output capability, or by the user agent otherwise.
 - Process all the supported extensions requested by the client.
-- If the signature counter is supported, increment the signature counter.  
+- If the signature counter is supported, increment the signature counter by some positive value.  
     If a signature counter is not supported by this authenticator, assume a value of 0 for it.
 - Generate the [=authenticator data=] as specified in
     [[#sec-authenticator-data]], though without [=attestation data=]. 
@@ -2138,13 +2138,22 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 10. Using the credential public key looked up in step 1, verify that |sig| is a valid signature over the binary concatenation of
     |aData| and |hash|.
 
-11. If the [=signature counter=] value |adata|.|signCount| is nonzero or the value stored 
+11. If the [=signature counter=] value |adata|.|signCount| has the most significant bit (MSB) set to 0 or the value stored 
     in conjunction with |credential|'s {{Credential/id}} attribute
-    is nonzero, then set |signatureCounterSupported| to true.
+    has the most significant bit (MSB) set to 0, then set |signatureCounterSupported| to true.
 
 12. If |signatureCounterSupported| is true 
         If the [=signature counter=] value |adata|.|signCount| is
           <dl class="switch">
+              <dt>greater or equal to 0x80000000 (i.e. has MSB set to 1).</dt>
+	      <dd>This is an signal that the authenticator may be cloned, i.e. at least 
+                  two copies of the [=credential private key=] may exist and are  
+                  being used in parallel. [=[RPS]=] should incorporate this information  
+                  into their risk scoring.  Whether the [=RP=] updates the 
+                  stored [=signature counter=] value in this case, or not, or fails the 
+                  authentication ceremony or not, is 
+                  [=RP=]-specific. 
+	      </dd>
               <dt>greater than the [=signature counter=] value stored in conjunction 
                   with |credential|'s {{Credential/id}} attribute.</dt>
               <dd>Update the stored [=signature counter=] value, associated with 

--- a/index.bs
+++ b/index.bs
@@ -1621,6 +1621,22 @@ Note that the [=authenticator data=] describes its own length: If the AT and ED 
 The [=attestation data=] (which is only present if the AT flag is set) describes its own length. If the ED flag is set, then the
 total length is 37 bytes plus the length of the [=attestation data=], plus the length of the [=CBOR=] map that follows.
 
+### <dfn>Signature Counter</dfn> Considerations ### {#sign-counter}
+
+Authenticators may implement a [=signature counter=].  The [=signature counter=] increases the likelihood that
+a cloned authenticator gets detected.  This is especially helpful for authenticators 
+with limited protection measures.
+
+The [=signature counter=] is incremented at each [=authenticatorGetAssertion=] operation. The relying party stores
+the [=signature counter=] of the last operation and compares the stored [=signature counter=] with the [=signature counter=]
+included in the current assertion.  If the current value is less or equal to the stored value, a cloned authenticator exists.
+
+Detecting a counter mismatch doesn't indicate whether the current operation was triggered by the cloned authenticator
+or the original authenticator.  But it is an indication that the authenticator was cloned.
+The relying party should handle this reduced trust in the current authenticator appropriately.
+
+Authenticators should ensure that the [=signature counter=] value doesn't accidentally decrease 
+(e.g. due to hardware failures).
 
 ## Authenticator operations ## {#authenticator-ops}
 
@@ -1674,7 +1690,10 @@ When this operation is invoked, the authenticator must perform the following pro
         that are stored locally by the [=authenticator=].
 - If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
-- Process all the supported extensions requested by the client, and generate the [=authenticator data=] with
+- Process all the supported extensions requested by the client.
+- If the authenticator support a signature counter <i>per credential</i>, then initialize this counter with 0.  
+    (Alternatively, the authenticator might support a global signature counter).
+- Generate the [=authenticator data=] with
     [=attestation data=] as specified in [[#sec-authenticator-data]]. Use this [=authenticator data=] and the
     [=hash of the serialized client data=] to create an [=attestation object=] for the new credential using the procedure
     specified in [[#generating-an-attestation-object]]. For more details on attestation, see [[#sctn-attestation]].
@@ -1703,8 +1722,12 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 - Prompt the user to select a [=public key credential|credential=] from among the above list. Obtain [=user consent=] for using
     this [=public key credential|credential=]. The prompt for obtaining this [=user consent|consent=] may be shown by the
     [=authenticator=] if it has its own output capability, or by the user agent otherwise.
-- Process all the supported extensions requested by the client, and generate the [=authenticator data=] as specified in
-    [[#sec-authenticator-data]], though without [=attestation data=]. Concatenate this [=authenticator data=] with the [=hash of
+- Process all the supported extensions requested by the client.
+- If the signature counter is supported, increment the signature counter.  
+    If a signature counter is not supported by this authenticator, assume a value of 0 for it.
+- Generate the [=authenticator data=] as specified in
+    [[#sec-authenticator-data]], though without [=attestation data=]. 
+- Concatenate this [=authenticator data=] with the [=hash of
     the serialized client data=] to generate an [=assertion signature=] using the [=credential private key|private key=] of the
     selected [=public key credential|credential=] as shown in [Figure 2](#fig-signature), below. A simple, undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
@@ -2059,7 +2082,8 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 13. If the attestation statement |attStmt| verified successfully and is found to be trustworthy, then register the new
     credential with the account that was denoted in the
     {{PublicKeyCredential/[[Create]](options)/options}}.{{MakePublicKeyCredentialOptions/user}} passed to
-    {{CredentialsContainer/create()}}, by associating it with the credential ID and credential public key contained in
+    {{CredentialsContainer/create()}}, by associating it with the credential ID and credential public key, 
+    and the [=signature counter=] contained in
     |authData|'s [=attestation data=], as appropriate for the [=[RP]=]'s systems.
 
 14. If the attestation statement |attStmt| successfully verified but is not trustworthy per step 12 above, the [=[RP]=] SHOULD fail
@@ -2069,10 +2093,6 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
         credential as one with [=self attestation=] (see [[#sctn-attestation-types]]). If doing so, the [=[RP]=] is asserting there
         is no cryptographic proof that the [=public key credential=] has been generated by a particular [=authenticator=] model.
         See [[FIDOSecRef]] and [[UAFProtocol]] for a more detailed discussion.
-
-15. If verification of the attestation statement failed, the [=[RP]=] MUST fail the registration ceremony.
-
-16. Store the public key and the signature counter included in the attestation statement for this authenticator.
 
 Verification of [=attestation objects=] requires that the [=[RP]=] has a trusted method of determining acceptable trust anchors
 in step 11 above. Also, if certificates are being used, the [=[RP]=] must have access to certificate status information for the
@@ -2118,9 +2138,31 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 10. Using the credential public key looked up in step 1, verify that |sig| is a valid signature over the binary concatenation of
     |aData| and |hash|.
 
-11. Verify that the signature counter value is either (a) greater than the value stored or (b) it is equal to the value stored and the value stored is 0. If the signature counter violates this condition, this is an indication that the authenticator was cloned, i.e. at least two copies of the credential private key exist and are used in parallel.  This is a signal of potential fraud.
+11. If the [=signature counter=] value |adata|.|signCount| is nonzero or the value stored 
+    in conjunction with |credential|'s {{Credential/id}} attribute
+    is nonzero, then set |signatureCounterSupported| to true.
 
-12. If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the
+12. If |signatureCounterSupported| is true 
+        If the [=signature counter=] value |adata|.|signCount| is
+          <dl class="switch">
+              <dt>greater than the [=signature counter=] value stored in conjunction 
+                  with |credential|'s {{Credential/id}} attribute.</dt>
+              <dd>Update the stored [=signature counter=] value, associated with 
+                  |credential|'s {{Credential/id}} attribute, to be the value of 
+                  |adata|.|signCount|.</dd>
+	      <dt>less than or equal to the [=signature counter=] value stored in conjunction 
+                  with |credential|'s {{Credential/id}} attribute.</dt>
+              <dd>This is an signal that 
+                  the authenticator may be cloned, i.e. at least 
+                  two copies of the [=credential private key=] may exist and are  
+                  being used in parallel. [=[RPS]=] should incorporate this information  
+                  into their risk scoring.  Whether the [=RP=] updates the 
+                  stored [=signature counter=] value in this case, or not, or fails the 
+                  authentication ceremony or not, is 
+                  [=RP=]-specific. </dd>
+      </dl>
+
+13. If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the
     authentication ceremony.
 
 
@@ -2589,14 +2631,14 @@ This attestation statement format is used with FIDO U2F authenticators using the
     1. Set RP ID hash to the SHA-256 hash of the [=RP ID=]
     2. Set Flags to <code>u2fresp.reserved_byte</code>.
     3. Set counter to all zeros.
-    4. Set attestationData.AAGUID to all zeros
-    5. Set length L of credential ID to length of <code>u2fresp.keyHandle</code>
-    6. Set credential ID to <code>u2fresp.keyHandle</code>
-    7. Set credential public key to <code>u2fresp.userPublicKey</code>
-
-    Let the platform set:
-    1. |x5c| to <code>u2fresp.attestationCertificate</code>.
-    2. |sig| to <code>u2fresp.signature</code>.
+    4. Let the platform populate the |authenticatorData|'s [=attestation data=] as follows:
+         1. Set AAGUID to all zeros
+         2. Set L the length of credential ID to length of <code>u2fresp.keyHandle</code>
+         3. Set credentialID to <code>u2fresp.keyHandle</code>
+         4. Set credentialPublicKey to <code>u2fresp.userPublicKey</code>
+    5. Let the platform set the fields in u2fStmtFormat:
+         1. Set |x5c| to <code>u2fresp.attestationCertificate</code>.
+         2. Set |sig| to <code>u2fresp.signature</code>.
 
 
 : Verification procedure

--- a/index.bs
+++ b/index.bs
@@ -2118,7 +2118,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 10. Using the credential public key looked up in step 1, verify that |sig| is a valid signature over the binary concatenation of
     |aData| and |hash|.
 
-11. Verify that the signature counter value is either (a) greater than the value stored or (b) it is equal to the value stored and the value stored is 0. 
+11. Verify that the signature counter value is either (a) greater than the value stored or (b) it is equal to the value stored and the value stored is 0. If the signature counter violates this condition, this is an indication that the authenticator was cloned, i.e. at least two copies of the credential private key exist and are used in parallel.  This is a signal of potential fraud.
 
 12. If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the
     authentication ceremony.


### PR DESCRIPTION
This is the one with MSB=1 flagging it is not supported. MSB=0 means it is suported and included in the other bits.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/sign-counter-alg-507-alternative.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/089c10e...1a93e76.html)