### PR TITLE
Tiny nit: "pair of cryptographic keys" instead of "set of cryptographic keys"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1992,7 +1992,7 @@ When this operation is invoked, the authenticator must perform the following pro
     equivalent to "{{NotAllowedError}}" and terminate the operation. The Authenticator and user agent MAY skip this prompt
     if the Authenticator is a [=platform authenticator=] and |excludeCredentialDescriptorList| is empty.
 1. Once user consent has been obtained, generate a new credential object:
-    1. Let (|publicKey|,|privateKey|) be a new set of cryptographic keys using the combination of {{PublicKeyCredentialType}}
+    1. Let (|publicKey|,|privateKey|) be a new pair of cryptographic keys using the combination of {{PublicKeyCredentialType}}
         and cryptographic parameters represented by the first [=list/item=] in |credTypesAndPubKeyAlgs| that is supported by
         this authenticator.
     1. Let |credentialId| be a new identifier for this credential that is globally unique with high probability across all


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/emlun/webauthn/nit0.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/cd59128...emlun:641eed3.html)