### PR TITLE
Fix #618 - Make PublicKeyCredential.isPlatformAuthenticatorAvailable static

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -998,7 +998,7 @@ but short enough that the dangling promise will still be resolved in a reasonabl
 <pre class="idl">
     [SecureContext]
     partial interface PublicKeyCredential {
-        [Unscopable] Promise < boolean > isPlatformAuthenticatorAvailable();
+        static Promise < boolean > isPlatformAuthenticatorAvailable();
     };
 </pre>
 


### PR DESCRIPTION
Please see issue #618 for details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/618-isPlatformAuthenticatorAvailable.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/089c10e...jcjones:d0a010c.html)