### PR TITLE
Resolve #292 - Clarify that only one operation is permitted per authenticator session

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1962,7 +1962,7 @@ It takes the following input parameters:
 :: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
     extensions requested by the [=[RP]=], if any.
 
-Note: Before performing this operation, all other operations in progress in the [=authenticator session=] must be aborted by setting their [=AbortSignal/aborted flag=] to true.
+Note: Before performing this operation, all other operations in progress in the [=authenticator session=] must be aborted by running the [=authenticatorCancel=] operation.
 
 When this operation is invoked, the [=authenticator=] must perform the following procedure:
 1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
@@ -2034,7 +2034,7 @@ It takes the following input parameters:
 :: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
     extensions requested by the [=[RP]=], if any.
 
-Note: Before performing this operation, all other operations in progress in the [=authenticator session=] must be aborted by setting their [=AbortSignal/aborted flag=] to true.
+Note: Before performing this operation, all other operations in progress in the [=authenticator session=] must be aborted by running the [=authenticatorCancel=] operation.
 
 When this method is invoked, the [=authenticator=] must perform the following procedure:
 1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code

--- a/index.bs
+++ b/index.bs
@@ -1576,9 +1576,9 @@ See [[dom#abortcontroller-api-integration]] section for detailed instructions.
     and {{PublicKeyCredential/[[DiscoverFromExternalSource]](options)}} methods, the algorithms for the two APIs fulfills this 
     requirement by checking the [=AbortSignal/aborted flag=] in three places. In the case of 
     {{PublicKeyCredential/[[Create]](options)}}, the aborted flag is checked first in 
-    [[credential-management-1#algorithm-create]] right before calling {{Credential/[[Create]](options)}}, 
-    then in [[#createCredential]] right before [=authenticator session=]s start, and finally
-    during [=authenticator session=]s. The same goes for
+    [[credential-management-1#algorithm-create]] immediately before calling {{Credential/[[Create]](options)}},
+    then in [[#createCredential]] right before [=authenticator sessions=] start, and finally
+    during [=authenticator sessions=]. The same goes for
     {{PublicKeyCredential/[[DiscoverFromExternalSource]](options)}}.
 
 The [=visibility states|visibility=] and [=focus=] state of the [=Window=] object determines whether the 

--- a/index.bs
+++ b/index.bs
@@ -1577,8 +1577,8 @@ See [[dom#abortcontroller-api-integration]] section for detailed instructions.
     requirement by checking the [=AbortSignal/aborted flag=] in three places. In the case of 
     {{PublicKeyCredential/[[Create]](options)}}, the aborted flag is checked first in 
     [[credential-management-1#algorithm-create]] right before calling {{Credential/[[Create]](options)}}, 
-    then in [[#createCredential]] right before authenticator sessions start, and finally 
-    during authenticator sessions. The same goes for 
+    then in [[#createCredential]] right before [=authenticator session=]s start, and finally
+    during [=authenticator session=]s. The same goes for
     {{PublicKeyCredential/[[DiscoverFromExternalSource]](options)}}.
 
 The [=visibility states|visibility=] and [=focus=] state of the [=Window=] object determines whether the 
@@ -1929,7 +1929,7 @@ Authenticators:
 ## Authenticator operations ## {#authenticator-ops}
 
 A client must connect to an authenticator in order to invoke any of the operations of that authenticator. This connection
-defines an authenticator session. An authenticator must maintain isolation between sessions. It may do this by only allowing one
+defines an <dfn>authenticator session</dfn>. An authenticator must maintain isolation between sessions. It may do this by only allowing one
 session to exist at any particular time, or by providing more complicated session management.
 
 The following operations can be invoked by the client in an authenticator session.
@@ -1937,8 +1937,7 @@ The following operations can be invoked by the client in an authenticator sessio
 
 <h4 id="op-make-cred" algorithm>The <dfn>authenticatorMakeCredential</dfn> operation</h4>
 
-This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following
-input parameters:
+It takes the following input parameters:
 
 <!-- @@EDITOR-ANCHOR-01B: KEEP THIS LIST SYNC'D WITH THE LIST UP AT @@EDITOR-ANCHOR-01A -->
 : |hash|
@@ -1963,7 +1962,9 @@ input parameters:
 :: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
     extensions requested by the [=[RP]=], if any.
 
-When this operation is invoked, the authenticator must perform the following procedure:
+Note: Before performing this operation, all other operations in progress in the [=authenticator session=] must be aborted by setting their [=AbortSignal/aborted flag=] to true.
+
+When this operation is invoked, the [=authenticator=] must perform the following procedure:
 1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
     equivalent to "{{UnknownError}}" and terminate the operation.
 1. Check if at least one of the specified combinations of {{PublicKeyCredentialType}} and cryptographic parameters in
@@ -2020,8 +2021,7 @@ On successful completion of this operation, the authenticator returns the [=atte
 
 <h4 id="op-get-assertion" algorithm> The <dfn>authenticatorGetAssertion</dfn> operation</h4>
 
-This operation must be invoked in an authenticator session which has no other operations in progress. It takes the following
-input parameters:
+It takes the following input parameters:
 
 : |rpId|
 :: The caller's [=RP ID=], as <a href='#GetAssn-DetermineRpId'>determined</a> by the user agent and the client.
@@ -2033,6 +2033,8 @@ input parameters:
 : |extensions|
 :: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
     extensions requested by the [=[RP]=], if any.
+
+Note: Before performing this operation, all other operations in progress in the [=authenticator session=] must be aborted by setting their [=AbortSignal/aborted flag=] to true.
 
 When this method is invoked, the [=authenticator=] must perform the following procedure:
 1. Check if all the supplied parameters are syntactically well-formed and of the correct length. If not, return an error code
@@ -2093,12 +2095,12 @@ If the user refuses consent, the authenticator returns an appropriate error stat
 
 This operation takes no input parameters and returns no result.
 
-When this operation is invoked by the client in an authenticator session, it has the effect of terminating any
+When this operation is invoked by the client in an [=authenticator session=], it has the effect of terminating any
 [=authenticatorMakeCredential=] or [=authenticatorGetAssertion=] operation currently in progress in that authenticator
 session. The authenticator stops prompting for, or accepting, any user input related to authorizing the canceled operation. The
 client ignores any further responses from the authenticator for the canceled operation.
 
-This operation is ignored if it is invoked in an authenticator session which does not have an [=authenticatorMakeCredential=]
+This operation is ignored if it is invoked in an [=authenticator session=] which does not have an [=authenticatorMakeCredential=]
 or [=authenticatorGetAssertion=] operation currently in progress.
 
 


### PR DESCRIPTION
- Adds a definition tag for "authenticator session" 
- Moves the normative language about aborting other operations to a note for each operation, leaving the exact tracking mechanisms up to the UA
- Ensures that this abort is per "authenticator session", leaving room for multi-session authenticators in the future. (Thanks @gmandyam!)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jcjones/webauthn/292-operations_in_flight.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/5f4f3e6...jcjones:66f094f.html)