### PR TITLE
Only exclude CredIDs matching the RPID

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1831,7 +1831,7 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
     an exact match of |rpId|).
 1. Remove any items from |allowCredentialDescriptorList| that are not present on this [=authenticator=] for
-    the supplied <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>
+    the supplied |rpId|.
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.

--- a/index.bs
+++ b/index.bs
@@ -1763,7 +1763,8 @@ When this operation is invoked, the authenticator must perform the following pro
     |credTypesAndPubKeyAlgs| is supported.
     If not, return an error code equivalent to "{{NotSupportedError}}" and terminate the operation.
 1. Check if a credential matching an [=list/item=] of |excludeCredentialDescriptorList| is present on this authenticator for
-    the supplied |rpId|. If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
+    the supplied <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>. If so, return an error code equivalent to 
+    "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is |true| and the authenticator cannot perform user verification,

--- a/index.bs
+++ b/index.bs
@@ -1762,9 +1762,10 @@ When this operation is invoked, the authenticator must perform the following pro
 1. Check if at least one of the specified combinations of {{PublicKeyCredentialType}} and cryptographic parameters in
     |credTypesAndPubKeyAlgs| is supported.
     If not, return an error code equivalent to "{{NotSupportedError}}" and terminate the operation.
-1. Check if a credential matching an [=list/item=] of |excludeCredentialDescriptorList| is present on this authenticator for
-    the supplied <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>. If so, return an error code equivalent to 
-    "{{NotAllowedError}}" and terminate the operation.
+1. Check if any credential bound to this authenticator matches an [=list/item=] of |excludeCredentialDescriptorList|. A match 
+   occurs if a credential matches <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>, <code>|excludeCredentialDescriptorList|. 
+   {{PublicKeyCredentialDescriptor/id}}</code>, and <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code>. 
+   If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is |true| and the authenticator cannot perform user verification,

--- a/index.bs
+++ b/index.bs
@@ -1762,8 +1762,8 @@ When this operation is invoked, the authenticator must perform the following pro
 1. Check if at least one of the specified combinations of {{PublicKeyCredentialType}} and cryptographic parameters in
     |credTypesAndPubKeyAlgs| is supported.
     If not, return an error code equivalent to "{{NotSupportedError}}" and terminate the operation.
-1. Check if a credential matching an [=list/item=] of |excludeCredentialDescriptorList| is present on this authenticator. If
-    so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
+1. Check if a credential matching an [=list/item=] of |excludeCredentialDescriptorList| is present on this authenticator for
+    the supplied |rpId|. If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is |true| and the authenticator cannot perform user verification,

--- a/index.bs
+++ b/index.bs
@@ -1835,7 +1835,6 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 1. Remove any items from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A match 
    occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's <code>|allowCredentialDescriptorList| 
    {{PublicKeyCredentialDescriptor/id}}</code> and <code>|allowCredentialDescriptorList|{{PublicKeyCredentialDescriptor/type}}</code>. 
-   If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.

--- a/index.bs
+++ b/index.bs
@@ -1763,8 +1763,9 @@ When this operation is invoked, the authenticator must perform the following pro
     |credTypesAndPubKeyAlgs| is supported.
     If not, return an error code equivalent to "{{NotSupportedError}}" and terminate the operation.
 1. Check if any credential bound to this authenticator matches an [=list/item=] of |excludeCredentialDescriptorList|. A match 
-   occurs if a credential matches <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>, <code>|excludeCredentialDescriptorList|. 
-   {{PublicKeyCredentialDescriptor/id}}</code>, and <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code>. 
+   occurs if a credential matches <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and an |excludeCredentialDescriptorList| 
+   item's <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/id}}</code> and 
+   <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code>.
    If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
@@ -1831,8 +1832,10 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     equivalent to "{{UnknownError}}" and terminate the operation.
 1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
     an exact match of |rpId|).
-1. Remove any items from |allowCredentialDescriptorList| that are not present on this [=authenticator=] for
-    the supplied |rpId|.
+1. Remove any items from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A match 
+   occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's <code>|allowCredentialDescriptorList| 
+   {{PublicKeyCredentialDescriptor/id}}</code> and <code>|allowCredentialDescriptorList|{{PublicKeyCredentialDescriptor/type}}</code>. 
+   If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.

--- a/index.bs
+++ b/index.bs
@@ -1830,7 +1830,8 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     equivalent to "{{UnknownError}}" and terminate the operation.
 1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
     an exact match of |rpId|).
-1. Remove any items from |allowCredentialDescriptorList| that are not present on this [=authenticator=].
+1. Remove any items from |allowCredentialDescriptorList| that are not present on this [=authenticator=] for
+    the supplied <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.

--- a/index.bs
+++ b/index.bs
@@ -1763,10 +1763,10 @@ When this operation is invoked, the authenticator must perform the following pro
     |credTypesAndPubKeyAlgs| is supported.
     If not, return an error code equivalent to "{{NotSupportedError}}" and terminate the operation.
 1. Check if any credential bound to this authenticator matches an [=list/item=] of |excludeCredentialDescriptorList|. A match 
-   occurs if a credential matches <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and an |excludeCredentialDescriptorList| 
-   item's <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/id}}</code> and 
-   <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code>.
-   If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
+    occurs if a credential matches <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and an |excludeCredentialDescriptorList| 
+    item's <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/id}}</code> and 
+    <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code>.
+    If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is |true| and the authenticator cannot perform user verification,
@@ -1833,8 +1833,8 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
     an exact match of |rpId|).
 1. Remove any items from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A match 
-   occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's <code>|allowCredentialDescriptorList| 
-   {{PublicKeyCredentialDescriptor/id}}</code> and <code>|allowCredentialDescriptorList|{{PublicKeyCredentialDescriptor/type}}</code>. 
+    occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's <code>|allowCredentialDescriptorList| 
+    {{PublicKeyCredentialDescriptor/id}}</code> and <code>|allowCredentialDescriptorList|{{PublicKeyCredentialDescriptor/type}}</code>. 
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.


### PR DESCRIPTION
Only credentials in the exclude credentials list that match this RPID should result in a not allowed error.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jovasco/webauthn/patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/ee174c2...jovasco:6e5f27f.html)