### PR TITLE
Remove [SameObject] from AuthenticatorAssertionResponse.userId

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1065,7 +1065,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
-        [SameObject] readonly attribute DOMString        userId;
+        readonly attribute DOMString                     userId;
     };
 </pre>
 <div dfn-type="attribute" dfn-for="AuthenticatorAssertionResponse">


### PR DESCRIPTION
WebIDL does not allow `[SameObject]` to be used for non-interface types, like
`DOMString`.

The WebIDL spec describes its limitations [1] as:

> The `[SameObject]` extended attribute must not be used on anything other than a
> read only attribute whose type is an interface type or object.

`DOMString` is a primitive; it is neither an interface type nor an object [2],
so this patch removes the [SameObject] that was mistakenly annotated on it.

[1] https://heycam.github.io/webidl/#SameObject
[2] https://heycam.github.io/webidl/#idl-DOMString


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/sameobject-userid.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/089c10e...jcjones:e11baf3.html)