### PR TITLE
Rewrite the "make an assertion" introduction to clarify how get() works.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -98,6 +98,7 @@ spec: mixed-content; urlPrefix: www.w3.org/TR/mixed-content/
 </pre> <!-- class=anchors -->
 
 <pre class="link-defaults">
+spec:credential-management; type:dfn; text:credentials
 spec:html; type:dfn; for:environment settings object; text:global object
 spec:infra; type:dfn; text:list
 spec:url; type:dfn; text:domain
@@ -753,29 +754,28 @@ authorizing an authenticator.
 </div>
 
 
-### Use an existing credential to make an assertion - PublicKeyCredential's `[[DiscoverFromExternalSource]](options)` method ### {#getAssertion}
+### Use an existing credential to make an assertion ### {#getAssertion}
 
-<div link-for-hint="PublicKeyCredential/[[DiscoverFromExternalSource]](options)">
-The <dfn for="PublicKeyCredential" method>\[[DiscoverFromExternalSource]](options)</dfn> method is used to discover and use an
-existing [=public key credential=], with the user's consent. The script optionally specifies some criteria to indicate what
-credentials are acceptable to it. The user agent and/or platform locates credentials matching the specified criteria, and guides
-the user to pick one that the script will be allowed to use. The user may choose not to provide a credential even if one is
-present, for example to maintain privacy.
+[RPS] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
+discover and use an existing [=public key credential=], with the user's consent. The script optionally specifies some criteria
+to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential sources=]
+matching the specified criteria, and guides the user to pick one that the script will be allowed to use. It then uses
+[[#op-get-assertion]] to sign a [RP]-provided challenge and other collected data into an assertion, which is used as a
+[=credential=]. The user may choose not to provide a credential even if one is present, for example to maintain privacy.
 
-Note: This algorithm is synchronous; the {{Promise}} resolution/rejection is handled by
-{{CredentialsContainer/get()|navigator.credentials.get()}}.
+The {{CredentialsContainer/get()}} implementation calls
+<code>PublicKeyCredential.{{PublicKeyCredential/[[CollectFromCredentialStore]]()}}</code> to collect any [=credentials=] that
+should be available without [=user mediation=] (roughly this specification's [=test of user presence=]), and if it doesn't find
+exactly one of those, it calls <code>PublicKeyCredential.{{PublicKeyCredential/[[DiscoverFromExternalSource]]()}}</code> to have
+the user select a [=credential source=].
 
-This method accepts a single argument:
+Since this specification requires a [=test of user presence=] to create any [=credentials=], <code>PublicKeyCredential.<dfn
+for="PublicKeyCredential" method>\[[CollectFromCredentialStore]](options)</dfn></code> inherits the default behavior of
+{{Credential/[[CollectFromCredentialStore]]()|Credential.[[CollectFromCredentialStore]]()}}, of returning an empty set.
 
-<dl dfn-type="argument" dfn-for="PublicKeyCredential/[[DiscoverFromExternalSource]](options)">
-    :   <dfn>options</dfn>
-    ::  This argument is a {{CredentialRequestOptions}} object whose
-        <code>|options|.{{CredentialRequestOptions/publicKey}}</code> member contains a challenge and additional options as
-        described in [[#assertion-options]]. The selected authenticator signs the challenge along with other collected data in
-        order to produce an assertion. See [[#op-get-assertion]].
-</dl>
-
-When this method is invoked, the user agent MUST execute the following algorithm:
+<div link-for-hint="PublicKeyCredential/[[DiscoverFromExternalSource]](options)" algorithm="[[DiscoverFromExternalSource]]">
+When the <code>PublicKeyCredential.<dfn for="PublicKeyCredential" method>\[[DiscoverFromExternalSource]](options)</dfn></code>
+method is invoked, the user agent MUST:
 
 1. Assert: <code>|options|.{{CredentialRequestOptions/publicKey}}</code> is [=present=].
 

--- a/index.bs
+++ b/index.bs
@@ -756,24 +756,26 @@ authorizing an authenticator.
 
 ### Use an existing credential to make an assertion ### {#getAssertion}
 
-[RPS] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
+[=[RPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
 discover and use an existing [=public key credential=], with the user's consent. The script optionally specifies some criteria
 to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential sources=]
 matching the specified criteria, and guides the user to pick one that the script will be allowed to use. It then uses
 [[#op-get-assertion]] to sign a [RP]-provided challenge and other collected data into an assertion, which is used as a
 [=credential=]. The user may choose not to provide a credential even if one is present, for example to maintain privacy.
 
-The {{CredentialsContainer/get()}} implementation calls
+The {{CredentialsContainer/get()}} implementation [[CREDENTIAL-MANAGEMENT-1]] calls
 <code>PublicKeyCredential.{{PublicKeyCredential/[[CollectFromCredentialStore]]()}}</code> to collect any [=credentials=] that
-should be available without [=user mediation=] (roughly this specification's [=test of user presence=]), and if it doesn't find
+should be available without [=user mediation=] (roughly, this specification's [=authorization gesture=]), and if it doesn't find
 exactly one of those, it calls <code>PublicKeyCredential.{{PublicKeyCredential/[[DiscoverFromExternalSource]]()}}</code> to have
 the user select a [=credential source=].
 
-Since this specification requires a [=test of user presence=] to create any [=credentials=], <code>PublicKeyCredential.<dfn
+Since this specification requires an [=authorization gesture=] to create any [=credentials=], <code>PublicKeyCredential.<dfn
 for="PublicKeyCredential" method>\[[CollectFromCredentialStore]](options)</dfn></code> inherits the default behavior of
 {{Credential/[[CollectFromCredentialStore]]()|Credential.[[CollectFromCredentialStore]]()}}, of returning an empty set.
 
-<div link-for-hint="PublicKeyCredential/[[DiscoverFromExternalSource]](options)" algorithm="[[DiscoverFromExternalSource]]">
+<h5 id="discover-from-external-source" algorithm>PublicKeyCredential's `[[DiscoverFromExternalSource]](options)` method</h5>
+
+<div link-for-hint="PublicKeyCredential/[[DiscoverFromExternalSource]](options)">
 When the <code>PublicKeyCredential.<dfn for="PublicKeyCredential" method>\[[DiscoverFromExternalSource]](options)</dfn></code>
 method is invoked, the user agent MUST:
 

--- a/index.bs
+++ b/index.bs
@@ -759,9 +759,11 @@ authorizing an authenticator.
 [=[RPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
 discover and use an existing [=public key credential=], with the user's consent. The script optionally specifies some criteria
 to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential sources=]
-matching the specified criteria, and guides the user to pick one that the script will be allowed to use. It then uses
+matching the specified criteria, and guides the user to pick one that the script will be allowed to use. The user may choose to
+decline the entire interaction even if a [=credential source=] is present, for example to maintain privacy. If the user picks a
+[=credential source=], the user agent then uses
 [[#op-get-assertion]] to sign a [RP]-provided challenge and other collected data into an assertion, which is used as a
-[=credential=]. The user may choose not to provide a credential even if one is present, for example to maintain privacy.
+[=credential=].
 
 The {{CredentialsContainer/get()}} implementation [[CREDENTIAL-MANAGEMENT-1]] calls
 <code>PublicKeyCredential.{{PublicKeyCredential/[[CollectFromCredentialStore]]()}}</code> to collect any [=credentials=] that


### PR DESCRIPTION
Fixes #566.

I hope this makes things easier to understand.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#getAssertion
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jyasskin/webauthn/clarify-get-flow.html#getAssertion) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/997e749...jyasskin:9ed6734.html)