### PR TITLE
Rewrite Generating an Attestation Object as an algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1928,15 +1928,15 @@ WebAuthn supports multiple attestation types:
 To generate an [=attestation object=] (see: [Figure 3](#fig-attStructs)) given:
 
 : |attestationFormat|
-:: An [=attestation statement format=]
+:: An [=attestation statement format=].
 : |authData|
 :: A byte array containing [=authenticator data=].
 : |hash|
-:: A cryptographic hash expected to contain the [=hash of the serialized client data=].
+:: The [=hash of the serialized client data=].
 
 the [=authenticator=] MUST:
 
-1. Let <var ignore>attStmt</var> be the result of running |attestationFormat|'s [=signing procedure=] over |authData| and
+1. Let <var ignore>attStmt</var> be the result of running |attestationFormat|'s [=signing procedure=] given |authData| and
     |hash|.
 1. Let <var ignore>fmt</var> be |attestationFormat|'s [=attestation statement format identifier=]
 1. Return the [=attestation object=] as a CBOR map with the following syntax, filled in with variables initialized by this

--- a/index.bs
+++ b/index.bs
@@ -1923,47 +1923,39 @@ WebAuthn supports multiple attestation types:
     ECDAA-Issuer (see [[FIDOEcdaaAlgorithm]]).
 
 
-### Generating an Attestation Object ### {#generating-an-attestation-object}
+<h4 id="generating-an-attestation-object" algorithm>Generating an Attestation Object</h4>
 
-This section specifies the algorithm for generating an [=attestation object=] (see: [Figure 3](#fig-attStructs)) for any
-[=attestation statement format=].
+To generate an [=attestation object=] (see: [Figure 3](#fig-attStructs)) given:
 
-In order to construct an [=attestation object=] for a given [=public key credential=] using a particular [=attestation statement
-format=], the [=authenticator=] MUST first generate the [=authenticator data=].
+: |attestationFormat|
+:: An [=attestation statement format=]
+: |authData|
+:: A byte array containing [=authenticator data=].
+: |hash|
+:: A cryptographic hash expected to contain the [=hash of the serialized client data=].
 
-The [=authenticator=] MUST then run the signing procedure for the desired attestation statement format with this
-[=authenticator data=] and the [=hash of the serialized client data=] as input, and use this to construct an attestation
-statement in that attestation statement format.
+the [=authenticator=] MUST:
 
-Finally, the authenticator MUST construct the [=attestation object=] as a CBOR map with the following syntax:
+1. Let <var ignore>attStmt</var> be the result of running |attestationFormat|'s [=signing procedure=] over |authData| and
+    |hash|.
+1. Let <var ignore>fmt</var> be |attestationFormat|'s [=attestation statement format identifier=]
+1. Return the [=attestation object=] as a CBOR map with the following syntax, filled in with variables initialized by this
+    algorithm:
 
-```
-attObj = {
-            authData: bytes,
-            $$attStmtType
-         }
+    ```
+    attObj = {
+                authData: bytes,
+                $$attStmtType
+             }
 
-attStmtTemplate = (
-                      fmt: text,
-                      attStmt: { * tstr => any } ; Map is filled in by each concrete attStmtType
-                  )
+    attStmtTemplate = (
+                          fmt: text,
+                          attStmt: { * tstr => any } ; Map is filled in by each concrete attStmtType
+                      )
 
-; Every attestation statement format must have the above fields
-attStmtTemplate .within $$attStmtType
-```
-
-The semantics of the fields in the [=attestation object=] are as follows:
-
-: fmt
-:: The [=attestation statement format identifier=] associated with the attestation statement. Each attestation statement
-    format defines its identifier.
-
-: authData
-:: The [=authenticator data=] used to generate the attestation statement.
-
-: attStmt
-:: The attestation statement constructed above. The syntax of this is defined by the attestation statement format used.
-
+    ; Every attestation statement format must have the above fields
+    attStmtTemplate .within $$attStmtType
+    ```
 
 ### Security Considerations ### {#sec-attestation-security-considerations}
 


### PR DESCRIPTION
This replaces the "first generate the authenticator data" step with an input
because that's how it's called.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#generating-an-attestation-object
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jyasskin/webauthn/generate-att-obj-algorithm.html#generating-an-attestation-object) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/e74d8c4...jyasskin:e1bbfd9.html)