### PR TITLE
Add RSASSA-PKCS1-v1_5 w/ SHA1 for TPM attestations and correct TPM signing/verification text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2744,7 +2744,8 @@ engine.
     Concatenate |authenticatorData| and |clientDataHash| to form |attToBeSigned|.
 
     Generate a signature using the procedure specified in [[TPMv2-Part3]] Section 18.2, using the attestation private key and
-    setting the `qualifyingData` parameter to |attToBeSigned|.
+    setting the `extraData` parameter to the digest of |attToBeSigned| using the hash algorithm corresponding to the "alg" signature algorithm.
+    (For the "RS256" algorithm, this would be a SHA-256 digest.)
 
     Set the |pubArea| field to the public area of the credential public key, the |certInfo| field to the output parameter of the
     same name, and the |sig| field to the signature obtained from the above procedure.
@@ -2764,7 +2765,7 @@ engine.
     Validate that |certInfo| is valid:
     - Verify that `magic` is set to `TPM_GENERATED_VALUE`.
     - Verify that `type` is set to `TPM_ST_ATTEST_CERTIFY`.
-    - Verify that `extraData` is set to |attToBeSigned|.
+    - Verify that `extraData` is set to the hash of |attToBeSigned| using the hash algorithm employed in "alg".
     - Verify that `attested` contains a `TPMS_CERTIFY_INFO` structure, whose `name` field contains a valid Name for |pubArea|,
         as computed using the algorithm in the `nameAlg` field of |pubArea| using the procedure specified in [[TPMv2-Part1]]
         section 16.
@@ -3687,8 +3688,9 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
 
 ## COSE Algorithm Registrations ## {#sctn-cose-alg-reg}
 
-This section registers identifiers for RSASSA-PKCS1-v1_5 [[RFC8017]] algorithms using SHA-2 hash functions in the
+This section registers identifiers for RSASSA-PKCS1-v1_5 [[RFC8017]] algorithms using SHA-2 and SHA-1 hash functions in the
 IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]].
+It also registers identifiers for ECDAA algorithms.
 
 - Name: RS256
 - Value: -257
@@ -3719,6 +3721,12 @@ IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]].
 - Description: ECC_BN_ISOP512 curve w/ SHA-512
 - Reference: Section 4.2 of [[!FIDOEcdaaAlgorithm]]
 - Recommended: Yes
+    <br/><br/>
+- Name: RS1
+- Value: -262
+- Description: RSASSA-PKCS1-v1_5 w/ SHA-1
+- Reference: Section 8.2 of [[RFC8017]]
+- Recommended: No
 
 # Sample scenarios # {#sample-scenarios}
 


### PR DESCRIPTION
Fixes #689


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/selfissued/webauthn/mbj-RS1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webauthn/b865645...selfissued:f5d533f.html)