### PR TITLE
Fix #624 - Change PublicKeyCredential.clientExtensionResults to an operation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -471,7 +471,7 @@ that are returned to the caller when a new credential is created, or a new asser
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
         [SameObject] readonly attribute AuthenticatorResponse    response;
-        [SameObject] readonly attribute AuthenticationExtensions clientExtensionResults;
+        AuthenticationExtensions getClientExtensionResults();
     };
 </xmp>
 <dl dfn-type="attribute" dfn-for="PublicKeyCredential">
@@ -490,8 +490,8 @@ that are returned to the caller when a new credential is created, or a new asser
         the {{PublicKeyCredential}} was created in response to {{CredentialsContainer/get()}}, and this attribute's value
         will be an {{AuthenticatorAssertionResponse}}.
 
-    :   <dfn>clientExtensionResults</dfn>
-    ::  This attribute contains a [=map=] containing [=extension identifier=] → [=client extension output=] entries
+    :   {{PublicKeyCredential/getClientExtensionResults()}}
+    ::  This operation returns a [=map=] containing [=extension identifier=] → [=client extension output=] entries
         produced by the extension's [=client extension processing=].
 
     :   <dfn>\[[type]]</dfn>
@@ -735,10 +735,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of |clientDataJSON|.
                 :   {{AuthenticatorAttestationResponse/attestationObject}}
                 ::  |attestationObject|
-            :   {{PublicKeyCredential/clientExtensionResults}}
-            ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
-                entries created by running each extension's [=client extension processing=] algorithm to create the [=client
-                extension outputs=], for each [=client extension=] in {{AuthenticatorResponse/clientDataJSON}}.clientExtensions.
 
         5. [=set/For each=] remaining |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on
             |authenticator| and [=set/remove=] it from |issuedRequests|.
@@ -955,10 +951,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 : {{AuthenticatorAssertionResponse/userHandle}}
                 :: A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the [=user handle=] returned from the successful [=authenticatorGetAssertion=]
                     operation, as defined in [[#op-get-assertion]].
-            :   {{PublicKeyCredential/clientExtensionResults}}
-            ::  A new {{AuthenticationExtensions}} object containing the [=extension identifier=] → [=client extension output=]
-                entries created by running each extension's [=client extension processing=] algorithm to create the [=client
-                extension outputs=], for each [=client extension=] in {{AuthenticatorResponse/clientDataJSON}}.clientExtensions.
 
         3.  [=set/For each=] remaining |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on
             |authenticator| and [=set/remove=] it from |issuedRequests|.
@@ -2761,7 +2753,7 @@ Supported [=client extensions=] are recorded as a dictionary in the [=client dat
 {{CollectedClientData/clientExtensions}}. For each such extension, the client adds an entry to this dictionary with the
 [=extension identifier=] as the key, and the extension's [=client extension input=] as the value.
 
-Likewise, the [=client extension outputs=] are represented as a dictionary in the {{PublicKeyCredential/clientExtensionResults}}
+Likewise, the [=client extension outputs=] are represented as a dictionary in the result of {{PublicKeyCredential/getClientExtensionResults()}}
 with [=extension identifiers=] as keys, and the <dfn>client extension output</dfn> value of each extension as the value.
 Like the [=client extension input=], the [=client extension output=] is a value that can be encoded in JSON.
 


### PR DESCRIPTION
The attribute `clientExtensionResults` is a typedef of `record<DOMString, any>`.
The WebIDL spec says "Records must not be used as the type of an attribute
or constant", so this is not legal.

This commit changes the attribute `clientExtensionResults` into an operation
`getClientExtensionResults()`.

This resolves #624.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/624-clientExtensionResults.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/e74d8c4...jcjones:355f1ca.html)