### PR TITLE
Resolve #698 - Rename requireUserVerification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -782,7 +782,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
               verification=], [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
-        as follows. If {{AuthenticatorSelectionCriteria/userVerificationRequirement}}
+        as follows. If
+        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerificationRequirement}}</code></code>
 
             <dl class="switch">
 

--- a/index.bs
+++ b/index.bs
@@ -776,12 +776,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
           1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is set to
             `true` and the |authenticator| is not capable of storing a [=Client-Side-Resident Credential Private Key=],
             [=iteration/continue=].
-          1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
-            set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
-            verification=], [=iteration/continue=].
+          1. If
+              <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerificationRequirement}}</code>
+              is set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
+              verification=], [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
-        as follows. If {{AuthenticatorSelectionCriteria/userVerification}}
+        as follows. If {{AuthenticatorSelectionCriteria/userVerificationRequirement}}
 
             <dl class="switch">
 
@@ -1070,12 +1071,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. If |options|.{{PublicKeyCredentialRequestOptions/userVerification}} is set to
+    1. If |options|.{{PublicKeyCredentialRequestOptions/userVerificationRequirement}} is set to
         {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user verification=],
         [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
-        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
+        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerificationRequirement}}</code>
 
             <dl class="switch">
 
@@ -1566,7 +1567,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        UserVerificationRequirement  userVerification = "preferred";
+        UserVerificationRequirement  userVerificationRequirement = "preferred";
     };
 </xmp>
 
@@ -1580,7 +1581,7 @@ attributes.
         Private Key=]. If the parameter is set to true, the authenticator MUST create a
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
-    :   <dfn>userVerification</dfn>
+    :   <dfn>userVerificationRequirement</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/create()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.
@@ -1669,7 +1670,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-        UserVerificationRequirement          userVerification = "preferred";
+        UserVerificationRequirement          userVerificationRequirement = "preferred";
         AuthenticationExtensions             extensions;
     };
 </xmp>
@@ -1693,7 +1694,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         acceptable to the caller, in decending order of the caller's preference (the first item in the list is the most
         preferred credential, and so on down the list).
 
-    :   <dfn>userVerification</dfn>
+    :   <dfn>userVerificationRequirement</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/get()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.

--- a/index.bs
+++ b/index.bs
@@ -776,12 +776,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
           1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is set to
             `true` and the |authenticator| is not capable of storing a [=Client-Side-Resident Credential Private Key=],
             [=iteration/continue=].
-          1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireUserVerification}}</code> is
+          1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
             set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
             verification=], [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
-        as follows. If {{AuthenticatorSelectionCriteria/requireUserVerification}}
+        as follows. If {{AuthenticatorSelectionCriteria/userVerification}}
 
             <dl class="switch">
 
@@ -1566,7 +1566,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        UserVerificationRequirement  requireUserVerification = "preferred";
+        UserVerificationRequirement  userVerification = "preferred";
     };
 </xmp>
 
@@ -1580,7 +1580,7 @@ attributes.
         Private Key=]. If the parameter is set to true, the authenticator MUST create a
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
-    :   <dfn>requireUserVerification</dfn>
+    :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/create()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.

--- a/index.bs
+++ b/index.bs
@@ -783,7 +783,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
         as follows. If
-        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerificationRequirement}}</code></code>
+        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerificationRequirement}}</code>
 
             <dl class="switch">
 

--- a/index.bs
+++ b/index.bs
@@ -776,14 +776,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
           1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is set to
             `true` and the |authenticator| is not capable of storing a [=Client-Side-Resident Credential Private Key=],
             [=iteration/continue=].
-          1. If
-              <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerificationRequirement}}</code>
-              is set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
-              verification=], [=iteration/continue=].
+          1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
+            set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
+            verification=], [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
         as follows. If
-        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerificationRequirement}}</code>
+        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
 
             <dl class="switch">
 
@@ -1072,12 +1071,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerificationRequirement}}</code> is set to
+    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code> is set to
         {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user verification=],
         [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
-        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerificationRequirement}}</code>
+        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
 
             <dl class="switch">
 
@@ -1568,7 +1567,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        UserVerificationRequirement  userVerificationRequirement = "preferred";
+        UserVerificationRequirement  userVerification = "preferred";
     };
 </xmp>
 
@@ -1582,7 +1581,7 @@ attributes.
         Private Key=]. If the parameter is set to true, the authenticator MUST create a
         [=Client-side-resident Credential Private Key=] when creating a [=public key credential=].
 
-    :   <dfn>userVerificationRequirement</dfn>
+    :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/create()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.
@@ -1671,7 +1670,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-        UserVerificationRequirement          userVerificationRequirement = "preferred";
+        UserVerificationRequirement          userVerification = "preferred";
         AuthenticationExtensions             extensions;
     };
 </xmp>
@@ -1695,7 +1694,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member must be
         acceptable to the caller, in decending order of the caller's preference (the first item in the list is the most
         preferred credential, and so on down the list).
 
-    :   <dfn>userVerificationRequirement</dfn>
+    :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/get()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.

--- a/index.bs
+++ b/index.bs
@@ -1072,7 +1072,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. If |options|.{{PublicKeyCredentialRequestOptions/userVerificationRequirement}} is set to
+    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerificationRequirement}}</code> is set to
         {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user verification=],
         [=iteration/continue=].
 


### PR DESCRIPTION
@ttaubert [writes](https://github.com/w3c/webauthn/issues/698#issue-276415097):

> I'd like to propose that `AuthenticatorSelectionCriteria.requireUserVerification` should be renamed to just `userVerification`. The possible values are "preferred", "required", and "discouraged". Having "require" in the name itself seems misleading. That would also match the [change](https://github.com/w3c/webauthn/commit/b245b72221568403cb197270bfd4715ed5098869) to `PublicKeyCredentialRequestOptions`.

This PR accomplishes this.
fix #698


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://s3.amazonaws.com/pr-preview/w3c/webauthn/pull/699.html" title="Last updated on Nov 26, 2017, 7:31 PM GMT">Preview</a> | <a href="https://s3.amazonaws.com/pr-preview/w3c/webauthn/81fdc9a...a9639cd.html" title="Last updated on Nov 26, 2017, 7:31 PM GMT">Diff</a>