### PR TITLE
Relaxing user prompt requirements in certain cases

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1710,7 +1710,8 @@ When this operation is invoked, the authenticator must perform the following pro
     return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
     if it has its own output capability, or by the user agent otherwise. If the user denies consent, return an error code
-    equivalent to "{{NotAllowedError}}" and terminate the operation.
+    equivalent to "{{NotAllowedError}}" and terminate the operation. The Authenticator and user agent MAY skip this prompt
+    if the Authenticator is a [=platform authenticator=] and |excludeCredentialDescriptorList| is empty.
 1. Once user consent has been obtained, generate a new credential object:
     1. Generate a set of cryptographic keys using the most preferred combination of {{PublicKeyCredentialType}} and cryptographic
         parameters supported by this authenticator.


### PR DESCRIPTION
Relaxing the requirement to prompt the user on key creation *if* the authenticator is built-in *and* the RP didn't supply an excludeList of credentials.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/balfanz-patch-3.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/1674caa...9598e1d.html)