### PR TITLE
Fix #713: Define JSON deserialization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2625,19 +2625,19 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 1. Let |C|, the [=client data=] claimed as collected during the credential creation, be the result of [=parse JSON from
     bytes|parsing JSON from the bytes=] in <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code>.
 
-1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.create`.
+1. Verify that the value of <code>|C|.{{CollectedClientData/type}}</code> is `webauthn.create`.
 
-1. Verify that the {{CollectedClientData/challenge}} in |C| matches the challenge that was sent to the authenticator in the
-    {{CredentialsContainer/create()}} call.
+1. Verify that the value of <code>|C|.{{CollectedClientData/challenge}}</code> matches the challenge that was sent to the
+    authenticator in the {{CredentialsContainer/create()}} call.
 
-1. Verify that the {{CollectedClientData/origin}} in |C| matches the [=[RP]=]'s [=origin=].
+1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
 
-1. Verify that the {{CollectedClientData/tokenBindingId}} in |C| matches the [=Token Binding ID=] for the TLS connection over
-    which the attestation was obtained.
+1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBindingId}}</code> matches the [=Token Binding ID=] for the TLS
+    connection over which the attestation was obtained.
 
-1. Verify that the {{CollectedClientData/clientExtensions}} in |C| is a subset of the extensions requested by the RP
-    and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions requested by
-    the RP.
+1. Verify that the value of <code>|C|.{{CollectedClientData/clientExtensions}}</code> is a subset of the extensions requested by
+    the RP and that the value of <code>|C|.{{CollectedClientData/authenticatorExtensions}}</code> is also a subset of the
+    extensions requested by the RP.
 
 1. Compute the hash of <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> using SHA-256.
 
@@ -2711,19 +2711,19 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 1. Let |C|, the [=client data=] used for the signature, be the result of [=parse JSON from
     bytes|parsing JSON from the bytes=] in |cData|.
 
-1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.get`.
+1. Verify that the value of <code>|C|.{{CollectedClientData/type}}</code> is the string `webauthn.get`.
 
-1. Verify that the {{CollectedClientData/challenge}} member of |C| matches the challenge that was sent to the authenticator in
-    the {{PublicKeyCredentialRequestOptions}} passed to the {{CredentialsContainer/get()}} call.
+1. Verify that the value of <code>|C|.{{CollectedClientData/challenge}}</code> matches the challenge that was sent to the
+    authenticator in the {{PublicKeyCredentialRequestOptions}} passed to the {{CredentialsContainer/get()}} call.
 
-1. Verify that the {{CollectedClientData/origin}} member of |C| matches the [=[RP]=]'s [=origin=].
+1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
 
-1. Verify that the {{CollectedClientData/tokenBindingId}} member of |C| (if present) matches the [=Token Binding ID=] for the
-    TLS connection over which the signature was obtained.
+1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBindingId}}</code> (if present) matches the [=Token Binding ID=]
+    for the TLS connection over which the signature was obtained.
 
-1. Verify that the {{CollectedClientData/clientExtensions}} member of |C| is a subset of the extensions requested by the
-    [=[RP]=] and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions
-    requested by the [=[RP]=].
+1. Verify that the value of <code>|C|.{{CollectedClientData/clientExtensions}}</code> is a subset of the extensions requested by
+    the [=[RP]=] and that the value of <code>|C|.{{CollectedClientData/authenticatorExtensions}}</code> is also a subset of the
+    extensions requested by the [=[RP]=].
 
 1. Verify that the <code>[=rpIdHash=]</code> in |aData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
 

--- a/index.bs
+++ b/index.bs
@@ -2639,61 +2639,61 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
     {{AuthenticatorAttestationResponse}} object to extract the [=client data=] |C| claimed as collected during the credential
     creation.
 
-2. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.create`.
+1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.create`.
 
-2. Verify that the {{CollectedClientData/challenge}} in |C| matches the challenge that was sent to the authenticator in the
+1. Verify that the {{CollectedClientData/challenge}} in |C| matches the challenge that was sent to the authenticator in the
     {{CredentialsContainer/create()}} call.
 
-3. Verify that the {{CollectedClientData/origin}} in |C| matches the [=[RP]=]'s [=origin=].
+1. Verify that the {{CollectedClientData/origin}} in |C| matches the [=[RP]=]'s [=origin=].
 
-4. Verify that the {{CollectedClientData/tokenBindingId}} in |C| matches the [=Token Binding ID=] for the TLS connection over
+1. Verify that the {{CollectedClientData/tokenBindingId}} in |C| matches the [=Token Binding ID=] for the TLS connection over
     which the attestation was obtained.
 
-5. Verify that the {{CollectedClientData/clientExtensions}} in |C| is a subset of the extensions requested by the RP
+1. Verify that the {{CollectedClientData/clientExtensions}} in |C| is a subset of the extensions requested by the RP
     and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions requested by
     the RP.
 
-6. Compute the hash of {{AuthenticatorResponse/clientDataJSON}} using the algorithm identified by
+1. Compute the hash of {{AuthenticatorResponse/clientDataJSON}} using the algorithm identified by
     <code>|C|.{{CollectedClientData/hashAlgorithm}}</code>.
 
-7. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the
+1. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the
     {{AuthenticatorAttestationResponse}} structure to obtain the attestation statement format |fmt|, the [=authenticator data=]
     |authData|, and the attestation statement |attStmt|.
 
-8. Verify that the [=RP ID=] hash in |authData| is indeed the SHA-256 hash of the [=RP ID=] expected by the RP.
+1. Verify that the [=RP ID=] hash in |authData| is indeed the SHA-256 hash of the [=RP ID=] expected by the RP.
 
-9. Determine the attestation statement format by performing an USASCII case-sensitive match on |fmt| against the set of
+1. Determine the attestation statement format by performing an USASCII case-sensitive match on |fmt| against the set of
     supported WebAuthn Attestation Statement Format Identifier values.
     The up-to-date list of registered WebAuthn Attestation Statement Format Identifier values
     is maintained in the in the IANA registry of the same name [[!WebAuthn-Registries]].
 
-10. Verify that |attStmt| is a correct [=attestation statement=], conveying a valid [=attestation signature=], by using the
+1. Verify that |attStmt| is a correct [=attestation statement=], conveying a valid [=attestation signature=], by using the
     [=attestation statement format=] |fmt|'s verification procedure given |attStmt|, |authData| and the [=hash of the serialized
     client data=] computed in step 6.
 
     Note: Each [=attestation statement format=] specifies its own verification procedure. See [[#defined-attestation-formats]] for
     the initially-defined formats, and [[!WebAuthn-Registries]] for the up-to-date list.
 
-11. If validation is successful, obtain a list of acceptable trust anchors (attestation root certificates or [=ECDAA-Issuer
+1. If validation is successful, obtain a list of acceptable trust anchors (attestation root certificates or [=ECDAA-Issuer
     public key=]s) for that attestation type and attestation statement format |fmt|, from a trusted source or from policy. For
     example, the FIDO Metadata Service [[FIDOMetadataService]] provides one way to obtain such information, using the
     <code>[=aaguid=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|.
 
-12. Assess the attestation trustworthiness using the outputs of the verification procedure in step 10, as follows:
+1. Assess the attestation trustworthiness using the outputs of the verification procedure in step 10, as follows:
         - If [=self attestation=] was used, check if [=self attestation=] is acceptable under [=[RP]=] policy.
         - If [=ECDAA=] was used, verify that the [=identifier of the ECDAA-Issuer public key=] used is included in the set of
             acceptable trust anchors obtained in step 11.
         - Otherwise, use the X.509 certificates returned by the verification procedure to verify that the attestation public key
             correctly chains up to an acceptable root certificate.
 
-13. If the attestation statement |attStmt| verified successfully and is found to be trustworthy, then register the new
+1. If the attestation statement |attStmt| verified successfully and is found to be trustworthy, then register the new
     credential with the account that was denoted in the
     {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/options}}.{{MakePublicKeyCredentialOptions/user}} passed to
     {{CredentialsContainer/create()}}, by associating it with the <code>[=credentialId=]</code> and
     <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|, as appropriate for the
     [=[RP]=]'s system.
 
-14. If the attestation statement |attStmt| successfully verified but is not trustworthy per step 12 above, the [=[RP]=] SHOULD fail
+1. If the attestation statement |attStmt| successfully verified but is not trustworthy per step 12 above, the [=[RP]=] SHOULD fail
     the registration ceremony.
 
     NOTE: However, if permitted by policy, the [=[RP]=] MAY register the [=credential ID=] and credential public key but treat the
@@ -2719,35 +2719,35 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 1. Using |credential|'s {{Credential/id}} attribute (or the corresponding {{PublicKeyCredential/rawId}}, if
     [=base64url encoding=] is inappropriate for your use case), look up the corresponding credential public key.
 
-2. Let |cData|, |aData| and |sig| denote the value of |credential|'s {{PublicKeyCredential/response}}'s
+1. Let |cData|, |aData| and |sig| denote the value of |credential|'s {{PublicKeyCredential/response}}'s
     {{AuthenticatorResponse/clientDataJSON}}, {{AuthenticatorAssertionResponse/authenticatorData}}, and
     {{AuthenticatorAssertionResponse/signature}} respectively.
 
-3. Perform JSON deserialization on |cData| to extract the [=client data=] |C| used for the signature.
+1. Perform JSON deserialization on |cData| to extract the [=client data=] |C| used for the signature.
 
-3. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.get`.
+1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.get`.
 
-4. Verify that the {{CollectedClientData/challenge}} member of |C| matches the challenge that was sent to the authenticator in
+1. Verify that the {{CollectedClientData/challenge}} member of |C| matches the challenge that was sent to the authenticator in
     the {{PublicKeyCredentialRequestOptions}} passed to the {{CredentialsContainer/get()}} call.
 
-5. Verify that the {{CollectedClientData/origin}} member of |C| matches the [=[RP]=]'s [=origin=].
+1. Verify that the {{CollectedClientData/origin}} member of |C| matches the [=[RP]=]'s [=origin=].
 
-6. Verify that the {{CollectedClientData/tokenBindingId}} member of |C| (if present) matches the [=Token Binding ID=] for the
+1. Verify that the {{CollectedClientData/tokenBindingId}} member of |C| (if present) matches the [=Token Binding ID=] for the
     TLS connection over which the signature was obtained.
 
-7. Verify that the {{CollectedClientData/clientExtensions}} member of |C| is a subset of the extensions requested by the
+1. Verify that the {{CollectedClientData/clientExtensions}} member of |C| is a subset of the extensions requested by the
     [=[RP]=] and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions
     requested by the [=[RP]=].
 
-8. Verify that the <code>[=rpIdHash=]</code> in |aData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
+1. Verify that the <code>[=rpIdHash=]</code> in |aData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
 
-9. Let |hash| be the result of computing a hash over the |cData| using the algorithm represented by the
+1. Let |hash| be the result of computing a hash over the |cData| using the algorithm represented by the
     {{CollectedClientData/hashAlgorithm}} member of |C|.
 
-10. Using the credential public key looked up in step 1, verify that |sig| is a valid signature over the binary concatenation of
+1. Using the credential public key looked up in step 1, verify that |sig| is a valid signature over the binary concatenation of
     |aData| and |hash|.
 
-11. If the [=signature counter=] value |adata|.<code>[=signCount=]</code> is nonzero or the value stored
+1. If the [=signature counter=] value |adata|.<code>[=signCount=]</code> is nonzero or the value stored
     in conjunction with |credential|'s {{Credential/id}} attribute
     is nonzero, then run the following substep: 
       - If the [=signature counter=] value |adata|.<code>[=signCount=]</code> is
@@ -2769,7 +2769,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
                   [=[RP]=]-specific. </dd>
            </dl>
 
-12. If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the
+1. If all the above steps are successful, continue with the authentication ceremony as appropriate. Otherwise, fail the
     [=authentication|authentication ceremony=].
 
 

--- a/index.bs
+++ b/index.bs
@@ -2632,12 +2632,11 @@ structures.
 
 ## Registering a new credential ## {#registering-a-new-credential}
 
-When registering a new credential, represented by a {{AuthenticatorAttestationResponse}} structure, as part of a
+When registering a new credential, represented by a {{AuthenticatorAttestationResponse}} structure |response|, as part of a
 [=registration=] [=ceremony=], a [=[RP]=] MUST proceed as follows:
 
-1. Perform JSON deserialization on the {{AuthenticatorResponse/clientDataJSON}} field of the
-    {{AuthenticatorAttestationResponse}} object to extract the [=client data=] |C| claimed as collected during the credential
-    creation.
+1. Perform JSON deserialization on <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> to extract the [=client data=]
+    |C| claimed as collected during the credential creation.
 
 1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.create`.
 
@@ -2653,7 +2652,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
     and that the {{CollectedClientData/authenticatorExtensions}} in |C| is also a subset of the extensions requested by
     the RP.
 
-1. Compute the hash of {{AuthenticatorResponse/clientDataJSON}} using the algorithm identified by
+1. Compute the hash of <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> using the algorithm identified by
     <code>|C|.{{CollectedClientData/hashAlgorithm}}</code>.
 
 1. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the

--- a/index.bs
+++ b/index.bs
@@ -2657,7 +2657,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
     the RP and that the value of <code>|C|.{{CollectedClientData/authenticatorExtensions}}</code> is also a subset of the
     extensions requested by the RP.
 
-1. Compute the hash of <code>|resoinse|.{{AuthenticatorResponse/clientDataJSON}}</code> using SHA-256.
+1. Compute the hash of <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> using SHA-256.
 
 1. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the
     {{AuthenticatorAttestationResponse}} structure to obtain the attestation statement format |fmt|, the [=authenticator data=]

--- a/index.bs
+++ b/index.bs
@@ -2722,7 +2722,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
     {{AuthenticatorResponse/clientDataJSON}}, {{AuthenticatorAssertionResponse/authenticatorData}}, and
     {{AuthenticatorAssertionResponse/signature}} respectively.
 
-1. Let |C|, the [=client data=] used for the signature, be the result ofj[=parse JSON from
+1. Let |C|, the [=client data=] used for the signature, be the result of [=parse JSON from
     bytes|parsing JSON from the bytes=] in |cData|.
 
 1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.get`.

--- a/index.bs
+++ b/index.bs
@@ -2635,8 +2635,8 @@ structures.
 When registering a new credential, represented by a {{AuthenticatorAttestationResponse}} structure |response|, as part of a
 [=registration=] [=ceremony=], a [=[RP]=] MUST proceed as follows:
 
-1. Perform JSON deserialization on <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> to extract the [=client data=]
-    |C| claimed as collected during the credential creation.
+1. Let |C|, the [=client data=] claimed as collected during the credential creation, be the result of [=parse JSON from
+    bytes|parsing JSON from the bytes=] in <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code>.
 
 1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.create`.
 
@@ -2722,7 +2722,8 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
     {{AuthenticatorResponse/clientDataJSON}}, {{AuthenticatorAssertionResponse/authenticatorData}}, and
     {{AuthenticatorAssertionResponse/signature}} respectively.
 
-1. Perform JSON deserialization on |cData| to extract the [=client data=] |C| used for the signature.
+1. Let |C|, the [=client data=] used for the signature, be the result ofj[=parse JSON from
+    bytes|parsing JSON from the bytes=] in |cData|.
 
 1. Verify that the {{CollectedClientData/type}} in |C| is the string `webauthn.get`.
 


### PR DESCRIPTION
This replaces the "perform JSON deserialization" language with references to _parse JSON from bytes_ in Infra. See #713.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/718.html" title="Last updated on Jan 17, 2018, 11:34 AM GMT (910c25d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/718/a6c0da2...910c25d.html" title="Last updated on Jan 17, 2018, 11:34 AM GMT (910c25d)">Diff</a>