### PR TITLE
Fix #587: Make PublicKeyCredentialEntity members required in IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -639,12 +639,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
-1. If any of the {{PublicKeyCredentialEntity/name}} member of <code>|options|.{{MakePublicKeyCredentialOptions/rp}}</code>, the
-    {{PublicKeyCredentialEntity/name}} member of <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
-    the {{PublicKeyCredentialUserEntity/displayName}} member of <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
-    or the {{PublicKeyCredentialUserEntity/id}}
-    member of <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code> are [=present|not present=], return a {{TypeError}} [=simple exception=].
-
 1. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present=], check if its value lies within a
     reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set a timer
     |lifetimeTimer| to this adjusted value. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present|not
@@ -1260,8 +1254,8 @@ optionally evidence of [=user consent=] to a specific transaction.
     :   <dfn>rp</dfn>
     ::  This member contains data about the [=[RP]=] responsible for the request.
 
-        Its value's {{PublicKeyCredentialEntity/name}} member is required, and contains the friendly name of the [=[RP]=]
-        (e.g. "Acme Corporation", "Widgets, Inc.", or "Awesome Site".
+        Its value's {{PublicKeyCredentialEntity/name}} member contains the friendly name of the [=[RP]=] (e.g. "Acme Corporation",
+        "Widgets, Inc.", or "Awesome Site".
 
         Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=relying party identifier=] with which the credential
         should be associated. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
@@ -1270,14 +1264,14 @@ optionally evidence of [=user consent=] to a specific transaction.
     :   <dfn>user</dfn>
     ::  This member contains data about the user account for which the [=[RP]=] is requesting attestation.
 
-        Its value's {{PublicKeyCredentialEntity/name}} member is required, and contains a name for the user account
-        (e.g., "john.p.smith@example.com" or "+14255551234").
+        Its value's {{PublicKeyCredentialEntity/name}} member contains a name for the user account (e.g.,
+        "john.p.smith@example.com" or "+14255551234").
 
-        Its value's {{PublicKeyCredentialUserEntity/displayName}} member is required, and contains a friendly name for the user
-        account (e.g., "John P. Smith").
+        Its value's {{PublicKeyCredentialUserEntity/displayName}} member contains a friendly name for the user account (e.g.,
+        "John P. Smith").
 
-        Its value's {{PublicKeyCredentialUserEntity/id}} member is required and contains the [=user handle=] for the account,
-        specified by the [=[RP]=].
+        Its value's {{PublicKeyCredentialUserEntity/id}} member contains the [=user handle=] for the account, specified by the
+        [=[RP]=].
 
     :   <dfn>challenge</dfn>
     ::  This member contains a challenge intended to be used for generating the newly created credential's [=attestation
@@ -1316,8 +1310,8 @@ associated.
 
 <xmp class="idl">
     dictionary PublicKeyCredentialEntity {
-        DOMString      name;
-        USVString      icon;
+        required DOMString    name;
+        USVString             icon;
     };
 </xmp>
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialEntity">
@@ -1358,8 +1352,8 @@ credential.
 
 <pre class="idl">
     dictionary PublicKeyCredentialUserEntity : PublicKeyCredentialEntity {
-        BufferSource   id;
-        DOMString      displayName;
+        required BufferSource   id;
+        required DOMString      displayName;
     };
 </pre>
 


### PR DESCRIPTION
This resolves #587.

Summary:

- Make member `PublicKeyCredentialEntity.name` required
- Make member `PublicKeyCredentialUserEntity.id` required
- Make member `PublicKeyCredentialUserEntity.displayName` required
- Remove algorithm step from _§5.1.3 Create a new credential_ that
  instructed to throw an exception if any of the above members were
  missing


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/issue-587.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/0418f3e...9f5df06.html)