### PR TITLE
use the registered ext ids in examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3783,7 +3783,7 @@ The sample code for generating and registering a new key follows:
 
       timeout: 60000,  // 1 minute
       excludeCredentials: [], // No exclude list of PKCredDescriptors
-      extensions: {"webauthn.location": true}  // Include location information
+      extensions: {"loc": true}  // Include location information
                                                // in attestation
     };
 
@@ -3917,7 +3917,7 @@ extension for transaction authorization.
                     challenge: encoder.encode("climb a mountain"),
                     timeout: 60000,  // 1 minute
                     allowCredentials: [acceptableCredential1, acceptableCredential2],
-                    extensions: { 'webauthn.txauth.simple':
+                    extensions: { 'txAuthSimple':
                        "Wave your hands in the air like you just don't care" }
                   };
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/consistent-extension-ids-588.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/0e93926...40875f1.html)