### PR TITLE
Fix #716: Add formal links to PublicKeyCredentialDescriptor description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1875,14 +1875,14 @@ following Web IDL.
     };
 </xmp>
 
-This dictionary contains the attributes that are specified by a caller when referring to a credential as an input parameter to
-the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods. It mirrors the fields of the
+This dictionary contains the attributes that are specified by a caller when referring to a [=public key credential=] as an input
+parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} methods. It mirrors the fields of the
 {{PublicKeyCredential}} object returned by the latter methods.
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialDescriptor">
-    The <dfn>type</dfn> member contains the type of the credential the caller is referring to.
+    The <dfn>type</dfn> member contains the type of the [=public key credential=] the caller is referring to.
 
-    The <dfn>id</dfn> member contains the identifier of the credential that the caller is referring to.
+    The <dfn>id</dfn> member contains the [=credential id=] of the [=public key credential=] that the caller is referring to.
 </div>
 
 


### PR DESCRIPTION
This resolves #716.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/719.html" title="Last updated on Dec 8, 2017, 9:29 AM GMT (f0342a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/719/33ac796...f0342a7.html" title="Last updated on Dec 8, 2017, 9:29 AM GMT (f0342a7)">Diff</a>