### PR TITLE
Use || uniformly for concatenation.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3040,9 +3040,10 @@ This [=registration extension=] and [=authentication extension=] enables use of 
     The UVI data can be used by servers to understand whether an authentication was authorized by the exact same biometric data
     as the initial key generation. This allows the detection and prevention of "friendly fraud".
 
-    As an example, the UVI could be computed as SHA256(KeyID | SHA256(rawUVI)), where the rawUVI reflects (a) the biometric
-    reference data, (b) the related OS level user ID and (c) an identifier which changes whenever a factory reset is performed
-    for the device, e.g. rawUVI = biometricReferenceData | OSLevelUserID | FactoryResetCounter.
+    As an example, the UVI could be computed as SHA256(KeyID || SHA256(rawUVI)), where `||` represents concatenation, and the
+    rawUVI reflects (a) the biometric reference data, (b) the related OS level user ID and (c) an identifier which changes
+    whenever a factory reset is performed for the device, e.g. rawUVI = biometricReferenceData || OSLevelUserID ||
+    FactoryResetCounter.
 
     Servers supporting UVI extensions MUST support a length of up to 32 bytes for the UVI value.
 


### PR DESCRIPTION
Fixes #562.

This doesn't yet introduce the notational conventions section since it's straightforward to say what || means everywhere it's used so far.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jyasskin/webauthn/use-double-bar-for-concat.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/8b23fb8...jyasskin:c69fe5b.html)