### PR TITLE
fix #657: where does return value of PublicKeyCredential.getClientExtensionResults() come from?

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -506,8 +506,9 @@ that are returned to the caller when a new credential is created, or a new asser
         will be an {{AuthenticatorAssertionResponse}}.
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
-    ::  This operation returns a [=map=] containing [=extension identifier=] → [=client extension output=] entries
-        produced by the extension's [=client extension processing=].
+    ::  This operation returns the value of a {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing
+        [=extension identifier=] → [=client extension output=] entries produced by the extension's
+        [=client extension processing=].
 
     :   <dfn>\[[type]]</dfn>
     ::  The {{PublicKeyCredential}} [=interface object=]'s {{Credential/[[type]]}} [=internal slot=]'s value is the string
@@ -526,6 +527,11 @@ that are returned to the caller when a new credential is created, or a new asser
         the format or length of this identifier, except that it must be sufficient for the platform to uniquely select a key.
         For example, an authenticator without on-board storage may create identifiers containing a [=credential private key=]
         wrapped with a symmetric key that is burned into the authenticator.
+
+    :   <dfn>\[[clientExtensionsResults]]</dfn>
+    ::  This [=internal slot=] contains the results of processing client extensions requested by the [=[RP]=] upon the
+        [=[RP]=]'s invocation of either {{CredentialsContainer/create()|navigator.credentials.create()}} or
+        {{CredentialsContainer/get()|navigator.credentials.get()}}.
 </dl>
 
 {{PublicKeyCredential}}'s [=interface object=] inherits {{Credential}}'s implementation of
@@ -779,9 +785,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         :   {{AuthenticatorAttestationResponse/attestationObject}}
                         ::  |attestationObject|
 
-                Issue: need to place [=clientExtensionResults=] data somewhere such that the data is subsequently available
-                    to RP script when the latter invokes `PublicKeyCredential.getClientExtensionResults()`.
-                    See [issue #657](https://github.com/w3c/webauthn/issues/657).
+                    :   {{PublicKeyCredential/[[clientExtensionsResults]]}}
+                    ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
+                        <code>|credentialCreationData|.[=clientExtensionResults=]</code>.
 
                 1.  Return |pubKeyCred|.
 

--- a/index.bs
+++ b/index.bs
@@ -506,7 +506,7 @@ that are returned to the caller when a new credential is created, or a new asser
         will be an {{AuthenticatorAssertionResponse}}.
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
-    ::  This operation returns the value of a {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing
+    ::  This operation returns the value of {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing
         [=extension identifier=] → [=client extension output=] entries produced by the extension's
         [=client extension processing=].
 


### PR DESCRIPTION
This fixes #657: where does return value of PublicKeyCredential.getClientExtensionResults() come from?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/jeffh-fixup-algs-contd-5.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/e9a9c33...5ea8a28.html)