### PR TITLE
Number the steps in the authenticator operations.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1673,31 +1673,31 @@ input parameters:
 - Extension data created by the client based on the extensions requested by the [=[RP]=], if any.
 
 When this operation is invoked, the authenticator must perform the following procedure:
-- Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
+1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
     equivalent to "{{UnknownError}}" and terminate the operation.
--  Check if at least one of the specified combinations of {{PublicKeyCredentialType}} and cryptographic parameters is supported.
+1. Check if at least one of the specified combinations of {{PublicKeyCredentialType}} and cryptographic parameters is supported.
     If not, return an error code equivalent to "{{NotSupportedError}}" and terminate the operation.
-- Check if a credential matching any of the supplied {{PublicKeyCredential}} identifiers is present on this authenticator. If
+1. Check if a credential matching any of the supplied {{PublicKeyCredential}} identifiers is present on this authenticator. If
     so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
-- If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
+1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-- If |requireUserVerification| is |true| and the authenticator cannot perform user verification,
+1. If |requireUserVerification| is |true| and the authenticator cannot perform user verification,
     return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-- Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
+1. Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
     if it has its own output capability, or by the user agent otherwise. If the user denies consent, return an error code
     equivalent to "{{NotAllowedError}}" and terminate the operation.
-- Once user consent has been obtained, generate a new credential object:
-    - Generate a set of cryptographic keys using the most preferred combination of {{PublicKeyCredentialType}} and cryptographic
+1. Once user consent has been obtained, generate a new credential object:
+    1. Generate a set of cryptographic keys using the most preferred combination of {{PublicKeyCredentialType}} and cryptographic
         parameters supported by this authenticator.
-    - Generate an identifier for this credential, such that this identifier is globally unique with high probability across all
+    1. Generate an identifier for this credential, such that this identifier is globally unique with high probability across all
         credentials with the same type across all authenticators.
-    - Associate the credential with the specified [=RP ID=] and the user's account identifier
+    1. Associate the credential with the specified [=RP ID=] and the user's account identifier
         {{MakePublicKeyCredentialOptions/user}}.{{PublicKeyCredentialUserEntity/id}}.
-    - Delete any older credentials with the same [=RP ID=] and {{MakePublicKeyCredentialOptions/user}}.{{PublicKeyCredentialUserEntity/id}}
+    1. Delete any older credentials with the same [=RP ID=] and {{MakePublicKeyCredentialOptions/user}}.{{PublicKeyCredentialUserEntity/id}}
         that are stored locally by the [=authenticator=].
-- If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
+1. If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
-- Process all the supported extensions requested by the client, and generate the [=authenticator data=] with
+1. Process all the supported extensions requested by the client, and generate the [=authenticator data=] with
     [=attestation data=] as specified in [[#sec-authenticator-data]]. Use this [=authenticator data=] and the
     [=hash of the serialized client data=] to create an [=attestation object=] for the new credential using the procedure
     specified in [[#generating-an-attestation-object]]. For more details on attestation, see [[#sctn-attestation]].
@@ -1716,23 +1716,23 @@ input parameters:
 - Extension data created by the client based on the extensions requested by the [=[RP]=], if any.
 
 When this method is invoked, the [=authenticator=] must perform the following procedure:
-- Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
+1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
     equivalent to "{{UnknownError}}" and terminate the operation.
-- If a list of credentials was supplied by the client, filter it by removing those credentials that are not present on this
+1. If a list of credentials was supplied by the client, filter it by removing those credentials that are not present on this
     [=authenticator=]. If no list was supplied, create a list with all credentials stored for the caller's [=RP ID=] (as
     determined by an exact match of the [=RP ID=]).
-- If the previous step resulted in an empty list, return an error code equivalent to "{{NotAllowedError}}" and terminate the
+1. If the previous step resulted in an empty list, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
-- Prompt the user to select a [=public key credential|credential=] from among the above list. Obtain [=user consent=] for using
+1. Prompt the user to select a [=public key credential|credential=] from among the above list. Obtain [=user consent=] for using
     this [=public key credential|credential=]. The prompt for obtaining this [=user consent|consent=] may be shown by the
     [=authenticator=] if it has its own output capability, or by the user agent otherwise.
-- Process all the supported extensions requested by the client, and generate the [=authenticator data=] as specified in
+1. Process all the supported extensions requested by the client, and generate the [=authenticator data=] as specified in
     [[#sec-authenticator-data]], though without [=attestation data=]. Concatenate this [=authenticator data=] with the [=hash of
     the serialized client data=] to generate an [=assertion signature=] using the [=credential private key|private key=] of the
     selected [=public key credential|credential=] as shown in [Figure 2](#fig-signature), below. A simple, undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
     client data=] (which potentially has a variable length) is always the last element.
-- If any error occurred while generating the [=assertion signature=], return an error code equivalent to "{{UnknownError}}" and
+1. If any error occurred while generating the [=assertion signature=], return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
 
 <figure id="fig-signature">


### PR DESCRIPTION
This shouldn't change any actual text.

It starts addressing https://github.com/w3c/webauthn/issues/410#issuecomment-304353265.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#authenticator-ops
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jyasskin/webauthn/number-authenticator-steps.html#authenticator-ops) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/23b91fb...jyasskin:eaba474.html)