### PR TITLE
Fix issue #685

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1012,20 +1012,23 @@ When this method is invoked, the user agent MUST execute the following algorithm
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. Let |allowCredentialDescriptorList| be a new [=list=].
 
-    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> [=list/is not empty=], execute a
-        platform-specific procedure to determine which, if any, [=public key credentials=] described by
-        <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are bound to this |authenticator|, by
-        matching with |rpId|,
-        <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>, and
-        <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/type}}</code>.
-        Set |allowCredentialDescriptorList| to this filtered list.
-
-    1. If |allowCredentialDescriptorList|
+    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>
         <dl class="switch">
             :   [=list/is not empty=]
-            ::  1. Let |distinctTransports| be a new [=ordered set=].
+            ::  1. Let |allowCredentialDescriptorList| be a new [=list=].
+
+                1. Execute a platform-specific procedure to determine which, if any, [=public key credentials=] described by
+                    <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are bound to this
+                    |authenticator|, by matching with |rpId|,
+                    <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
+                    and
+                    <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/type}}</code>.
+                    Set |allowCredentialDescriptorList| to this filtered list.
+
+                1. If |allowCredentialDescriptorList| [=list/is empty=], [=continue=].
+
+                1. Let |distinctTransports| be a new [=ordered set=].
 
                 1. If |allowCredentialDescriptorList| has exactly one value, let |savedCredentialId| be a new 
                     {{PublicKeyCredentialDescriptor}}.{{PublicKeyCredentialDescriptor/id}} and set its value to <code>|allowCredentialDescriptorList|[0].id</code>'s


### PR DESCRIPTION
See https://github.com/w3c/webauthn/issues/685 . This is the suggested solution (2):

>Move the 1st factor mode invocation branch to before filtering, and skip the authenticator completely if `options.allowCredentials` is nonempty and is known to not intersect with the credentials available on the authenticator.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webauthn/issue-685.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/e09e0c3...7fe7dc7.html)