### PR TITLE
Specify that SHA-256 is used for hashing the client data.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3237,7 +3237,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
             confirm its size to be of 32 bytes and concatenate it with |publicKeyU2F|.
             If size differs or "-3" key is not found, terminate this algorithm and return an appropriate error. 
     5. Let |verificationData| be the concatenation of (0x00 || |rpIdHash| || 
-        |tbsHash| || |credentialId| || |publicKeyU2F|) (see Section 4.3 of [[!FIDO-U2F-Message-Formats]]).
+        |clientDataHash| || |credentialId| || |publicKeyU2F|) (see Section 4.3 of [[!FIDO-U2F-Message-Formats]]).
     6. Verify the |sig| using |verificationData| and |certificate public key| per [[!SEC1]].
     7. If successful, return attestation type Basic with the [=attestation trust path=] set to |x5c|.
 

--- a/index.bs
+++ b/index.bs
@@ -3204,27 +3204,26 @@ This attestation statement format is used with FIDO U2F authenticators using the
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
     Otherwise, let |authenticatorData| denote the [=authenticator data for the attestation=],
-    and let |tbsHash| denote the [=hash of the serialized client data=]. (Since SHA-256 is used to hash the
-    serialized client data, |tbsHash| will be 32 bytes long.)
+    and let |clientDataHash| denote the [=hash of the serialized client data=]. (Since SHA-256 is used to hash the
+    serialized client data, |clientDataHash| will be 32 bytes long.)
 
     Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with the application parameter set to the
-    SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |tbsHash|, and the key handle
+    SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |clientDataHash|, and the key handle
     parameter set to the [=credential ID=] of the given credential. Set the raw signature part of this Registration Response Message (i.e., without the user public key,
     key handle, and attestation certificates) as |sig| and set the attestation certificates of
     the attestation public key as |x5c|.
 
 : Verification procedure
-:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and
-    [=hash of the serialized client data=], the verification procedure is as follows:
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the verification procedure is
+    as follows:
     1. Verify that |attStmt| is valid CBOR conforming to the syntax defined above, and perform CBOR decoding on it to extract the
         contained fields.
-    2. Let |attCert| be value of the first element of |x5c|. Let |certificate public key| be the public key
+    2. Let |attCert| be the value of the first element of |x5c|. Let |certificate public key| be the public key
         conveyed by |attCert|. If |certificate public key| is not an Elliptic Curve (EC) public 
         key over the P-256 curve, terminate this algorithm and return an appropriate error. 
     3. Extract the claimed |rpIdHash| from |authenticatorData|, and the claimed |credentialId| and |credentialPublicKey| from
         |authenticatorData|.<code>[=attestedCredentialData=]</code>.
-    4. Set |tbsHash| to the [=hash of the serialized client data=].
-    5. Convert the COSE_KEY formatted |credentialPublicKey| (see Section 7 of [[!RFC8152]]) to CTAP1/U2F public Key 
+    4. Convert the COSE_KEY formatted |credentialPublicKey| (see Section 7 of [[!RFC8152]]) to CTAP1/U2F public Key 
         format [[!FIDO-CTAP]]. 
         - Let |publicKeyU2F| represent the result of the 
             conversion operation and set its first byte to 0x04.
@@ -3237,10 +3236,10 @@ This attestation statement format is used with FIDO U2F authenticators using the
             (representing y coordinate) from |credentialPublicKey|, 
             confirm its size to be of 32 bytes and concatenate it with |publicKeyU2F|.
             If size differs or "-3" key is not found, terminate this algorithm and return an appropriate error. 
-    6. Let |verificationData| be the concatenation of (0x00 || |rpIdHash| || 
+    5. Let |verificationData| be the concatenation of (0x00 || |rpIdHash| || 
         |tbsHash| || |credentialId| || |publicKeyU2F|) (see Section 4.3 of [[!FIDO-U2F-Message-Formats]]).
-    7. Verify the |sig| using |verificationData| and |certificate public key| per [[!SEC1]].
-    8. If successful, return attestation type Basic with the [=attestation trust path=] set to |x5c|.
+    6. Verify the |sig| using |verificationData| and |certificate public key| per [[!SEC1]].
+    7. If successful, return attestation type Basic with the [=attestation trust path=] set to |x5c|.
 
 
 # WebAuthn Extensions # {#extensions}

--- a/index.bs
+++ b/index.bs
@@ -77,10 +77,6 @@ spec: TokenBinding; urlPrefix: https://tools.ietf.org/html/draft-ietf-tokbind-pr
         text: Token Binding
         text: Token Binding ID; url: section-3.2
 
-spec: WebCryptoAPI; urlPrefix: https://www.w3.org/TR/WebCryptoAPI/
-    type: dfn
-        text: recognized algorithm name
-
 spec: credential-management-1; urlPrefix: https://w3c.github.io/webappsec-credential-management/
     type: dictionary
         text: CredentialCreationOptions; url: dictdef-credentialcreationoptions
@@ -764,9 +760,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
     :: The [=base64url encoding=] of |options|.{{MakePublicKeyCredentialOptions/challenge}}.
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
-    : {{CollectedClientData/hashAlgorithm}}
-    :: The [=recognized algorithm name=] of the hash algorithm selected by the client for generating the
-        [=hash of the serialized client data=].
     : {{CollectedClientData/tokenBindingId}}
     :: The [=Token Binding ID=] associated with |callerOrigin|, if one is available.
     : {{CollectedClientData/clientExtensions}}
@@ -1080,9 +1073,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
     :: The [=base64url encoding=] of |options|.{{PublicKeyCredentialRequestOptions/challenge}}
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
-    : {{CollectedClientData/hashAlgorithm}}
-    :: The [=recognized algorithm name=] of the hash algorithm selected by the client for generating the
-        [=hash of the serialized client data=]
     : {{CollectedClientData/tokenBindingId}}
     :: The [=Token Binding ID=] associated with |callerOrigin|, if one is available.
     : {{CollectedClientData/clientExtensions}}
@@ -1807,7 +1797,6 @@ following Web IDL.
         required DOMString           type;
         required DOMString           challenge;
         required DOMString           origin;
-        required DOMString           hashAlgorithm;
         DOMString                    tokenBindingId;
         AuthenticationExtensions     clientExtensions;
         AuthenticationExtensions     authenticatorExtensions;
@@ -1825,10 +1814,6 @@ following Web IDL.
     The <dfn>origin</dfn> member contains the fully qualified [=origin=] of the requester, as provided to the authenticator by
     the client, in the syntax defined by [[RFC6454]].
 
-    The <dfn>hashAlgorithm</dfn> member is a [=recognized algorithm name=] that supports the `"digest"` operation, which
-    specifies the algorithm used to compute the [=hash of the serialized client data=]. This algorithm is chosen by the client
-    at its sole discretion.
-
     The <dfn>tokenBindingId</dfn> member contains the base64url encoding of the [=Token Binding ID=] that this client uses for
     the [=Token Binding=] protocol when communicating with the [=[RP]=]. This can be omitted if no [=Token Binding=] has been
     negotiated between the client and the [=[RP]=].
@@ -1844,7 +1829,7 @@ following Web IDL.
         {{CollectedClientData}} dictionary.
 
     : <dfn dfn>Hash of the serialized client data</dfn>
-    :: This is the hash (computed using {{hashAlgorithm}}) of the [=JSON-serialized client data=], as constructed by the client.
+    :: This is the hash (computed using SHA-256) of the [=JSON-serialized client data=], as constructed by the client.
 </div>
 
 
@@ -2653,8 +2638,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
     and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions requested by
     the RP.
 
-6. Compute the hash of {{AuthenticatorResponse/clientDataJSON}} using the algorithm identified by
-    <code>|C|.{{CollectedClientData/hashAlgorithm}}</code>.
+6. Compute the hash of {{AuthenticatorResponse/clientDataJSON}} using SHA-256.
 
 7. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the
     {{AuthenticatorAttestationResponse}} structure to obtain the attestation statement format |fmt|, the [=authenticator data=]
@@ -2741,8 +2725,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 
 8. Verify that the <code>[=rpIdHash=]</code> in |aData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
 
-9. Let |hash| be the result of computing a hash over the |cData| using the algorithm represented by the
-    {{CollectedClientData/hashAlgorithm}} member of |C|.
+9. Let |hash| be the result of computing a hash over the |cData| using SHA-256.
 
 10. Using the credential public key looked up in step 1, verify that |sig| is a valid signature over the binary concatenation of
     |aData| and |hash|.
@@ -3220,11 +3203,9 @@ This attestation statement format is used with FIDO U2F authenticators using the
 
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
-    Otherwise, let |authenticatorData| denote the [=authenticator data for the attestation=], 
-    and let |clientDataHash| denote the [=hash of the serialized client data=].
-
-    If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256 hash of
-    |clientDataHash|.
+    Otherwise, let |authenticatorData| denote the [=authenticator data for the attestation=],
+    and let |tbsHash| denote the [=hash of the serialized client data=]. (Since SHA-256 is used to hash the
+    serialized client data, |tbsHash| will be 32 bytes long.)
 
     Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with the application parameter set to the
     SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |tbsHash|, and the key handle
@@ -3233,8 +3214,8 @@ This attestation statement format is used with FIDO U2F authenticators using the
     the attestation public key as |x5c|.
 
 : Verification procedure
-:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the verification procedure is
-    as follows:
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and
+    [=hash of the serialized client data=], the verification procedure is as follows:
     1. Verify that |attStmt| is valid CBOR conforming to the syntax defined above, and perform CBOR decoding on it to extract the
         contained fields.
     2. Let |attCert| be value of the first element of |x5c|. Let |certificate public key| be the public key
@@ -3242,8 +3223,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
         key over the P-256 curve, terminate this algorithm and return an appropriate error. 
     3. Extract the claimed |rpIdHash| from |authenticatorData|, and the claimed |credentialId| and |credentialPublicKey| from
         |authenticatorData|.<code>[=attestedCredentialData=]</code>.
-    4. If |clientDataHash| is 256 bits long, set |tbsHash| to this value. Otherwise set |tbsHash| to the SHA-256
-        hash of |clientDataHash|.
+    4. Set |tbsHash| to the [=hash of the serialized client data=].
     5. Convert the COSE_KEY formatted |credentialPublicKey| (see Section 7 of [[!RFC8152]]) to CTAP1/U2F public Key 
         format [[!FIDO-CTAP]]. 
         - Let |publicKeyU2F| represent the result of the 


### PR DESCRIPTION
Previously, the client could choose any "recognized algorithm name" for
hashing, but RPs need to know which hash function(s) to support.

Rather than choose a set of hash functions and add implementation burden
for no clear reason, this change specifies that SHA-256 will be used.

Should we need to revisit this, we can spin a new version of the spec:
the RP can signal support for other algorithms via
`PublicKeyCredentialType` and the hashAlgorithm member can be readded to
the JSON to indicate when a new hash function was added.

Fixes #362.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/710.html" title="Last updated on Dec 8, 2017, 4:28 AM GMT (eeac8d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/710/12f2d09...agl:eeac8d1.html" title="Last updated on Dec 8, 2017, 4:28 AM GMT (eeac8d1)">Diff</a>