### PR TITLE
Fix #644: Add UV parameter to getAssertion

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -478,7 +478,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn id=concept-user-present>User Present</dfn>
 : <dfn>UP</dfn>
 :: Upon successful completion of a [=test of user presence|user presence test=], the user is said to be
-    "[=user present|present=]". If the user is [=user verified|verified=], the user is also said to be [=user present|present=].
+    "[=user present|present=]".
 
 : <dfn id=concept-user-verified>User Verified</dfn>
 : <dfn>UV</dfn>
@@ -1921,18 +1921,14 @@ When this operation is invoked, the authenticator must perform the following pro
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
+1. If |requireUserVerification| is true, perform [=user verification=]. If [=user verification=] fails, return an
+    error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
-    authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the contents of
+    authenticator if it has its own output capability, or by the user agent otherwise.  The prompt SHOULD display the contents of
     |rpEntity| and |userEntity|, if possible.
 
-    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows:
-
-    - If |requireUserVerification| is true, [=user verification=] MUST be used.
-    - If |requireUserVerification| is false, [=user verification=] SHOULD NOT be used.
-    - If [=user verification=] is not used, a [=test of user presence=] MUST be used.
-
-    If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
-    "{{NotAllowedError}}" and terminate the operation.
+    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
+    operation.
 
 1. Once [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|,|privateKey|) be a new set of cryptographic keys using the combination of {{PublicKeyCredentialType}}
@@ -2000,6 +1996,8 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     operation.
 1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
+1. If |requireUserVerification| is true, perform [=user verification=]. If [=user verification=] fails, return an error code
+    equivalent to "{{NotAllowedError}}" and terminate the operation.
 
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.
 
@@ -2007,14 +2005,8 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
     |rpId| and any additional data associated with |selectedCredential|, if possible.
 
-    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows:
-
-    - If |requireUserVerification| is true, [=user verification=] MUST be used.
-    - If |requireUserVerification| is false, [=user verification=] SHOULD NOT be used.
-    - If [=user verification=] is not used, a [=test of user presence=] MUST be used.
-
-    If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
-    "{{NotAllowedError}}" and terminate the operation.
+    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
+    operation.
 
 1. Let |processedExtensions| be the result of [=authenticator extension processing=] for each supported [=extension
     identifier=]/input pair in |extensions|.

--- a/index.bs
+++ b/index.bs
@@ -1466,30 +1466,6 @@ example of the latter, when the user is accessing the [=[RP]=] from a given clie
 use a [=roaming authenticator=] which was originally registered with the [=[RP]=] using a different client.
 
 
-### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
-
-<pre class="idl">
-    enum UserVerificationRequirement {
-        "required",
-        "wanted",
-        "not-wanted"
-    };
-</pre>
-
-A [=[RP]=] may require [=user verified|user verification=] for some of its operations but not for others, and may use this type to
-express this level of requirement.
-
-The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
-and will fail the operation if the response does not have the [=UV=] [=flag=] set.
-
-The value {{UserVerificationRequirement/wanted}} indicates that the [=[RP]=] would like [=user verification=] for this operation
-is possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
-
-The value {{UserVerificationRequirement/not-wanted}} indicates that the [=[RP]=] does not require [=user verification=], and does
-not want the [=client=] or [=authenticator=] to ask for it, but will not fail the operation if the response has the [=UV=]
-[=flag=] set.
-
-
 ## Options for Assertion Generation (dictionary <dfn dictionary>PublicKeyCredentialRequestOptions</dfn>) ## {#assertion-options}
 
 The {{PublicKeyCredentialRequestOptions}} dictionary supplies {{CredentialsContainer/get()}} with the data it needs to generate
@@ -1554,6 +1530,30 @@ context.
 
 The [=public key credential=] type uses certain data structures that are specified in supporting specifications. These are as
 follows.
+
+
+### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
+
+<pre class="idl">
+    enum UserVerificationRequirement {
+        "required",
+        "wanted",
+        "not-wanted"
+    };
+</pre>
+
+A [=[RP]=] may require [=user verified|user verification=] for some of its operations but not for others, and may use this type to
+express this level of requirement.
+
+The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
+and will fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/wanted}} indicates that the [=[RP]=] would like [=user verification=] for this operation
+is possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/not-wanted}} indicates that the [=[RP]=] does not require [=user verification=], and does
+not want the [=client=] or [=authenticator=] to ask for it, but will not fail the operation if the response has the [=UV=]
+[=flag=] set.
 
 
 ### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}

--- a/index.bs
+++ b/index.bs
@@ -2043,9 +2043,9 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     equivalent to "{{UnknownError}}" and terminate the operation.
 1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
     an exact match of |rpId|).
-1. Remove any items from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A match 
-    occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's <code>|allowCredentialDescriptorList| 
-    {{PublicKeyCredentialDescriptor/id}}</code> and <code>|allowCredentialDescriptorList|{{PublicKeyCredentialDescriptor/type}}</code>. 
+1. Remove any items from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A match
+    occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's
+    {{PublicKeyCredentialDescriptor/id}} and {{PublicKeyCredentialDescriptor/type}} members.
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code

--- a/index.bs
+++ b/index.bs
@@ -1931,11 +1931,14 @@ When this operation is invoked, the authenticator must perform the following pro
     authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the contents of
     |rpEntity| and |userEntity|, if possible.
 
-    - If |requireUserVerification| is true, obtain [=user consent=] by performing [=user verification=].
-    - If |requireUserVerification| is false, obtain [=user consent=] by performing a [=test of user presence=].
+    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows:
 
-    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
-    operation.
+    - If |requireUserVerification| is true, [=user verification=] MUST be used.
+    - If |requireUserVerification| is false, [=user verification=] SHOULD NOT be used.
+    - If [=user verification=] is not used, a [=test of user presence=] MUST be used.
+
+    If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
+    "{{NotAllowedError}}" and terminate the operation.
 
 1. Once [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|,|privateKey|) be a new set of cryptographic keys using the combination of {{PublicKeyCredentialType}}
@@ -2010,11 +2013,14 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
     contents of |rpEntity| and |userEntity|, if possible.
 
-    - If |requireUserVerification| is true, obtain [=user consent=] by performing [=user verification=].
-    - If |requireUserVerification| is false, obtain [=user consent=] by performing a [=test of user presence=].
+    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows:
 
-    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
-    operation.
+    - If |requireUserVerification| is true, [=user verification=] MUST be used.
+    - If |requireUserVerification| is false, [=user verification=] SHOULD NOT be used.
+    - If [=user verification=] is not used, a [=test of user presence=] MUST be used.
+
+    If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
+    "{{NotAllowedError}}" and terminate the operation.
 
 1. Let |processedExtensions| be the result of [=authenticator extension processing=] for each supported [=extension
     identifier=]/input pair in |extensions|.

--- a/index.bs
+++ b/index.bs
@@ -752,7 +752,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. If {{AuthenticatorSelectionCriteria/authenticatorAttachment}} is [=present|present=] and its value is not equal
         to |authenticator|'s attachment modality, [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to |true| and the |authenticator|
+    1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to true and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to |true| and the
         |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
@@ -969,6 +969,10 @@ method is invoked, the user agent MUST:
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
+    1. If |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}} is [=present=], and
+        |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
+        is set to true, and the |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
+
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 
     1. If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> [=list/is not empty=], execute a
@@ -1002,19 +1006,23 @@ method is invoked, the user agent MUST:
                             selection.
 
                             Then, using |transport|, invoke [=in parallel=] the [=authenticatorGetAssertion=] operation on
-                            |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|, and
-                            |authenticatorExtensions| as parameters.
+                            |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|,
+                            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}},
+                            and |authenticatorExtensions| as parameters.
 
                         :   [=list/is empty=]
                         ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|,
                             invoke [=in parallel=] the [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|,
-                            |clientDataHash|, |allowCredentialDescriptorList|, and |clientExtensions| as parameters.
+                            |clientDataHash|, |allowCredentialDescriptorList|,
+                            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}},
+                            and |clientExtensions| as parameters.
                     </dl>
 
             :   [=list/is empty=]
             ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|, invoke
                 [=in parallel=] the [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|, |clientDataHash|,
-                and |clientExtensions| as parameters.
+                |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}}, and
+                |clientExtensions| as parameters.
 
                 Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus the
                     authenticator is being asked to exercise any credential it may possess that is bound to
@@ -1299,7 +1307,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 
     :   <dfn>authenticatorSelection</dfn>
     ::  This member is intended for use by [=[RPS]=] that wish to select the appropriate authenticators to participate in
-        the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} operation.
+        the {{CredentialsContainer/create()}} operation.
 
     :   <dfn>extensions</dfn>
     ::  This member contains additional parameters requesting additional processing by the client and authenticator. For
@@ -1398,10 +1406,9 @@ attributes.
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
     :   <dfn>requireUserVerification</dfn>
-    ::  This member describes the [=[RPS]=]' requirements regarding the authenticator being capable of performing user verification.
-        If the parameter is set to true, the authenticator MUST perform user verification when performing
-        the {{CredentialsContainer/create()}} operation and future [[#getAssertion]] operations when it is
-        requested to verify the credential.
+    ::  This member describes the [=[RPS]=]' requirements regarding the authenticator being capable of performing user
+        verification. If the parameter is set to true, the authenticator MUST perform [=user verification=] when performing the
+        {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} operation.
 </div>
 
 
@@ -1451,6 +1458,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
+        AuthenticatorSelectionCriteria       authenticatorSelection;
         AuthenticationExtensions             extensions;
     };
 </xmp>
@@ -1473,6 +1481,13 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
     ::  This optional member contains a list of {{PublicKeyCredentialDescriptor}} object representing [=public key credentials=]
         acceptable to the caller, in decending order of the caller's preference (the first item in the list is the most
         preferred credential, and so on down the list).
+
+    :   <dfn>authenticatorSelection</dfn>
+    ::  This member is intended for use by [=[RPS]=] that wish to select the appropriate authenticators to participate in
+        the {{CredentialsContainer/get()}} operation.
+
+        Note: Only the {{AuthenticatorSelectionCriteria/requireUserVerification}} member of this member currently has any effect
+        when used in {{PublicKeyCredentialRequestOptions}}; any other members are ignored.
 
     :   <dfn>extensions</dfn>
     ::  This optional member contains additional parameters requesting additional processing by the client and authenticator.
@@ -1866,9 +1881,9 @@ When this operation is invoked, the authenticator must perform the following pro
     If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |requireUserVerification| is |true| and the authenticator cannot perform user verification,
-    return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-1. Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
+1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
+    equivalent to "{{ConstraintError}}" and terminate the operation.
+  1. Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
     if it has its own output capability, or by the user agent otherwise. If the user denies consent, return an error code
     equivalent to "{{NotAllowedError}}" and terminate the operation. The Authenticator and user agent MAY skip this prompt
     if the Authenticator is a [=platform authenticator=] and |excludeCredentialDescriptorList| is empty.
@@ -1920,6 +1935,8 @@ input parameters:
 : |allowCredentialDescriptorList|
 :: An optional list of {{PublicKeyCredentialDescriptor}}s describing credentials acceptable to the [=[RP]=] (possibly filtered
     by the client), if any.
+: |requireUserVerification|
+:: |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}}.
 : |extensions|
 :: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
     extensions requested by the [=[RP]=], if any.
@@ -1934,6 +1951,8 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     {{PublicKeyCredentialDescriptor/id}}</code> and <code>|allowCredentialDescriptorList|{{PublicKeyCredentialDescriptor/type}}</code>. 
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
+1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
+    equivalent to "{{ConstraintError}}" and terminate the operation.
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.
     Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown
     by the

--- a/index.bs
+++ b/index.bs
@@ -1615,7 +1615,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         [=effective domain=].
 
     :   <dfn>allowCredentials</dfn>
-    ::  This optional member contains a list of {{PublicKeyCredentialDescriptor}} object representing [=public key credentials=]
+    ::  This optional member contains a list of {{PublicKeyCredentialDescriptor}} objects representing [=public key credentials=]
         acceptable to the caller, in decending order of the caller's preference (the first item in the list is the most
         preferred credential, and so on down the list).
 

--- a/index.bs
+++ b/index.bs
@@ -987,12 +987,12 @@ method is invoked, the user agent MUST:
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. If |options|.{{PublicKeyCredentialRequestOptions/requireUserVerification}} is set to
+    1. If |options|.{{PublicKeyCredentialRequestOptions/userVerification}} is set to
         {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user verification=],
         [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
-        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/requireUserVerification}}</code>
+        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
 
             <dl class="switch">
 
@@ -1503,7 +1503,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-        UserVerificationRequirement          requireUserVerification = "preferred";
+        UserVerificationRequirement          userVerification = "preferred";
         AuthenticationExtensions             extensions;
     };
 </xmp>
@@ -1527,7 +1527,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         acceptable to the caller, in decending order of the caller's preference (the first item in the list is the most
         preferred credential, and so on down the list).
 
-    :   <dfn>requireUserVerification</dfn>
+    :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/get()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.

--- a/index.bs
+++ b/index.bs
@@ -752,16 +752,30 @@ When this method is invoked, the user agent MUST execute the following algorithm
         |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
-        as follows:
-        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/required}}, let
-            |userVerification| be true.
-        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/preferred}}, let
-            |userVerification| be true if the |authenticator| is capable of [=user verification=] and false if the |authenticator|
-            is not capable of [=user verification=].
-        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/discouraged}}, let
-            |userVerification| be false.
+        as follows. If {{AuthenticatorSelectionCriteria/requireUserVerification}}
 
-    1. Let |excludeCredentialDescriptorList| be a new [=list=].
+            <dl class="switch">
+
+                :   is set to {{UserVerificationRequirement/required}}
+                ::  Let |userVerification| be `true`.
+
+                :   is set to {{UserVerificationRequirement/preferred}}
+                ::  If the |authenticator|
+
+                    <dl class="switch">
+                        :   is capable of [=user verification=]
+                        ::  Let |userVerification| be `true`.
+
+                        :   is not capable of [=user verification=]
+                        ::  Let |userVerification| be `false`.
+                    </dl>
+
+                :   is set to {{UserVerificationRequirement/discouraged}}
+                ::  Let |userVerification| be `false`.
+
+            </dl>
+
+    l. Let |excludeCredentialDescriptorList| be a new [=list=].
 
     1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakePublicKeyCredentialOptions/excludeCredentials}}</code>:
         1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
@@ -977,14 +991,29 @@ method is invoked, the user agent MUST:
         [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
-        follows:
-        - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
-            {{UserVerificationRequirement/required}}, let |userVerification| be true.
-        - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
-            {{UserVerificationRequirement/preferred}}, let |userVerification| be true if the |authenticator| is capable of [=user
-            verification=] and false if the |authenticator| is not capable of [=user verification=].
-        - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
-            {{UserVerificationRequirement/discouraged}}, let |userVerification| be false.
+        follows. If <code>|options|.{{AuthenticatorSelectionCriteria/requireUserVerification}}</code>
+
+            <dl class="switch">
+
+                :   is set to {{UserVerificationRequirement/required}}
+                ::  Let |userVerification| be `true`.
+
+                :   is set to {{UserVerificationRequirement/preferred}}
+                ::  If the |authenticator|
+
+                    <dl class="switch">
+                        :   is capable of [=user verification=]
+                        ::  Let |userVerification| be `true`.
+
+                        :   is not capable of [=user verification=]
+                        ::  Let |userVerification| be `false`.
+                    </dl>
+
+                :   is set to {{UserVerificationRequirement/discouraged}}
+                ::  Let |userVerification| be `false`.
+
+            </dl>
+
 
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 

--- a/index.bs
+++ b/index.bs
@@ -903,7 +903,7 @@ authorizing an authenticator.
 </div>
 
 
-### Use an existing credential to make an assertion ### {#getAssertion}
+### Use an existing credential to make an assertion - PublicKeyCredential's `[[Get]](options)` method ### {#getAssertion}
 
 [=[RPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
 discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[RP]=] script optionally specifies some criteria

--- a/index.bs
+++ b/index.bs
@@ -746,7 +746,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. If {{AuthenticatorSelectionCriteria/authenticatorAttachment}} is [=present|present=] and its value is not equal
         to |authenticator|'s attachment modality, [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to true and the |authenticator|
+    1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to `true` and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/required}} and the
         |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
@@ -1560,8 +1560,8 @@ follows.
     };
 </pre>
 
-A [=[RP]=] may require [=user verified|user verification=] for some of its operations but not for others, and may use this type to
-express this level of requirement.
+A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express this
+level of requirement.
 
 The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
 and will fail the operation if the response does not have the [=UV=] [=flag=] set.
@@ -1940,11 +1940,11 @@ When this operation is invoked, the authenticator must perform the following pro
     item's <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/id}}</code> and 
     <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code>.
     If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
-1. If |requireResidentKey| is true and the authenticator cannot store a [=Client-side-resident Credential
+1. If |requireResidentKey| is `true` and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
+1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |requireUserVerification| is true, perform [=user verification=]. If [=user verification=] fails, return an
+1. If |requireUserVerification| is `true`, perform [=user verification=]. If [=user verification=] fails, return an
     error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
     authenticator if it has its own output capability, or by the user agent otherwise.  The prompt SHOULD display the contents of
@@ -2017,9 +2017,9 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     {{PublicKeyCredentialDescriptor/id}}</code> and <code>|allowCredentialDescriptorList|{{PublicKeyCredentialDescriptor/type}}</code>. 
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
-1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
+1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |requireUserVerification| is true, perform [=user verification=]. If [=user verification=] fails, return an error code
+1. If |requireUserVerification| is `true`, perform [=user verification=]. If [=user verification=] fails, return an error code
     equivalent to "{{NotAllowedError}}" and terminate the operation.
 
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.

--- a/index.bs
+++ b/index.bs
@@ -2149,8 +2149,7 @@ input parameters:
 When this method is invoked, the [=authenticator=] must perform the following procedure:
 1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
     equivalent to "{{UnknownError}}" and terminate the operation.
-1. Let |isFirstFactorOperation| be a Boolean value, set to `true` if and only if |allowCredentialDescriptorList| was not supplied.
-1. If at least one of |requireUserVerification| and |isFirstFactorOperation| is `true` and the authenticator cannot perform [=user
+1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user
     verification=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
     an exact match of |rpId|).
@@ -2160,26 +2159,20 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 
-1. If |isFirstFactorOperation| is `true`, perform [=user verification=]. If [=user verification=] fails, return an error code
-    equivalent to "{{NotAllowedError}}" and terminate the operation.
-
-    Remove any items from |allowCredentialDescriptorList| that match a credential that was created by a [=user verified|verified
-    user=] other than the current [=user verified|verified user=].
-
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.
 
 1. Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown by
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
     |rpId| and any additional displayable data associated with |selectedCredential|, if possible.
 
-    The method of obtaining [=user consent=] MUST ensure that the user is [=user verified|verified=] or [=user present|present=]
-    as follows. If the user is not already [=user verified|verified=],
+    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows. If
+    |requireUserVerification|
 
     <dl class="switch">
-        :   if |requireUserVerification| is `true`
+        :   is `true`
         ::  [=User verification=] MUST be performed.
 
-        :   if |requireUserVerification| is `false`
+        :   is `false`
         ::  [=User verification=] SHOULD NOT be performed. If [=user verification=] is not performed, a [=test of user presence=]
             MUST be performed.
     </dl>

--- a/index.bs
+++ b/index.bs
@@ -992,7 +992,7 @@ method is invoked, the user agent MUST:
         [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
-        follows. If <code>|options|.{{AuthenticatorSelectionCriteria/requireUserVerification}}</code>
+        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/requireUserVerification}}</code>
 
             <dl class="switch">
 

--- a/index.bs
+++ b/index.bs
@@ -1809,18 +1809,17 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
     };
 </pre>
 
-A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express this
-level of requirement.
+A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express its
+needs.
 
-The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
+The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for the operation
 and will fail the operation if the response does not have the [=UV=] [=flag=] set.
 
-The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] would like [=user verification=] for this
+The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] prefers [=user verification=] for the
 operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
 
-The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
-not want the [=client=] or [=authenticator=] to request it, but will not fail the operation if the response has the [=UV=]
-[=flag=] set.
+The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not want [=user verification=] employed
+during the operation (e.g., in the interest of minimizing disruption to the user interaction flow).
 
 
 # WebAuthn Authenticator model # {#authenticator-model}
@@ -2073,8 +2072,10 @@ When this operation is invoked, the authenticator must perform the following pro
 1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
 1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
-    authenticator if it has its own output capability, or by the user agent otherwise.  The prompt SHOULD display the contents of
-    |rpEntity| and |userEntity|, if possible.
+    authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display
+    <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>, <code>|rpEntity|.{{PublicKeyCredentialEntity/name}}</code>,
+    <code>|userEntity|.{{PublicKeyCredentialEntity/name}}</code> and
+    <code>|userEntity|.{{PublicKeyCredentialUserEntity/displayName}}</code>, if possible.
 
     The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows. If
     |requireUserVerification|
@@ -2169,7 +2170,7 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 
 1. Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown by
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
-    |rpId| and any additional data associated with |selectedCredential|, if possible.
+    |rpId| and any additional displayable data associated with |selectedCredential|, if possible.
 
     The method of obtaining [=user consent=] MUST ensure that the user is [=user verified|verified=] or [=user present|present=]
     as follows. If the user is not already [=user verified|verified=],

--- a/index.bs
+++ b/index.bs
@@ -136,9 +136,9 @@ the existence, of credentials scoped to other [RPS].
 is [=Registration=], where a [=public key credential=] is created on an [=authenticator=], and associated by a [=[RP]=]
 with the present user's account (the account may already exist or may be created at this time). The second is
 [=Authentication=], where the [=[RP]=] is presented with an <em>[=Authentication Assertion=]</em> proving the presence
-and consent of the user who registered the [=public key credential=]. Functionally, the [=Web Authentication API=] comprises
-a {{PublicKeyCredential}} which extends the Credential Management API [[!CREDENTIAL-MANAGEMENT-1]], and infrastructure which
-allows those credentials to be used with {{CredentialsContainer/create()|navigator.credentials.create()}} and
+and [=user consent|consent=] of the user who registered the [=public key credential=]. Functionally, the [=Web Authentication
+API=] comprises a {{PublicKeyCredential}} which extends the Credential Management API [[!CREDENTIAL-MANAGEMENT-1]], and
+infrastructure which allows those credentials to be used with {{CredentialsContainer/create()|navigator.credentials.create()}} and
 {{CredentialsContainer/get()|navigator.credentials.get()}}. The former is used during [=Registration=], and the
 latter during [=Authentication=].
 
@@ -492,11 +492,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[RP]=] interacts through the
-client (consisting of the browser and underlying OS platform). Scripts can (with the user's consent) request the browser to
-create a new credential for future use by the [=[RP]=]. Scripts can also request the user’s permission to perform authentication
-operations with an existing credential. All such operations are performed in the authenticator and are mediated by the browser
-and/or platform on the user's behalf. At no point does the script get access to the credentials themselves; it only gets
-information about the credentials in the form of objects.
+client (consisting of the browser and underlying OS platform). Scripts can (with the [=user consent|user's consent=]) request the
+browser to create a new credential for future use by the [=[RP]=]. Scripts can also request the user’s permission to perform
+authentication operations with an existing credential. All such operations are performed in the authenticator and are mediated by
+the browser and/or platform on the user's behalf. At no point does the script get access to the credentials themselves; it only
+gets information about the credentials in the form of objects.
 
 In addition to the above script interface, the authenticator may implement (or come with client software that implements) a user
 interface for management. Such an interface may be used, for example, to reset the authenticator to a clean state or to inspect
@@ -867,13 +867,12 @@ authorizing an authenticator.
 ### Use an existing credential to make an assertion ### {#getAssertion}
 
 [=[RPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
-discover and use an existing [=public key credential=], with the user's consent. The script optionally specifies some criteria
-to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential sources=]
-matching the specified criteria, and guides the user to pick one that the script will be allowed to use. The user may choose to
-decline the entire interaction even if a [=credential source=] is present, for example to maintain privacy. If the user picks a
-[=credential source=], the user agent then uses
-[[#op-get-assertion]] to sign a [RP]-provided challenge and other collected data into an assertion, which is used as a
-[=credential=].
+discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. The script optionally specifies
+some criteria to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential
+sources=] matching the specified criteria, and guides the user to pick one that the script will be allowed to use. The user may
+choose to decline the entire interaction even if a [=credential source=] is present, for example to maintain privacy. If the user
+picks a [=credential source=], the user agent then uses [[#op-get-assertion]] to sign a [RP]-provided challenge and other
+collected data into an assertion, which is used as a [=credential=].
 
 The {{CredentialsContainer/get()}} implementation [[CREDENTIAL-MANAGEMENT-1]] calls
 <code>PublicKeyCredential.{{PublicKeyCredential/[[CollectFromCredentialStore]]()}}</code> to collect any [=credentials=] that
@@ -3625,7 +3624,7 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
     <br/><br/>
 - WebAuthn Extension Identifier: loc
 - Description: The location [=registration extension=] and [=authentication extension=] provides the client device's current
-    location to the WebAuthn relying party, if supported by the client device and subject to user consent.
+    location to the WebAuthn relying party, if supported by the client device and subject to [=user consent=].
 - Specification Document: Section [[#sctn-location-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: uvm

--- a/index.bs
+++ b/index.bs
@@ -754,8 +754,18 @@ When this method is invoked, the user agent MUST execute the following algorithm
         to |authenticator|'s attachment modality, [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to true and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to true and the
+    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/required}} and the
         |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
+
+    1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
+        as follows:
+        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/required}}, let
+            |userVerification| be true.
+        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/wanted}}, let
+            |userVerification| be true if the |authenticator| is capable of [=user verification=] and false if the |authenticator|
+            is not capable of [=user verification=].
+        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/not-wanted}}, let
+            |userVerification| be false.
 
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
@@ -769,7 +779,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         |clientDataHash|,
         <code>|options|.{{MakePublicKeyCredentialOptions/rp}}</code>, <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
         <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
-        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}</code>,
+        |userVerification|,
         |credTypesAndPubKeyAlgs|,
         |excludeCredentialDescriptorList|,
         and |authenticatorExtensions| as parameters.
@@ -971,7 +981,21 @@ method is invoked, the user agent MUST:
 
     1. If |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}} is [=present=], and
         |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
-        is set to true, and the |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
+        is set to {{UserVerificationRequirement/required}}, and the |authenticator| is not capable of performing [=user
+        verification=], [=iteration/continue=].
+
+    1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
+        follows:
+        - If
+            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
+            is set to {{UserVerificationRequirement/required}}, let |userVerification| be true.
+        - If
+            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
+            is set to {{UserVerificationRequirement/wanted}}, let |userVerification| be true if the |authenticator| is capable
+            of [=user verification=] and false if the |authenticator| is not capable of [=user verification=].
+        - If
+            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
+            is set to {{UserVerificationRequirement/not-wanted}}, let |userVerification| be false.
 
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 
@@ -1006,23 +1030,20 @@ method is invoked, the user agent MUST:
                             selection.
 
                             Then, using |transport|, invoke [=in parallel=] the [=authenticatorGetAssertion=] operation on
-                            |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|,
-                            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}},
+                            |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|, |userVerification|,
                             and |authenticatorExtensions| as parameters.
 
                         :   [=list/is empty=]
                         ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|,
                             invoke [=in parallel=] the [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|,
-                            |clientDataHash|, |allowCredentialDescriptorList|,
-                            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}},
-                            and |clientExtensions| as parameters.
+                            |clientDataHash|, |allowCredentialDescriptorList|, |userVerification|, and |clientExtensions| as
+                            parameters.
                     </dl>
 
             :   [=list/is empty=]
             ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|, invoke
                 [=in parallel=] the [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|, |clientDataHash|,
-                |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}}, and
-                |clientExtensions| as parameters.
+                |userVerification|, and |clientExtensions| as parameters.
 
                 Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus the
                     authenticator is being asked to exercise any credential it may possess that is bound to
@@ -1391,7 +1412,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        boolean                      requireUserVerification = false;
+        UserVerificationRequirement  requireUserVerification = "not-wanted";
     };
 </xmp>
 
@@ -1406,9 +1427,8 @@ attributes.
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
     :   <dfn>requireUserVerification</dfn>
-    ::  This member describes the [=[RPS]=]' requirements regarding the authenticator being capable of performing user
-        verification. If the parameter is set to true, the authenticator MUST perform [=user verification=] when performing the
-        {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} operation.
+    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this operation. If this member is
+        [=present=], eligible authenticators are filtered to satisfy this requirement as well as possible.
 </div>
 
 
@@ -1445,6 +1465,30 @@ credential on a [=platform authenticator=] may be used by [=[RPS]=] to quickly a
 a minimum of friction, e.g., the user will not have to dig around in their pocket for their key fob or phone. As a concrete
 example of the latter, when the user is accessing the [=[RP]=] from a given client for the first time, they may be required to
 use a [=roaming authenticator=] which was originally registered with the [=[RP]=] using a different client.
+
+
+### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
+
+<pre class="idl">
+    enum UserVerificationRequirement {
+        "required",
+        "wanted",
+        "not-wanted"
+    };
+</pre>
+
+A [=[RP]=] may require [=user verified|user verification=] for some of its operations but not for others, and may use this type to
+express this level of requirement.
+
+The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
+and will fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/wanted}} indicates that the [=[RP]=] would like [=user verification=] for this operation
+is possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/not-wanted}} indicates that the [=[RP]=] does not require [=user verification=], and does
+not want the [=client=] or [=authenticator=] to ask for it, but will not fail the operation if the response has the [=UV=]
+[=flag=] set.
 
 
 ## Options for Assertion Generation (dictionary <dfn dictionary>PublicKeyCredentialRequestOptions</dfn>) ## {#assertion-options}
@@ -1855,7 +1899,7 @@ input parameters:
 : |requireResidentKey|
 :: |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}.
 : |requireUserVerification|
-:: |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireUserVerification}}.
+:: The [=effective user verification requirement for credential creation=], a Boolean value provided by the client.
 : |credTypesAndPubKeyAlgs|
 :: A sequence of pairs of {{PublicKeyCredentialType}} and public key algorithms ({{COSEAlgorithmIdentifier}}) requested by the
     [=[RP]=]. This sequence is ordered from most preferred to least preferred. The platform makes a best-effort to create the most
@@ -1942,7 +1986,7 @@ input parameters:
 :: An optional list of {{PublicKeyCredentialDescriptor}}s describing credentials acceptable to the [=[RP]=] (possibly filtered
     by the client), if any.
 : |requireUserVerification|
-:: |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{requireUserVerification}}.
+:: The [=effective user verification requirement for assertion=], a Boolean value provided by the client.
 : |extensions|
 :: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
     extensions requested by the [=[RP]=], if any.

--- a/index.bs
+++ b/index.bs
@@ -763,7 +763,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
         |clientDataHash|,
         <code>|options|.{{MakePublicKeyCredentialOptions/rp}}</code>, <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
         <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
-        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}</code>,
         |credTypesAndPubKeyAlgs|,
         |excludeCredentialDescriptorList|,
         and |authenticatorExtensions| as parameters.
@@ -1891,8 +1890,6 @@ input parameters:
 :: The user account's {{PublicKeyCredentialUserEntity}}, containing the [=user handle=] given by the [=[RP]=].
 : |requireResidentKey|
 :: |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}.
-: |requireUserVerification|
-:: <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}.</code>
 : |credTypesAndPubKeyAlgs|
 :: A sequence of pairs of {{PublicKeyCredentialType}} and public key algorithms ({{COSEAlgorithmIdentifier}}) requested by the
     [=[RP]=]. This sequence is ordered from most preferred to least preferred. The platform makes a best-effort to create the most
@@ -1918,8 +1915,6 @@ When this operation is invoked, the authenticator must perform the following pro
     If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is `true` and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code
-    equivalent to "{{ConstraintError}}" and terminate the operation.
 1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
     authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the contents of
     |rpEntity| and |userEntity|, if possible.

--- a/index.bs
+++ b/index.bs
@@ -797,6 +797,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
             </dl>
 
+    1. Let |userPresence| be a Boolean value set to the inverse of |userVerification|.
+
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
     1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakePublicKeyCredentialOptions/excludeCredentials}}</code>:
@@ -809,6 +811,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         |clientDataHash|,
         <code>|options|.{{MakePublicKeyCredentialOptions/rp}}</code>, <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
         <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
+        |userPresence|,
         |userVerification|,
         |credTypesAndPubKeyAlgs|,
         |excludeCredentialDescriptorList|,
@@ -1064,6 +1067,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
             </dl>
 
+    1. Let |userPresence| be a Boolean value set to the inverse of |userVerification|.
 
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 
@@ -1102,20 +1106,20 @@ When this method is invoked, the user agent MUST execute the following algorithm
                             selection.
 
                             Then, using |transport|, invoke the [=authenticatorGetAssertion=] operation on
-                            |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|, |userVerification|,
-                            and |authenticatorExtensions| as parameters.
+                            |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|, |userPresence|,
+                            |userVerification|, and |authenticatorExtensions| as parameters.
 
                         :   [=list/is empty=]
                         ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|,
                             invoke the [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|,
-                            |clientDataHash|, |allowCredentialDescriptorList|, |userVerification|, and |clientExtensions| as
-                            parameters.
+                            |clientDataHash|, |allowCredentialDescriptorList|, |userPresence|, |userVerification|, and
+                            |clientExtensions| as parameters.
                     </dl>
 
             :   [=list/is empty=]
             ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|, invoke the
-                [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|, |clientDataHash|, |userVerification| and
-                |clientExtensions| as parameters.
+                [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|, |clientDataHash|, |userPresence|,
+                |userVerification| and |clientExtensions| as parameters.
 
                 Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus the
                     authenticator is being asked to exercise any credential it may possess that is bound to
@@ -2042,6 +2046,10 @@ input parameters:
 :: The user account's {{PublicKeyCredentialUserEntity}}, containing the [=user handle=] given by the [=[RP]=].
 : |requireResidentKey|
 :: |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}.
+: |requireUserPresence|
+:: A Boolean value provided by the client, which in invocations from a [=[WAC]=]'s
+    {{PublicKeyCredential/[[Create]](origin, options)}} method is always set to the inverse of
+    |requireUserVerification|.
 : |requireUserVerification|
 :: The [=effective user verification requirement for credential creation=], a Boolean value provided by the client.
 : |credTypesAndPubKeyAlgs|
@@ -2077,17 +2085,9 @@ When this operation is invoked, the authenticator must perform the following pro
     <code>|userEntity|.{{PublicKeyCredentialEntity/name}}</code> and
     <code>|userEntity|.{{PublicKeyCredentialUserEntity/displayName}}</code>, if possible.
 
-    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows. If
-    |requireUserVerification|
+    If |requireUserVerification| is `true`, the method of obtaining [=user consent=] MUST include [=user verification=].
 
-    <dl class="switch">
-        :   is `true`
-        ::  [=User verification=] MUST be performed.
-
-        :   is `false`
-        ::  [=User verification=] SHOULD NOT be performed. If [=user verification=] is not performed, a [=test of user presence=]
-            MUST be performed.
-    </dl>
+    If |requireUserPresence| is `true`, the method of obtaining [=user consent=] MUST include a [=test of user presence=].
 
     If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
     "{{NotAllowedError}}" and terminate the operation.
@@ -2140,6 +2140,10 @@ input parameters:
 : |allowCredentialDescriptorList|
 :: An optional list of {{PublicKeyCredentialDescriptor}}s describing credentials acceptable to the [=[RP]=] (possibly filtered
     by the client), if any.
+: |requireUserPresence|
+:: A Boolean value provided by the client, which in invocations from a [=[WAC]=]'s
+    {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options)}} method is always set to the inverse of
+    |requireUserVerification|.
 : |requireUserVerification|
 :: The [=effective user verification requirement for assertion=], a Boolean value provided by the client.
 : |extensions|
@@ -2165,17 +2169,9 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
     |rpId| and any additional displayable data associated with |selectedCredential|, if possible.
 
-    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows. If
-    |requireUserVerification|
+    If |requireUserVerification| is `true`, the method of obtaining [=user consent=] MUST include [=user verification=].
 
-    <dl class="switch">
-        :   is `true`
-        ::  [=User verification=] MUST be performed.
-
-        :   is `false`
-        ::  [=User verification=] SHOULD NOT be performed. If [=user verification=] is not performed, a [=test of user presence=]
-            MUST be performed.
-    </dl>
+    If |requireUserPresence| is `true`, the method of obtaining [=user consent=] MUST include a [=test of user presence=].
 
     If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
     "{{NotAllowedError}}" and terminate the operation.

--- a/index.bs
+++ b/index.bs
@@ -978,23 +978,19 @@ method is invoked, the user agent MUST:
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. If |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}} is [=present=], and
-        |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
-        is set to {{UserVerificationRequirement/required}}, and the |authenticator| is not capable of performing [=user
-        verification=], [=iteration/continue=].
+    1. If |options|.{{PublicKeyCredentialRequestOptions/requireUserVerification}} is set to
+        {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user verification=],
+        [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
         follows:
-        - If
-            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
-            is set to {{UserVerificationRequirement/required}}, let |userVerification| be true.
-        - If
-            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
-            is set to {{UserVerificationRequirement/wanted}}, let |userVerification| be true if the |authenticator| is capable
-            of [=user verification=] and false if the |authenticator| is not capable of [=user verification=].
-        - If
-            |options|.{{PublicKeyCredentialRequestOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}
-            is set to {{UserVerificationRequirement/not-wanted}}, let |userVerification| be false.
+        - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
+            {{UserVerificationRequirement/required}}, let |userVerification| be true.
+        - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
+            {{UserVerificationRequirement/wanted}}, let |userVerification| be true if the |authenticator| is capable of [=user
+            verification=] and false if the |authenticator| is not capable of [=user verification=].
+        - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
+            {{UserVerificationRequirement/not-wanted}}, let |userVerification| be false.
 
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 
@@ -1426,8 +1422,9 @@ attributes.
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
     :   <dfn>requireUserVerification</dfn>
-    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this operation. If this member is
-        [=present=], eligible authenticators are filtered to satisfy this requirement as well as possible.
+    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this
+        {{CredentialsContainer/create()}} operation. If this member is [=present=], eligible authenticators are filtered to
+        satisfy this requirement as well as possible.
 </div>
 
 
@@ -1477,7 +1474,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-        AuthenticatorSelectionCriteria       authenticatorSelection;
+        UserVerificationRequirement          requireUserVerification = "not-wanted";
         AuthenticationExtensions             extensions;
     };
 </xmp>
@@ -1501,12 +1498,10 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         acceptable to the caller, in decending order of the caller's preference (the first item in the list is the most
         preferred credential, and so on down the list).
 
-    :   <dfn>authenticatorSelection</dfn>
-    ::  This member is intended for use by [=[RPS]=] that wish to select the appropriate authenticators to participate in
-        the {{CredentialsContainer/get()}} operation.
-
-        Note: Only the {{AuthenticatorSelectionCriteria/requireUserVerification}} member of this member currently has any effect
-        when used in {{PublicKeyCredentialRequestOptions}}; any other members are ignored.
+    :   <dfn>requireUserVerification</dfn>
+    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this
+        {{CredentialsContainer/get()}} operation. If this member is [=present=], eligible authenticators are filtered to
+        satisfy this requirement as well as possible.
 
     :   <dfn>extensions</dfn>
     ::  This optional member contains additional parameters requesting additional processing by the client and authenticator.

--- a/index.bs
+++ b/index.bs
@@ -1672,30 +1672,6 @@ The [=public key credential=] type uses certain data structures that are specifi
 follows.
 
 
-### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
-
-<pre class="idl">
-    enum UserVerificationRequirement {
-        "required",
-        "preferred",
-        "discouraged"
-    };
-</pre>
-
-A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express this
-level of requirement.
-
-The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
-and will fail the operation if the response does not have the [=UV=] [=flag=] set.
-
-The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] would like [=user verification=] for this
-operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
-
-The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
-not want the [=client=] or [=authenticator=] to request it, but will not fail the operation if the response has the [=UV=]
-[=flag=] set.
-
-
 ### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
 
 The <dfn>client data</dfn> represents the contextual bindings of both the [=[RP]=] and the client platform. It is a key-value
@@ -1821,6 +1797,30 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
     The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>
+
+
+### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
+
+<pre class="idl">
+    enum UserVerificationRequirement {
+        "required",
+        "preferred",
+        "discouraged"
+    };
+</pre>
+
+A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express this
+level of requirement.
+
+The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
+and will fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] would like [=user verification=] for this
+operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
+not want the [=client=] or [=authenticator=] to request it, but will not fail the operation if the response has the [=UV=]
+[=flag=] set.
 
 
 # WebAuthn Authenticator model # {#authenticator-model}

--- a/index.bs
+++ b/index.bs
@@ -2091,12 +2091,6 @@ When this operation is invoked, the authenticator must perform the following pro
     If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
     "{{NotAllowedError}}" and terminate the operation.
 
-1. If |requireUserVerification| is `true`, perform [=user verification=]. If [=user verification=] fails, return an
-    error code equivalent to "{{NotAllowedError}}" and terminate the operation.
-
-    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
-    operation.
-
 1. Once [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|,|privateKey|) be a new pair of cryptographic keys using the combination of {{PublicKeyCredentialType}}
         and cryptographic parameters represented by the first [=list/item=] in |credTypesAndPubKeyAlgs| that is supported by

--- a/index.bs
+++ b/index.bs
@@ -2163,7 +2163,19 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
 
-1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.
+1. Let |selectedCredential| be a [=public key credential|credential=] as follows. If the [=list/size=] of
+    |allowCredentialDescriptorList|
+
+    <dl class="switch">
+        :   is exactly 1
+        ::  Let |selectedCredential| be the [=public key credential|credential=] matching
+            <code>|allowCredentialDescriptorList|[0]</code>.
+
+        :   is greater than 1
+        ::  Prompt the user to select |selectedCredential| from the [=public key credential|credentials=] matching the
+            [=list/items=] in |allowCredentialDescriptorList|.
+    </dl>
+
 
 1. Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown by
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the

--- a/index.bs
+++ b/index.bs
@@ -1445,7 +1445,7 @@ attributes.
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
     :   <dfn>requireUserVerification</dfn>
-    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this
+    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/create()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.
 </div>
@@ -1522,7 +1522,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         preferred credential, and so on down the list).
 
     :   <dfn>requireUserVerification</dfn>
-    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this
+    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/get()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.
 
@@ -1570,7 +1570,7 @@ The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] 
 operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
 
 The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
-not want the [=client=] or [=authenticator=] to ask for it, but will not fail the operation if the response has the [=UV=]
+not want the [=client=] or [=authenticator=] to request it, but will not fail the operation if the response has the [=UV=]
 [=flag=] set.
 
 

--- a/index.bs
+++ b/index.bs
@@ -770,8 +770,32 @@ When this method is invoked, the user agent MUST execute the following algorithm
         to |authenticator|'s attachment modality, [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to `true` and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to `true` and the |authenticator| is not capable of
-        performing [=user verification=], [=iteration/continue=].
+    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/required}} and the
+        |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
+
+    1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
+        as follows. If {{AuthenticatorSelectionCriteria/requireUserVerification}}
+
+            <dl class="switch">
+
+                :   is set to {{UserVerificationRequirement/required}}
+                ::  Let |userVerification| be `true`.
+
+                :   is set to {{UserVerificationRequirement/preferred}}
+                ::  If the |authenticator|
+
+                    <dl class="switch">
+                        :   is capable of [=user verification=]
+                        ::  Let |userVerification| be `true`.
+
+                        :   is not capable of [=user verification=]
+                        ::  Let |userVerification| be `false`.
+                    </dl>
+
+                :   is set to {{UserVerificationRequirement/discouraged}}
+                ::  Let |userVerification| be `false`.
+
+            </dl>
 
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
@@ -785,6 +809,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         |clientDataHash|,
         <code>|options|.{{MakePublicKeyCredentialOptions/rp}}</code>, <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
         <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
+        |userVerification|,
         |credTypesAndPubKeyAlgs|,
         |excludeCredentialDescriptorList|,
         and |authenticatorExtensions| as parameters.
@@ -1499,7 +1524,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        boolean                      requireUserVerification = false;
+        UserVerificationRequirement  requireUserVerification = "preferred";
     };
 </xmp>
 
@@ -1602,30 +1627,6 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
 </dl>
 
 
-### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
-
-<pre class="idl">
-    enum UserVerificationRequirement {
-        "required",
-        "preferred",
-        "discouraged"
-    };
-</pre>
-
-A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express this
-level of requirement.
-
-The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
-and will fail the operation if the response does not have the [=UV=] [=flag=] set.
-
-The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] would like [=user verification=] for this
-operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
-
-The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
-not want the [=client=] or [=authenticator=] to request it, but will not fail the operation if the response has the [=UV=]
-[=flag=] set.
-
-
 ## Abort operations with `AbortSignal` ## {#abortoperation}
 
 Developers are encouraged to leverage the {{AbortController}} to manage the 
@@ -1669,6 +1670,30 @@ context.
 
 The [=public key credential=] type uses certain data structures that are specified in supporting specifications. These are as
 follows.
+
+
+### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
+
+<pre class="idl">
+    enum UserVerificationRequirement {
+        "required",
+        "preferred",
+        "discouraged"
+    };
+</pre>
+
+A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express this
+level of requirement.
+
+The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
+and will fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] would like [=user verification=] for this
+operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
+
+The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
+not want the [=client=] or [=authenticator=] to request it, but will not fail the operation if the response has the [=UV=]
+[=flag=] set.
 
 
 ### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
@@ -1796,6 +1821,7 @@ the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods.
     The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 </div>
+
 
 # WebAuthn Authenticator model # {#authenticator-model}
 
@@ -2017,6 +2043,8 @@ input parameters:
 :: The user account's {{PublicKeyCredentialUserEntity}}, containing the [=user handle=] given by the [=[RP]=].
 : |requireResidentKey|
 :: |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}.
+: |requireUserVerification|
+:: The [=effective user verification requirement for credential creation=], a Boolean value provided by the client.
 : |credTypesAndPubKeyAlgs|
 :: A sequence of pairs of {{PublicKeyCredentialType}} and public key algorithms ({{COSEAlgorithmIdentifier}}) requested by the
     [=[RP]=]. This sequence is ordered from most preferred to least preferred. The platform makes a best-effort to create the most
@@ -2042,15 +2070,32 @@ When this operation is invoked, the authenticator must perform the following pro
     If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. If |requireResidentKey| is `true` and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
+1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code
+    equivalent to "{{ConstraintError}}" and terminate the operation.
 1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
-    authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the contents of
+    authenticator if it has its own output capability, or by the user agent otherwise.  The prompt SHOULD display the contents of
     |rpEntity| and |userEntity|, if possible.
 
-    The method of obtaining [=user consent=] MUST include [=user verification=] if the authenticator supports [=user
-    verification=], and MUST include a [=test of user presence=] otherwise.
+    The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows. If
+    |requireUserVerification|
+
+    <dl class="switch">
+        :   is `true`
+        ::  [=User verification=] MUST be performed.
+
+        :   is `false`
+        ::  [=User verification=] SHOULD NOT be performed. If [=user verification=] is not performed, a [=test of user presence=]
+            MUST be performed.
+    </dl>
 
     If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
     "{{NotAllowedError}}" and terminate the operation.
+
+1. If |requireUserVerification| is `true`, perform [=user verification=]. If [=user verification=] fails, return an
+    error code equivalent to "{{NotAllowedError}}" and terminate the operation.
+
+    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
+    operation.
 
 1. Once [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|,|privateKey|) be a new pair of cryptographic keys using the combination of {{PublicKeyCredentialType}}

--- a/index.bs
+++ b/index.bs
@@ -2005,7 +2005,7 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 
 1. Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown by
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
-    contents of |rpEntity| and |userEntity|, if possible.
+    |rpId| and any additional data associated with |selectedCredential|, if possible.
 
     The method of obtaining [=user consent=] MUST include [=user verification=] or a [=test of user presence=] as follows:
 

--- a/index.bs
+++ b/index.bs
@@ -2158,7 +2158,7 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 1. If |allowCredentialDescriptorList| was not supplied, set it to a [=list=] of all credentials stored for |rpId| (as determined
     by an exact match of |rpId|).
 1. Remove any [=list/items=] from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A
-    match occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's
+    match occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| [=list/item=]'s
     {{PublicKeyCredentialDescriptor/id}} and {{PublicKeyCredentialDescriptor/type}} members.
 1. If |allowCredentialDescriptorList| is now [=list/empty=], return an error code equivalent to "{{NotAllowedError}}" and
     terminate the operation.

--- a/index.bs
+++ b/index.bs
@@ -1883,7 +1883,7 @@ When this operation is invoked, the authenticator must perform the following pro
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
-  1. Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
+1. Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
     if it has its own output capability, or by the user agent otherwise. If the user denies consent, return an error code
     equivalent to "{{NotAllowedError}}" and terminate the operation. The Authenticator and user agent MAY skip this prompt
     if the Authenticator is a [=platform authenticator=] and |excludeCredentialDescriptorList| is empty.

--- a/index.bs
+++ b/index.bs
@@ -2057,8 +2057,6 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 If the authenticator cannot find any credential corresponding to the specified [=[RP]=] that matches the specified criteria, it
 terminates the operation and returns an error.
 
-If the user refuses consent, the authenticator returns an appropriate error status to the client.
-
 
 ### The <dfn>authenticatorCancel</dfn> operation ### {#op-cancel}
 

--- a/index.bs
+++ b/index.bs
@@ -2138,7 +2138,7 @@ input parameters:
 : |hash|
 :: The [=hash of the serialized client data=], provided by the client.
 : |allowCredentialDescriptorList|
-:: An optional list of {{PublicKeyCredentialDescriptor}}s describing credentials acceptable to the [=[RP]=] (possibly filtered
+:: An optional [=list=] of {{PublicKeyCredentialDescriptor}}s describing credentials acceptable to the [=[RP]=] (possibly filtered
     by the client), if any.
 : |requireUserPresence|
 :: A Boolean value provided by the client, which in invocations from a [=[WAC]=]'s
@@ -2155,13 +2155,13 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     equivalent to "{{UnknownError}}" and terminate the operation.
 1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user
     verification=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
-    an exact match of |rpId|).
-1. Remove any items from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A match
-    occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's
+1. If |allowCredentialDescriptorList| was not supplied, set it to a [=list=] of all credentials stored for |rpId| (as determined
+    by an exact match of |rpId|).
+1. Remove any [=list/items=] from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A
+    match occurs if a credential matches <code>|rpId|</code> and an |allowCredentialDescriptorList| item's
     {{PublicKeyCredentialDescriptor/id}} and {{PublicKeyCredentialDescriptor/type}} members.
-1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
-    operation.
+1. If |allowCredentialDescriptorList| is now [=list/empty=], return an error code equivalent to "{{NotAllowedError}}" and
+    terminate the operation.
 
 1. Let |selectedCredential| be a [=public key credential|credential=] as follows. If the [=list/size=] of
     |allowCredentialDescriptorList|
@@ -2211,10 +2211,10 @@ When this method is invoked, the [=authenticator=] must perform the following pr
 
     <li id='authenticatorGetAssertion-return-values'>
     Return to the user agent:
-        - |selectedCredential|'s [=credential ID=], if either a list of credentials of length 2 or greater was supplied by the
-            client, or no such list was supplied. Otherwise, return only the below values.
+        - |selectedCredential|'s [=credential ID=], if either a [=list=] of credentials of [=list/size=] 2 or greater was supplied
+            by the client, or no such [=list=] was supplied. Otherwise, return only the below values.
 
-            Note: If the client supplies a list of exactly one credential and it was successfully employed, then its
+            Note: If the client supplies a [=list=] of exactly one credential and it was successfully employed, then its
                 [=credential ID=] is not returned since the client already knows it. This saves transmitting these bytes over
                 what may be a constrained connection in what is likely a common case.
 

--- a/index.bs
+++ b/index.bs
@@ -2041,6 +2041,9 @@ input parameters:
 When this method is invoked, the [=authenticator=] must perform the following procedure:
 1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
     equivalent to "{{UnknownError}}" and terminate the operation.
+1. Let |isFirstFactorOperation| be a Boolean value, set to `true` if and only if |allowCredentialDescriptorList| was not supplied.
+1. If at least one of |requireUserVerification| and |isFirstFactorOperation| is `true` and the authenticator cannot perform [=user
+    verification=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |allowCredentialDescriptorList| was not supplied, set it to a list of all credentials stored for |rpId| (as determined by
     an exact match of |rpId|).
 1. Remove any items from |allowCredentialDescriptorList| that do not match a credential bound to this authenticator. A match
@@ -2048,10 +2051,12 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     {{PublicKeyCredentialDescriptor/id}} and {{PublicKeyCredentialDescriptor/type}} members.
 1. If |allowCredentialDescriptorList| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the
     operation.
-1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code
-    equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |requireUserVerification| is `true`, perform [=user verification=]. If [=user verification=] fails, return an error code
+
+1. If |isFirstFactorOperation| is `true`, perform [=user verification=]. If [=user verification=] fails, return an error code
     equivalent to "{{NotAllowedError}}" and terminate the operation.
+
+    Remove any items from |allowCredentialDescriptorList| that match a credential that was created by a [=user verified|verified
+    user=] other than the current [=user verified|verified user=].
 
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.
 
@@ -2059,8 +2064,20 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
     |rpId| and any additional data associated with |selectedCredential|, if possible.
 
-    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
-    operation.
+    The method of obtaining [=user consent=] MUST ensure that the user is [=user verified|verified=] or [=user present|present=]
+    as follows. If the user is not already [=user verified|verified=],
+
+    <dl class="switch">
+        :   if |requireUserVerification| is `true`
+        ::  [=User verification=] MUST be performed.
+
+        :   if |requireUserVerification| is `false`
+        ::  [=User verification=] SHOULD NOT be performed. If [=user verification=] is not performed, a [=test of user presence=]
+            MUST be performed.
+    </dl>
+
+    If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
+    "{{NotAllowedError}}" and terminate the operation.
 
 1. Let |processedExtensions| be the result of [=authenticator extension processing=] for each supported [=extension
     identifier=]/input pair in |extensions|.

--- a/index.bs
+++ b/index.bs
@@ -1423,8 +1423,8 @@ attributes.
 
     :   <dfn>requireUserVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this
-        {{CredentialsContainer/create()}} operation. If this member is [=present=], eligible authenticators are filtered to
-        satisfy this requirement as well as possible.
+        {{CredentialsContainer/create()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
+        requirement.
 </div>
 
 
@@ -1500,8 +1500,8 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
 
     :   <dfn>requireUserVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for this
-        {{CredentialsContainer/get()}} operation. If this member is [=present=], eligible authenticators are filtered to
-        satisfy this requirement as well as possible.
+        {{CredentialsContainer/get()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
+        requirement.
 
     :   <dfn>extensions</dfn>
     ::  This optional member contains additional parameters requesting additional processing by the client and authenticator.

--- a/index.bs
+++ b/index.bs
@@ -1544,7 +1544,7 @@ The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] r
 and will fail the operation if the response does not have the [=UV=] [=flag=] set.
 
 The value {{UserVerificationRequirement/wanted}} indicates that the [=[RP]=] would like [=user verification=] for this operation
-is possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
+if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
 
 The value {{UserVerificationRequirement/not-wanted}} indicates that the [=[RP]=] does not require [=user verification=], and does
 not want the [=client=] or [=authenticator=] to ask for it, but will not fail the operation if the response has the [=UV=]

--- a/index.bs
+++ b/index.bs
@@ -761,7 +761,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         as follows:
         - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/required}}, let
             |userVerification| be true.
-        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/wanted}}, let
+        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/preferred}}, let
             |userVerification| be true if the |authenticator| is capable of [=user verification=] and false if the |authenticator|
             is not capable of [=user verification=].
         - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/not-wanted}}, let
@@ -987,7 +987,7 @@ method is invoked, the user agent MUST:
         - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
             {{UserVerificationRequirement/required}}, let |userVerification| be true.
         - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
-            {{UserVerificationRequirement/wanted}}, let |userVerification| be true if the |authenticator| is capable of [=user
+            {{UserVerificationRequirement/preferred}}, let |userVerification| be true if the |authenticator| is capable of [=user
             verification=] and false if the |authenticator| is not capable of [=user verification=].
         - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
             {{UserVerificationRequirement/not-wanted}}, let |userVerification| be false.
@@ -1407,7 +1407,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        UserVerificationRequirement  requireUserVerification = "wanted";
+        UserVerificationRequirement  requireUserVerification = "preferred";
     };
 </xmp>
 
@@ -1474,7 +1474,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-        UserVerificationRequirement          requireUserVerification = "wanted";
+        UserVerificationRequirement          requireUserVerification = "preferred";
         AuthenticationExtensions             extensions;
     };
 </xmp>
@@ -1532,7 +1532,7 @@ follows.
 <pre class="idl">
     enum UserVerificationRequirement {
         "required",
-        "wanted",
+        "preferred",
         "not-wanted"
     };
 </pre>
@@ -1543,8 +1543,8 @@ express this level of requirement.
 The value {{UserVerificationRequirement/required}} indicates that the [=[RP]=] requires [=user verification=] for this operation
 and will fail the operation if the response does not have the [=UV=] [=flag=] set.
 
-The value {{UserVerificationRequirement/wanted}} indicates that the [=[RP]=] would like [=user verification=] for this operation
-if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
+The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] would like [=user verification=] for this
+operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
 
 The value {{UserVerificationRequirement/not-wanted}} indicates that the [=[RP]=] does not require [=user verification=], and does
 not want the [=client=] or [=authenticator=] to ask for it, but will not fail the operation if the response has the [=UV=]

--- a/index.bs
+++ b/index.bs
@@ -775,7 +775,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
             </dl>
 
-    l. Let |excludeCredentialDescriptorList| be a new [=list=].
+    1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
     1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakePublicKeyCredentialOptions/excludeCredentials}}</code>:
         1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not

--- a/index.bs
+++ b/index.bs
@@ -1407,7 +1407,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        UserVerificationRequirement  requireUserVerification = "not-wanted";
+        UserVerificationRequirement  requireUserVerification = "wanted";
     };
 </xmp>
 
@@ -1474,7 +1474,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-        UserVerificationRequirement          requireUserVerification = "not-wanted";
+        UserVerificationRequirement          requireUserVerification = "wanted";
         AuthenticationExtensions             extensions;
     };
 </xmp>

--- a/index.bs
+++ b/index.bs
@@ -764,7 +764,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/preferred}}, let
             |userVerification| be true if the |authenticator| is capable of [=user verification=] and false if the |authenticator|
             is not capable of [=user verification=].
-        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/not-wanted}}, let
+        - If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/discouraged}}, let
             |userVerification| be false.
 
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
@@ -990,7 +990,7 @@ method is invoked, the user agent MUST:
             {{UserVerificationRequirement/preferred}}, let |userVerification| be true if the |authenticator| is capable of [=user
             verification=] and false if the |authenticator| is not capable of [=user verification=].
         - If |options|.{{AuthenticatorSelectionCriteria/requireUserVerification}} is set to
-            {{UserVerificationRequirement/not-wanted}}, let |userVerification| be false.
+            {{UserVerificationRequirement/discouraged}}, let |userVerification| be false.
 
     1. Let |allowCredentialDescriptorList| be a new [=list=].
 
@@ -1533,7 +1533,7 @@ follows.
     enum UserVerificationRequirement {
         "required",
         "preferred",
-        "not-wanted"
+        "discouraged"
     };
 </pre>
 
@@ -1546,7 +1546,7 @@ and will fail the operation if the response does not have the [=UV=] [=flag=] se
 The value {{UserVerificationRequirement/preferred}} indicates that the [=[RP]=] would like [=user verification=] for this
 operation if possible, but will not fail the operation if the response does not have the [=UV=] [=flag=] set.
 
-The value {{UserVerificationRequirement/not-wanted}} indicates that the [=[RP]=] does not require [=user verification=], and does
+The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
 not want the [=client=] or [=authenticator=] to ask for it, but will not fail the operation if the response has the [=UV=]
 [=flag=] set.
 

--- a/index.bs
+++ b/index.bs
@@ -748,32 +748,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
         to |authenticator|'s attachment modality, [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to `true` and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to {{UserVerificationRequirement/required}} and the
-        |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
-
-    1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
-        as follows. If {{AuthenticatorSelectionCriteria/requireUserVerification}}
-
-            <dl class="switch">
-
-                :   is set to {{UserVerificationRequirement/required}}
-                ::  Let |userVerification| be `true`.
-
-                :   is set to {{UserVerificationRequirement/preferred}}
-                ::  If the |authenticator|
-
-                    <dl class="switch">
-                        :   is capable of [=user verification=]
-                        ::  Let |userVerification| be `true`.
-
-                        :   is not capable of [=user verification=]
-                        ::  Let |userVerification| be `false`.
-                    </dl>
-
-                :   is set to {{UserVerificationRequirement/discouraged}}
-                ::  Let |userVerification| be `false`.
-
-            </dl>
+    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to `true` and the |authenticator| is not capable of
+        performing [=user verification=], [=iteration/continue=].
 
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
@@ -787,7 +763,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         |clientDataHash|,
         <code>|options|.{{MakePublicKeyCredentialOptions/rp}}</code>, <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
         <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
-        |userVerification|,
+        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}</code>,
         |credTypesAndPubKeyAlgs|,
         |excludeCredentialDescriptorList|,
         and |authenticatorExtensions| as parameters.
@@ -1430,7 +1406,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        UserVerificationRequirement  requireUserVerification = "preferred";
+        boolean                      requireUserVerification = false;
     };
 </xmp>
 
@@ -1533,23 +1509,6 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
 </dl>
 
 
-## Authentication Extensions (typedef <dfn>AuthenticationExtensions</dfn>) ## {#iface-authentication-extensions}
-
-<pre class="idl">
-    typedef record&lt;DOMString, any&gt;       AuthenticationExtensions;
-</pre>
-
-This is a dictionary containing zero or more WebAuthn extensions, as defined in [[#extensions]].
-An AuthenticationExtensions instance can contain either [=client extensions=] or [=authenticator extensions=], depending upon
-context.
-
-
-## Supporting Data Structures ## {#supporting-data-structures}
-
-The [=public key credential=] type uses certain data structures that are specified in supporting specifications. These are as
-follows.
-
-
 ### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
 
 <pre class="idl">
@@ -1572,6 +1531,23 @@ operation if possible, but will not fail the operation if the response does not 
 The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=] does not require [=user verification=], and does
 not want the [=client=] or [=authenticator=] to request it, but will not fail the operation if the response has the [=UV=]
 [=flag=] set.
+
+
+## Authentication Extensions (typedef <dfn>AuthenticationExtensions</dfn>) ## {#iface-authentication-extensions}
+
+<pre class="idl">
+    typedef record&lt;DOMString, any&gt;       AuthenticationExtensions;
+</pre>
+
+This is a dictionary containing zero or more WebAuthn extensions, as defined in [[#extensions]].
+An AuthenticationExtensions instance can contain either [=client extensions=] or [=authenticator extensions=], depending upon
+context.
+
+
+## Supporting Data Structures ## {#supporting-data-structures}
+
+The [=public key credential=] type uses certain data structures that are specified in supporting specifications. These are as
+follows.
 
 
 ### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
@@ -1916,7 +1892,7 @@ input parameters:
 : |requireResidentKey|
 :: |options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}.
 : |requireUserVerification|
-:: The [=effective user verification requirement for credential creation=], a Boolean value provided by the client.
+:: <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireUserVerification}}.</code>
 : |credTypesAndPubKeyAlgs|
 :: A sequence of pairs of {{PublicKeyCredentialType}} and public key algorithms ({{COSEAlgorithmIdentifier}}) requested by the
     [=[RP]=]. This sequence is ordered from most preferred to least preferred. The platform makes a best-effort to create the most
@@ -1944,14 +1920,15 @@ When this operation is invoked, the authenticator must perform the following pro
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is `true` and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
-1. If |requireUserVerification| is `true`, perform [=user verification=]. If [=user verification=] fails, return an
-    error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
-    authenticator if it has its own output capability, or by the user agent otherwise.  The prompt SHOULD display the contents of
+    authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the contents of
     |rpEntity| and |userEntity|, if possible.
 
-    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
-    operation.
+    The method of obtaining [=user consent=] MUST include [=user verification=] if the authenticator supports [=user
+    verification=], and MUST include a [=test of user presence=] otherwise.
+
+    If the user denies [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
+    "{{NotAllowedError}}" and terminate the operation.
 
 1. Once [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|,|privateKey|) be a new set of cryptographic keys using the combination of {{PublicKeyCredentialType}}

--- a/index.bs
+++ b/index.bs
@@ -290,8 +290,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Authentication</dfn>
 :: The [=ceremony=] where a user, and the user's computing device(s) (containing at least one [=authenticator=]) work in
     concert to cryptographically prove to an [=[RP]=] that the user controls the [=credential private key=] associated with a
-    previously-registered [=public key credential=] (see [=Registration=]). Note that this typically includes employing a [=test
-    of user presence=] or [=user verification=].
+    previously-registered [=public key credential=] (see [=Registration=]). Note that this includes a [=test of user presence=] or
+    [=user verification=].
 
 : <dfn>Authentication Assertion</dfn>
 :: The cryptographically signed {{AuthenticatorAssertionResponse}} object returned by an [=authenticator=] as the result of a
@@ -416,7 +416,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Registration</dfn>
 :: The [=ceremony=] where a user, a [=[RP]=], and the user's computing device(s) (containing at least one
     [=authenticator=]) work in concert to create a [=public key credential=] and associate it with the user's [=[RP]=] account.
-    Note that this typically includes employing a [=test of user presence=] or [=user verification=].
+    Note that this includes employing a [=test of user presence=] or [=user verification=].
 
 : <dfn>[RP]</dfn>
 :: The entity whose web application utilizes the [=Web Authentication API=] to register and authenticate users. See
@@ -478,7 +478,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn id=concept-user-present>User Present</dfn>
 : <dfn>UP</dfn>
 :: Upon successful completion of a [=test of user presence|user presence test=], the user is said to be
-    "[=user present|present=]".
+    "[=user present|present=]". If the user is [=user verified|verified=], the user is also said to be [=user present|present=].
 
 : <dfn id=concept-user-verified>User Verified</dfn>
 : <dfn>UV</dfn>
@@ -754,7 +754,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         to |authenticator|'s attachment modality, [=iteration/continue=].
     1. If {{AuthenticatorSelectionCriteria/requireResidentKey}} is set to true and the |authenticator|
         is not capable of storing a [=Client-Side-Resident Credential Private Key=], [=iteration/continue=].
-    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to |true| and the
+    1. If {{AuthenticatorSelectionCriteria/requireUserVerification}} is set to true and the
         |authenticator| is not capable of performing [=user verification=], [=iteration/continue=].
 
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
@@ -1879,15 +1879,21 @@ When this operation is invoked, the authenticator must perform the following pro
     item's <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/id}}</code> and 
     <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code>.
     If so, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
-1. If |requireResidentKey| is |true| and the authenticator cannot store a [=Client-side-resident Credential
+1. If |requireResidentKey| is true and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
-1. Prompt the user for consent to create a new credential. The prompt for obtaining this consent is shown by the authenticator
-    if it has its own output capability, or by the user agent otherwise. If the user denies consent, return an error code
-    equivalent to "{{NotAllowedError}}" and terminate the operation. The Authenticator and user agent MAY skip this prompt
-    if the Authenticator is a [=platform authenticator=] and |excludeCredentialDescriptorList| is empty.
-1. Once user consent has been obtained, generate a new credential object:
+1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
+    authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the contents of
+    |rpEntity| and |userEntity|, if possible.
+
+    - If |requireUserVerification| is true, obtain [=user consent=] by performing [=user verification=].
+    - If |requireUserVerification| is false, obtain [=user consent=] by performing a [=test of user presence=].
+
+    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
+    operation.
+
+1. Once [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|,|privateKey|) be a new set of cryptographic keys using the combination of {{PublicKeyCredentialType}}
         and cryptographic parameters represented by the first [=list/item=] in |credTypesAndPubKeyAlgs| that is supported by
         this authenticator.
@@ -1953,10 +1959,19 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     operation.
 1. If |requireUserVerification| is true and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
+
 1. Prompt the user to select a [=public key credential|credential=] |selectedCredential| from |allowCredentialDescriptorList|.
-    Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown
-    by the
-    [=authenticator=] if it has its own output capability, or by the user agent otherwise.
+
+1. Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown by
+    the [=authenticator=] if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display the
+    contents of |rpEntity| and |userEntity|, if possible.
+
+    - If |requireUserVerification| is true, obtain [=user consent=] by performing [=user verification=].
+    - If |requireUserVerification| is false, obtain [=user consent=] by performing a [=test of user presence=].
+
+    If the user denies [=user consent|consent=], return an error code equivalent to "{{NotAllowedError}}" and terminate the
+    operation.
+
 1. Let |processedExtensions| be the result of [=authenticator extension processing=] for each supported [=extension
     identifier=]/input pair in |extensions|.
 1. Increment the [=RP ID=]-associated


### PR DESCRIPTION
This resolves #644, and possibly #524 and #645.

Summary:

- ~~The definition of "user present" now states that if the user is "verified" they are also "present". Background: #629~~ *Reverted after review*
- A UV parameter has been added to `PublicKeyCredentialRequestOptions`.
- A Boolean UV parameter is now passed to `authenticatorGetAssertion()`.
- The type of the UV parameter of the client operations has changed from Boolean to `UserVerificationRequirement`.
  - Background: #644, #629.
  - The enum type `UserVerificationRequirement` has been added, with values `required`, ~~`wanted`~~ `preferred` and ~~`not-wanted`~~ `discouraged`.
  - The type of the member `requireUserVerification` of `AuthenticatorSelectionCriteria` has changed from Boolean to `UserVerificationRequirement`.
  - A member `requireUserVerification` of type `UserVerificationRequirement` has been added to `PublicKeyCredentialRequestOptions`.
  - This value is used by the client operations to compute a Boolean value to pass to the authenticator operations.
- ~~Authenticator operations are now specified to always require UP or UV.~~ This was already stated in prose in [§5.1.4 Use an existing credential to make an assertion][get-assertion], but not in the algorithms:

  >Since this specification requires an authorization gesture to create any credentials, [...]

  Silent authenticator operations has also raised objections (#629, #644), so we should state this requirement clearly until it's decided to support silent operations. This probably breaks compatibility with UAF Silent Authenticators (see https://github.com/w3c/webauthn/issues/199#issuecomment-341576776).

  *EDIT: This logic has moved to the client level instead.*
- ~~`authenticatorMakeCredential` now always uses UV if the authenticator supports it. If `requireUserVerification` is `true` the client will only send the command to capable authenticators.~~ *Reverted after review*
- Authenticator operations' UP/UV behaviour has been aligned to agree with CTAP2.
  - A Boolean UP parameter is now passed to `authenticatorMakeCredential()` and `authenticatorGetAssertion()`. The client always sets this to the inverse of the UV parameter.
- CTAP compatibility should not be affected by any of the above. If it is, that's a bug.

[get-assertion]: https://w3c.github.io/webauthn/#getAssertion


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/issue-644.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/e09e0c3...05f4b23.html)