### PR TITLE
Fix #551 - Define a Store method for PublicKeyCredential.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -985,6 +985,26 @@ During the above process, the user agent SHOULD show some UI to the user to guid
 authorizing an authenticator with which to complete the operation.
 </div>
 
+### Store an existing credential - PublicKeyCredential's `[[Store]](credential)` method ### {#storeCredential}
+
+<div link-for-hint="PublicKeyCredential/[[Store]](credential)">
+
+The <dfn for="PublicKeyCredential" method>\[[Store]](credential)</dfn> method is not supported
+for Web Authentication's {{PublicKeyCredential}} type, so it always returns an error.
+
+Note: This algorithm is synchronous; the {{Promise}} resolution/rejection is handled by
+{{CredentialsContainer/store()|navigator.credentials.store()}}.
+
+This method accepts a single argument:
+
+<dl dfn-type="argument" dfn-for="PublicKeyCredential/[[Store]](credential)">
+    :   <dfn>credential</dfn>
+    ::  This argument is a {{PublicKeyCredential}} object.
+</dl>
+
+When this method is invoked, the user agent MUST execute the following algorithm:
+
+1. Return a {{DOMException}} whose name is "{{NotSupportedError}}", and terminate this algorithm
 
 ### Platform Authenticator Availability - PublicKeyCredential's `isPlatformAuthenticatorAvailable()` method ### {#isPlatformAuthenticatorAvailable}
 


### PR DESCRIPTION
The Store operation isn't defined for PublicKeyCredential, even though it
is inherited from Credential Management. This defines that operation as
always resolving with an error.

This will resolve #551 .


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/551-store.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/f6c9ed6...jcjones:b7613fa.html)