### PR TITLE
Fix #569 - Add Exposed to all WebIDL interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -480,7 +480,7 @@ The {{PublicKeyCredential}} interface inherits from {{Credential}} [[!CREDENTIAL
 that are returned to the caller when a new credential is created, or a new assertion is requested.
 
 <xmp class="idl">
-    [SecureContext]
+    [SecureContext, Exposed=Window]
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
         [SameObject] readonly attribute AuthenticatorResponse    response;
@@ -1036,7 +1036,7 @@ this is enough time for successful user interactions to be performed
 but short enough that the dangling promise will still be resolved in a reasonably timely fashion.
 
 <pre class="idl">
-    [SecureContext]
+    [SecureContext, Exposed=Window]
     partial interface PublicKeyCredential {
         static Promise < boolean > isPlatformAuthenticatorAvailable();
     };
@@ -1051,7 +1051,7 @@ but short enough that the dangling promise will still be resolved in a reasonabl
 {{AuthenticatorResponse}} interface:
 
 <pre class="idl">
-    [SecureContext]
+    [SecureContext, Exposed=Window]
     interface AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      clientDataJSON;
     };
@@ -1070,7 +1070,7 @@ identify it for later use, and metadata that can be used by the [=[RP]=] to asse
 during registration.
 
 <pre class="idl">
-    [SecureContext]
+    [SecureContext, Exposed=Window]
     interface AuthenticatorAttestationResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      attestationObject;
     };
@@ -1101,7 +1101,7 @@ aware of. This response contains a cryptographic signature proving possession of
 optionally evidence of [=user consent=] to a specific transaction.
 
 <pre class="idl">
-    [SecureContext]
+    [SecureContext, Exposed=Window]
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;

--- a/index.bs
+++ b/index.bs
@@ -1036,7 +1036,6 @@ this is enough time for successful user interactions to be performed
 but short enough that the dangling promise will still be resolved in a reasonably timely fashion.
 
 <pre class="idl">
-    [SecureContext, Exposed=Window]
     partial interface PublicKeyCredential {
         static Promise < boolean > isPlatformAuthenticatorAvailable();
     };


### PR DESCRIPTION
This is to resolve issue #569.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/569-exposed_webidl.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/06d5468...jcjones:54ee9c9.html)