### PR TITLE
Fix #574 - Change language for Create and Get to support hotplugging

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -682,30 +682,25 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |clientDataHash| be the [=hash of the serialized client data=] represented by |clientDataJSON|.
 
-1. Let |currentlyAvailableAuthenticators| be a new [=ordered set=] consisting of all [=authenticators=]
-    currently available on this platform.
+1. Let |lifetimeTimer| be a timer for |adjustedTimeout| milliseconds.
 
-1. Let |selectedAuthenticators| be a new [=ordered set=].
+1. Let |issuedRequests| be a new [=ordered set=].
 
-1. If |currentlyAvailableAuthenticators| [=list/is empty=], return a {{DOMException}} whose name is
-    "{{NotFoundError}}", and terminate this algorithm.
+1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}</code> is
+    [=present|present=], [=set/for each=] |authenticator| that becomes available on this
+    platform during the lifetime of |lifetimeTimer| and do the following:
 
-1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}</code> is [=present|present=], iterate through
-        |currentlyAvailableAuthenticators| and do the following [=set/for each=] |authenticator|:
+    Issue: The definitions of "lifetime of" and "becomes available" are intended to represent how
+    devices are hotplugged into browsers, and are under-specified. Resolving this with good definitions
+    or some other means will be addressed by resolving [Issue #613](https://github.com/w3c/webauthn/issues/613).
+
     1. If {{AuthenticatorSelectionCriteria/authenticatorAttachment}} is [=present|present=] and its value is not equal
         to |authenticator|'s attachment modality, [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to |true| and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to |true| and the
         |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
-    1. [=set/Append=] |authenticator| to |selectedAuthenticators|.
 
-1. If |selectedAuthenticators| [=list/is empty=], return a {{DOMException}} whose name is
-    "{{ConstraintError}}", and terminate this algoritm.
-
-1. Let |issuedRequests| be a new [=ordered set=].
-
-1. [=set/For each=] |authenticator| in |currentlyAvailableAuthenticators|:
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
     1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakePublicKeyCredentialOptions/excludeCredentials}}</code>:
@@ -725,13 +720,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
-1. Start a timer for |adjustedTimeout| milliseconds.
-
-1. [=While=] |issuedRequests| [=list/is not empty=], perform the following actions depending upon the |adjustedTimeout| timer
-    and responses from the authenticators:
+1. [=While=] |issuedRequests| [=list/is not empty=], perform the following actions depending upon the
+    |lifetimeTimer| timer and responses from the authenticators:
     <dl class="switch">
 
-        :   If the |adjustedTimeout| timer expires,
+        :   If the |lifetimeTimer| timer expires,
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|.
 
@@ -908,12 +901,16 @@ method is invoked, the user agent MUST:
 
 1. Let |issuedRequests| be a new [=ordered set=].
 
-1. If there are no [=authenticators=] currently available on this platform, return a {{DOMException}} whose name is
-    "{{NotFoundError}}", and terminate this algorithm.
-
 1. Let |authenticator| be a platform-specific handle whose value identifies an [=authenticator=].
 
-1. For each |authenticator| currently available on this platform, perform the following steps:
+1. Let |lifetimeTimer| be a timer for |adjustedTimeout| milliseconds.
+
+1. [=set/For each=] |authenticator| that becomes available on this platform during the lifetime of
+    |lifetimeTimer|, perform the following steps:
+
+    Issue: The definitions of "lifetime of" and "becomes available" are intended to represent how
+    devices are hotplugged into browsers, and are under-specified. Resolving this with good definitions
+    or some other means will be addressed by resolving [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 
@@ -969,16 +966,14 @@ method is invoked, the user agent MUST:
 
     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
+1. Execute the following steps [=in parallel=]. The [=task source=] for these [=tasks=] is the [=dom manipulation task source=].
 
-1. Start a timer for |adjustedTimeout| milliseconds. Then execute the following steps [=in parallel=]. The [=task source=] for
-    these [=tasks=] is the [=dom manipulation task source=].
-
-    1. While |issuedRequests| [=list/is not empty=], perform the following actions depending upon the |adjustedTimeout| timer
+    1. While |issuedRequests| [=list/is not empty=], perform the following actions depending upon the |lifetimeTimer| timer
         and responses from the authenticators:
 
         <dl class="switch">
 
-            :   If the |adjustedTimeout| timer expires,
+            :   If the |lifetimeTimer| timer expires,
             ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on
                 |authenticator| and [=set/remove=] |authenticator| from |issuedRequests|.
 

--- a/index.bs
+++ b/index.bs
@@ -721,11 +721,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
-1. [=While=] |issuedRequests| [=list/is not empty=], perform the following actions depending upon the
-    |lifetimeTimer| timer and responses from the authenticators:
+1. [=While=] |issuedRequests| [=list/is not empty=], perform the following actions depending upon
+    |lifetimeTimer| and responses from the authenticators:
     <dl class="switch">
 
-        :   If the |lifetimeTimer| timer expires,
+        :   If |lifetimeTimer| expires,
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|.
 
@@ -970,12 +970,12 @@ method is invoked, the user agent MUST:
 
 1. Execute the following steps [=in parallel=]. The [=task source=] for these [=tasks=] is the [=dom manipulation task source=].
 
-    1. While |issuedRequests| [=list/is not empty=], perform the following actions depending upon the |lifetimeTimer| timer
+    1. While |issuedRequests| [=list/is not empty=], perform the following actions depending upon |lifetimeTimer|
         and responses from the authenticators:
 
         <dl class="switch">
 
-            :   If the |lifetimeTimer| timer expires,
+            :   If |lifetimeTimer| expires,
             ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on
                 |authenticator| and [=set/remove=] |authenticator| from |issuedRequests|.
 

--- a/index.bs
+++ b/index.bs
@@ -691,8 +691,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
     platform during the lifetime of |lifetimeTimer| and do the following:
 
     Issue: The definitions of "lifetime of" and "becomes available" are intended to represent how
-    devices are hotplugged into browsers, and are under-specified. Resolving this with good definitions
-    or some other means will be addressed by resolving [Issue #613](https://github.com/w3c/webauthn/issues/613).
+    devices are hotplugged into (USB) or discovered by (NFC) browsers, and are under-specified.
+    Resolving this with good definitions or some other means will be addressed by resolving
+    [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
     1. If {{AuthenticatorSelectionCriteria/authenticatorAttachment}} is [=present|present=] and its value is not equal
         to |authenticator|'s attachment modality, [=iteration/continue=].
@@ -909,8 +910,9 @@ method is invoked, the user agent MUST:
     |lifetimeTimer|, perform the following steps:
 
     Issue: The definitions of "lifetime of" and "becomes available" are intended to represent how
-    devices are hotplugged into browsers, and are under-specified. Resolving this with good definitions
-    or some other means will be addressed by resolving [Issue #613](https://github.com/w3c/webauthn/issues/613).
+    devices are hotplugged into (USB) or discovered by (NFC) browsers, and are under-specified.
+    Resolving this with good definitions or some other means will be addressed by resolving
+    [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 

--- a/index.bs
+++ b/index.bs
@@ -591,9 +591,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
     member of <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code> are [=present|not present=], return a {{TypeError}} [=simple exception=].
 
 1. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present=], check if its value lies within a
-    reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set
-    |adjustedTimeout| to this adjusted value. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present|not
-    present=], then set |adjustedTimeout| to a platform-specific default.
+    reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set a timer
+    |lifetimeTimer| to this adjusted value. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present|not
+    present=], then set |lifetimeTimer| to a platform-specific default.
 
 1. Let |global| be the {{PublicKeyCredential}}'s [=interface object=]'s [=global object|environment settings object's global
     object=].
@@ -682,7 +682,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |clientDataHash| be the [=hash of the serialized client data=] represented by |clientDataJSON|.
 
-1. Let |lifetimeTimer| be a timer for |adjustedTimeout| milliseconds.
+1. Start |lifetimeTimer|.
 
 1. Let |issuedRequests| be a new [=ordered set=].
 
@@ -832,8 +832,8 @@ method is invoked, the user agent MUST:
 
 1. If the {{PublicKeyCredentialRequestOptions/timeout}} member of |options| is [=present=], check if its value lies
     within a reasonable range as defined by the platform and if not, correct it to the closest value lying within that range.
-    Set |adjustedTimeout| to this adjusted value. If the {{PublicKeyCredentialRequestOptions/timeout}} member of
-    |options| is [=present|not present=], then set |adjustedTimeout| to a platform-specific default.
+    Set a timer |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialRequestOptions/timeout}} member of
+    |options| is [=present|not present=], then set |lifetimeTimer| to a platform-specific default.
 
 1. Let |global| be the {{PublicKeyCredential}}'s [=interface object=]'s [=relevant global object=].
 
@@ -904,7 +904,7 @@ method is invoked, the user agent MUST:
 
 1. Let |authenticator| be a platform-specific handle whose value identifies an [=authenticator=].
 
-1. Let |lifetimeTimer| be a timer for |adjustedTimeout| milliseconds.
+1. Start |lifetimeTimer|.
 
 1. [=set/For each=] |authenticator| that becomes available on this platform during the lifetime of
     |lifetimeTimer|, perform the following steps:


### PR DESCRIPTION
This is an incomplete fix; a full fix is intended to be handled [by the resolution to] Issue #613.

This reorders [a portion of the guts of] the Create and Get operations to 
indicate that the algorithms for
interacting with devices should be applied as devices are hotplugged / arrive.
It does not specify what happens when devices are removed, nor does it use
precise language. I'm not sure what language would be appropriate in this world,
so this patch is just to make things "better" not "correct".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/574-hotplugging.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/01aa320...jcjones:83da7ff.html)