### PR TITLE
Fix #720: Contradiction in whether user handle is required 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -392,7 +392,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     * A [=Credential ID=].
     * A [=credential private key=].
     * The [=Relying Party Identifier=] for the [=[RP]=] that created this credential source.
-    * An optional [=user handle=] for the person who created this credential source.
+    * A [=user handle=] for the person who created this credential source.
     * Optional other information used by the authenticator to inform its UI. For example, this might include the user's
         {{displayName}}.
 


### PR DESCRIPTION
This resolves #720.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/721.html" title="Last updated on Dec 8, 2017, 9:41 AM GMT (d448eb3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/721/33ac796...d448eb3.html" title="Last updated on Dec 8, 2017, 9:41 AM GMT (d448eb3)">Diff</a>