### PR TITLE
#420: Add note on why authenticator attachment is used only in create()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1654,18 +1654,27 @@ them as <dfn>roaming authenticators</dfn>.
 <ul>
     <li><dfn>platform attachment</dfn> - the respective authenticator is attached
         using platform-specific transports.  Usually, authenticators of
-        this class are non-removable from the platform.
+        this class are non-removable from the platform. A [=public key credential=] bound to a [=platform authenticator=] is
+        called a <dfn>platform credential</dfn>.
     <li><dfn lt="cross-platform attached|cross-platform attachment">cross-platform attachment</dfn> - the respective
         authenticator is attached using cross-platform transports. Authenticators of this class are removable from, and can
-        "roam" among, client platforms.
+        "roam" among, client platforms. A [=public key credential=] bound to a [=roaming authenticator=] is called a <dfn>roaming
+        credential</dfn>.
 </ul>
 
-This distinction is important because there are use-cases where only [=platform authenticators=] are acceptable to a
-[=[RP]=], and conversely ones where only [=roaming authenticators=] are employed. As a concrete example of the former, a
-credential on a [=platform authenticator=] may be used by [=[RPS]=] to quickly and conveniently reauthenticate the user with
-a minimum of friction, e.g., the user will not have to dig around in their pocket for their key fob or phone. As a concrete
-example of the latter, when the user is accessing the [=[RP]=] from a given client for the first time, they may be required to
-use a [=roaming authenticator=] which was originally registered with the [=[RP]=] using a different client.
+This distinction is important because there are use-cases where only [=platform authenticators=] are acceptable to a [=[RP]=], and
+conversely ones where only [=roaming authenticators=] are employed. As a concrete example of the former, a [=platform credential=]
+may be used by [=[RPS]=] to quickly and conveniently reauthenticate the user with a minimum of friction, e.g., the user will not
+have to dig around in their pocket for their key fob or phone. As a concrete example of the latter, when the user is accessing the
+[=[RP]=] from a given client for the first time, they may be required to use a [=roaming credential=] which was originally
+registered with the [=[RP]=] using a different client.
+
+Note: An [=attachment modality=] selection option is available only in the {{PublicKeyCredential/[[Create]](origin, options,
+sameOriginWithAncestors)}} operation. The [=[RP]=] MAY use it to, for example, ensure the user has a [=roaming credential=] for
+authenticating using other [=clients=]; or to specifically register a [=platform credential=] for easier reauthentication using a
+particular [=client=]. The {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
+operation has no [=attachment modality=] selection option, so the [=[RP]=] SHOULD accept any of the user's registered [=public key
+credential|credentials=]. The [=client=] and user will then use whichever is available and convenient at the time.
 
 
 ### <dfn>Attestation Conveyance</dfn> Preference enumeration (enum <dfn enum>AttestationConveyancePreference</dfn>) ### {#attestation-convey}


### PR DESCRIPTION
See #420.