### PR TITLE
update CTAP ref with correct authors and URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3821,10 +3821,11 @@ Axel Nennker, Kimberly Paulhamus, Adam Powers, Yaron Sheffer, Mike West, Jeffrey
   },
 
   "FIDO-CTAP": {
-    "authors": ["R. Lindemann", "V. Bharadwaj", "A. Czeskis", "M. B. Jones"],
+    "authors": ["R. Lindemann", "V. Bharadwaj", "A. Czeskis", "M. B. Jones", "J. Hodges", "A. Kumar", "C. Brand", "J. Verrept",
+        "J. Ehrensvard"],
     "title": "FIDO 2.0: Client to Authenticator Protocol",
-    "href": "",
-    "status": "FIDO Alliance Working Draft"
+    "href": "https://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-client-to-authenticator-protocol-v2.0-rd-20170927.html",
+    "status": "FIDO Alliance Review Draft"
   },
 
   "CDDL": {


### PR DESCRIPTION
update CTAP ref with correct authors and URL
fixes #608


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/fix-608-update-ctap-ref.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/97e8af0...121c703.html)