### PR TITLE
Add a Relying Party conformance class.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -220,7 +220,7 @@ external hardware, or a combination of both.
 
 ## [RPS] ## {#conforming-relying-parties}
 
-A [RP] MUST behave as described in [[#rp-operations]] to get the security benefits offered by this specification.
+A [=[RP]=] MUST behave as described in [[#rp-operations]] to get the security benefits offered by this specification.
 
 # Dependencies # {#dependencies}
 

--- a/index.bs
+++ b/index.bs
@@ -197,19 +197,32 @@ A variety of additional use cases and configurations are also possible, includin
 
 # Conformance # {#conformance}
 
-This specification defines criteria for a [=Conforming User Agent=]: A User Agent MUST behave as described in this
-specification in order to be considered conformant. [=Conforming User Agents=] MAY implement algorithms given in this
-specification in any way desired, so long as the end result is indistinguishable from the result that would be obtained by the
-specification's algorithms. A conforming User Agent MUST also be a conforming implementation of the IDL fragments of this
-specification, as described in the “Web IDL” specification. [[!WebIDL-1]]
+This specification defines three conformance classes. Each of these classes is specified so that conforming members of the class
+are secure against non-conforming or hostile members of the other classes.
 
-This specification also defines a model of a conformant [=authenticator=] (see [[#authenticator-model]]). This is a set of
-functional and security requirements for an authenticator to be usable by a [=Conforming User Agent=]. As described in
-[[#use-cases]], an authenticator may be implemented in the operating system underlying the User Agent, or in external hardware,
-or a combination of both.
+## User Agents ## {#conforming-user-agents}
 
+A User Agent MUST behave as described by [[#api]] in order to be considered conformant. [=Conforming User Agents=] MAY implement
+algorithms given in this specification in any way desired, so long as the end result is indistinguishable from the result that
+would be obtained by the specification's algorithms.
 
-## Dependencies ## {#dependencies}
+A conforming User Agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the
+“Web IDL” specification. [[!WebIDL-1]]
+
+## Authenticators ## {#conforming-authenticators}
+
+An [=authenticator=] MUST provide the operations defined by [[#authenticator-model]], and those operations MUST behave as
+described there. This is a set of functional and security requirements for an authenticator to be usable by a [=Conforming User
+Agent=].
+
+As described in [[#use-cases]], an authenticator may be implemented in the operating system underlying the User Agent, or in
+external hardware, or a combination of both.
+
+## [RPS] ## {#conforming-relying-parties}
+
+A [RP] MUST behave as described in [[#rp-operations]] to get the security benefits offered by this specification.
+
+# Dependencies # {#dependencies}
 
 This specification relies on several other underlying specifications, listed
 below and in [[#index-defined-elsewhere]].


### PR DESCRIPTION
Fixes #88.

This is very rough and isn't informed by other descriptions of conformance classes in other web specs. Let me know what you want to see here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#conformance
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jyasskin/webauthn/conformance-classes.html#conformance) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/e74d8c4...jyasskin:7dc8c96.html)