### PR TITLE
Add privacy consideration about terminating getAssertion early

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -791,8 +791,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
-1. [=While=] |issuedRequests| [=list/is not empty=], perform the following actions depending upon
-    |lifetimeTimer| and responses from the authenticators:
+1. [=While=] |lifetimeTimer| has not expired, perform the following actions depending upon |lifetimeTimer| and responses from the
+    authenticators:
     <dl class="switch">
 
         :   If |lifetimeTimer| expires,
@@ -1069,7 +1069,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
-1. While |issuedRequests| [=list/is not empty=], perform the following actions depending upon |lifetimeTimer|
+1. [=While=] |lifetimeTimer| has not expired, perform the following actions depending upon |lifetimeTimer|
     and responses from the authenticators:
 
     <dl class="switch">

--- a/index.bs
+++ b/index.bs
@@ -1089,6 +1089,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. [=set/For each=] remaining |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation
                 on |authenticator| and [=set/remove=] it from |issuedRequests|.
 
+            Note: This does not mean that the algorithm should be terminated, as that could leak identifying information about the
+            user. See [[#getAssertion-privacy-considerations]].
+
         :   If any |authenticator| returns an error status,
         ::  [=set/Remove=] |authenticator| from |issuedRequests|.
 
@@ -1166,6 +1169,20 @@ When this method is invoked, the user agent MUST execute the following algorithm
 During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and
 authorizing an authenticator with which to complete the operation.
 </div>
+
+
+#### Privacy considerations #### {#getAssertion-privacy-considerations}
+
+In order to protect the user from being identified without [=user consent|consent=], the client MUST make it impossible for the
+[=[RP]=] to distinguish between the cases:
+
+- A named [=public key credential|credential=] is not available.
+- A named [=public key credential|credential=] is available, but the user denies [=user consent|consent=] to use it.
+
+If the above cases are distinguishable, that leaks information by which a malicious [=[RP]=] could identify the user by probing
+for which [=public key credential|credentials=] are available. In particular, the client MUST NOT return a "{{NotAllowedError}}"
+before the |lifetimeTimer| has expired, as that would constitute such an information leak.
+
 
 ### Store an existing credential - PublicKeyCredential's `[[Store]](credential)` method ### {#storeCredential}
 

--- a/index.bs
+++ b/index.bs
@@ -4348,7 +4348,7 @@ RogueList when performing ECDAA-Verify (see section 3.6 in [[!FIDOEcdaaAlgorithm
 
 
 
-# Privacy Considertations # {#sctn-privacy-considerations}
+# Privacy Considerations # {#sctn-privacy-considerations}
 
 ## Attestation Privacy ## {#sec-attestation-privacy}
 

--- a/index.bs
+++ b/index.bs
@@ -955,7 +955,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     </dl>
 
-1. Return a {{DOMException}} whose name is "{{NotAllowedError}}".
+1. Return a {{DOMException}} whose name is "{{NotAllowedError}}". In order to prevent information leak that could identify the
+    user without [=user consent|consent=], this step MUST NOT be executed before |lifetimeTimer| has expired. See
+    [[#sec-assertion-privacy]] for details.
 
 During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and
 authorizing an authenticator.
@@ -1222,9 +1224,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. [=set/For each=] remaining |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation
                 on |authenticator| and [=set/remove=] it from |issuedRequests|.
 
-            Note: This does not mean that the algorithm should be terminated, as that could leak identifying information about the
-            user. See [[#sec-assertion-privacy]].
-
         :   If any |authenticator| returns an error status,
         ::  [=set/Remove=] |authenticator| from |issuedRequests|.
 
@@ -1297,7 +1296,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1.  Return |constructAssertionAlg| and terminate this algorithm.
     </dl>
 
-1. Return a {{DOMException}} whose name is "{{NotAllowedError}}".
+1. Return a {{DOMException}} whose name is "{{NotAllowedError}}". In order to prevent information leak that could identify the
+    user without [=user consent|consent=], this step MUST NOT be executed before |lifetimeTimer| has expired. See
+    [[#sec-assertion-privacy]] for details.
 
 During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and
 authorizing an authenticator with which to complete the operation.
@@ -2595,15 +2596,19 @@ in several ways, including:
 
 #### Privacy and Authentication Ceremonies #### {#sec-assertion-privacy}
 
-In order to protect the user from being identified without [=user consent|consent=], the client MUST make it impossible for the
-[=[RP]=] to distinguish between the cases:
+In order to protect the user from being identified without [=user consent|consent=], implementations of the
+{{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method need to take care to
+not leak information that could enable the [=[RP]=] to distinguish between the cases:
 
 - A named [=public key credential|credential=] is not available.
 - A named [=public key credential|credential=] is available, but the user denies [=user consent|consent=] to use it.
 
-If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing
-for which [=public key credential|credentials=] are available. In particular, the client MUST NOT return a "{{NotAllowedError}}"
-before the |lifetimeTimer| has expired, as that difference in timing would constitute such an information leak.
+If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing for
+which [=public key credential|credentials=] are available. For example, one such information leak is if the client returns a
+failure response as soon as the user denies [=user consent|consent=] to proceed with the operation. In this case the [=[RP]=]
+could detect that the operation was canceled by the user and not the timeout, and thus conclude that at least one of the [=public
+key credential|credentials=] listed in the {{PublicKeyCredentialRequestOptions/allowCredentials}} parameter is available to the
+user.
 
 
 #### Attestation Certificate and Attestation Certificate CA Compromise #### {#ca-compromise}

--- a/index.bs
+++ b/index.bs
@@ -1179,7 +1179,7 @@ In order to protect the user from being identified without [=user consent|consen
 - A named [=public key credential|credential=] is not available.
 - A named [=public key credential|credential=] is available, but the user denies [=user consent|consent=] to use it.
 
-If the above cases are distinguishable, that leaks information by which a malicious [=[RP]=] could identify the user by probing
+If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing
 for which [=public key credential|credentials=] are available. In particular, the client MUST NOT return a "{{NotAllowedError}}"
 before the |lifetimeTimer| has expired, as that difference in timing would constitute such an information leak.
 

--- a/index.bs
+++ b/index.bs
@@ -2598,14 +2598,14 @@ in several ways, including:
 
 In order to protect the user from being identified without [=user consent|consent=], implementations of the
 {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method need to take care to
-not leak information that could enable the [=[RP]=] to distinguish between the cases:
+not leak information that could enable the [=[RP]=] to distinguish between these cases:
 
 - A named [=public key credential|credential=] is not available.
-- A named [=public key credential|credential=] is available, but the user denies [=user consent|consent=] to use it.
+- A named [=public key credential|credential=] is available, but the user does not [=user consent|consent=] to use it.
 
 If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing for
 which [=public key credential|credentials=] are available. For example, one such information leak is if the client returns a
-failure response as soon as the user denies [=user consent|consent=] to proceed with the operation. In this case the [=[RP]=]
+failure response as soon as the user does not [=user consent|consent=] to proceed with the operation. In this case the [=[RP]=]
 could detect that the operation was canceled by the user and not the timeout, and thus conclude that at least one of the [=public
 key credential|credentials=] listed in the {{PublicKeyCredentialRequestOptions/allowCredentials}} parameter is available to the
 user.

--- a/index.bs
+++ b/index.bs
@@ -1603,8 +1603,8 @@ associated.
     :   <dfn>icon</dfn>
     ::  A [=URL serializer|serialized=] URL which resolves to an image associated with the entity. For example, this could be
         a user's avatar or a [=[RP]=]'s logo. This URL MUST be an [=a priori authenticated URL=]. [=Authenticators=] MUST
-        accept and store a 128 byte minimum length for a icon members's value.
-        Authenticators MAY ignore a icon members's value if its length is greater than 128 byes.
+        accept and store a 128 byte minimum length for an icon members's value.
+        Authenticators MAY ignore an icon members's value if its length is greater than 128 bytes.
 </div>
 
 
@@ -3277,7 +3277,7 @@ platform. The client platform performs [=client extension processing=] for each 
 [=client data=] as specified by each extension, by including the [=extension identifier=] and [=client extension output=]
 values.
 
-An extension can also be an <dfn>authenticator extension</dfn>, meaning that the extension invoves communication with and
+An extension can also be an <dfn>authenticator extension</dfn>, meaning that the extension involves communication with and
 processing by the authenticator. [=Authenticator extensions=] define the following steps and data:
 
 - [=authenticatorMakeCredential=] extension request parameters and response values for [=registration extensions=].

--- a/index.bs
+++ b/index.bs
@@ -1223,7 +1223,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 on |authenticator| and [=set/remove=] it from |issuedRequests|.
 
             Note: This does not mean that the algorithm should be terminated, as that could leak identifying information about the
-            user. See [[#getAssertion-privacy-considerations]].
+            user. See [[#sec-assertion-privacy]].
 
         :   If any |authenticator| returns an error status,
         ::  [=set/Remove=] |authenticator| from |issuedRequests|.
@@ -1302,19 +1302,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
 During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and
 authorizing an authenticator with which to complete the operation.
 </div>
-
-
-#### Privacy considerations #### {#getAssertion-privacy-considerations}
-
-In order to protect the user from being identified without [=user consent|consent=], the client MUST make it impossible for the
-[=[RP]=] to distinguish between the cases:
-
-- A named [=public key credential|credential=] is not available.
-- A named [=public key credential|credential=] is available, but the user denies [=user consent|consent=] to use it.
-
-If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing
-for which [=public key credential|credentials=] are available. In particular, the client MUST NOT return a "{{NotAllowedError}}"
-before the |lifetimeTimer| has expired, as that difference in timing would constitute such an information leak.
 
 
 ### Store an existing credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` method ### {#storeCredential}
@@ -2587,7 +2574,7 @@ the [=authenticator=] MUST:
 ### Security Considerations ### {#sec-attestation-security-considerations}
 
 
-#### Privacy #### {#sec-attestation-privacy}
+#### Privacy and Attestation Certificates #### {#sec-attestation-privacy}
 
 Attestation keys may be used to track users or link various online identities of the same user together. This may be mitigated
 in several ways, including:
@@ -2604,6 +2591,19 @@ in several ways, including:
 - A WebAuthn Authenticator can implement [=Elliptic Curve based direct anonymous attestation=] (see [[FIDOEcdaaAlgorithm]]).
     Using this scheme, the authenticator generates a blinded attestation signature. This allows the [=[RP]=] to verify the
     signature using the [=ECDAA-Issuer public key=], but the attestation signature does not serve as a global correlation handle.
+
+
+#### Privacy and Authentication Ceremonies #### {#sec-assertion-privacy}
+
+In order to protect the user from being identified without [=user consent|consent=], the client MUST make it impossible for the
+[=[RP]=] to distinguish between the cases:
+
+- A named [=public key credential|credential=] is not available.
+- A named [=public key credential|credential=] is available, but the user denies [=user consent|consent=] to use it.
+
+If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing
+for which [=public key credential|credentials=] are available. In particular, the client MUST NOT return a "{{NotAllowedError}}"
+before the |lifetimeTimer| has expired, as that difference in timing would constitute such an information leak.
 
 
 #### Attestation Certificate and Attestation Certificate CA Compromise #### {#ca-compromise}

--- a/index.bs
+++ b/index.bs
@@ -4380,7 +4380,7 @@ not leak information that could enable the [=[RP]=] to distinguish between these
 
 If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing for
 which [=public key credential|credentials=] are available. For example, one such information leak is if the client returns a
-failure response as soon as the user does not [=user consent|consent=] to proceed with the operation. In this case the [=[RP]=]
+failure response as soon as the user denies [=user consent|consent=] to proceed with the operation. In this case the [=[RP]=]
 could detect that the operation was canceled by the user and not the timeout, and thus conclude that at least one of the [=public
 key credential|credentials=] listed in the {{PublicKeyCredentialRequestOptions/allowCredentials}} parameter is available to the
 user.

--- a/index.bs
+++ b/index.bs
@@ -1181,7 +1181,7 @@ In order to protect the user from being identified without [=user consent|consen
 
 If the above cases are distinguishable, that leaks information by which a malicious [=[RP]=] could identify the user by probing
 for which [=public key credential|credentials=] are available. In particular, the client MUST NOT return a "{{NotAllowedError}}"
-before the |lifetimeTimer| has expired, as that would constitute such an information leak.
+before the |lifetimeTimer| has expired, as that difference in timing would constitute such an information leak.
 
 
 ### Store an existing credential - PublicKeyCredential's `[[Store]](credential)` method ### {#storeCredential}


### PR DESCRIPTION
Related issues: #184, #204 . Loosely related: #140 .

This adds a privacy consideration note to [§5.1.4. Use an existing credential to make an assertion][get] about the privacy implications of terminating before the timer expires.

The PR also includes some language changes to the waiting condition in both [§5.1.3. Create a new credential][create] and [§5.1.4. Use an existing credential to make an assertion][get] which are needed to make the privacy consideration text meaningful, and which were probably already intended.

[create]: https://w3c.github.io/webauthn/#createCredential
[get]: https://w3c.github.io/webauthn/#getAssertion


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/687.html" title="Last updated on Jan 12, 2018, 6:06 PM GMT (f716b7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/687/ade8321...f716b7f.html" title="Last updated on Jan 12, 2018, 6:06 PM GMT (f716b7f)">Diff</a>