### PR TITLE
fix 711 identifier internal slot contains credID

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -590,9 +590,11 @@ that are returned to the caller when a new credential is created, or a new asser
         "{{Credential/[[discovery]]/remote}}".
 
     :   <dfn>\[[identifier]]</dfn>
-    ::  This [=internal slot=] contains an identifier for the credential, chosen by the platform with help from the
-        authenticator. This identifier is used to look up credentials for use, and is therefore expected to be globally unique
-        with high probability across all credentials of the same type, across all authenticators. This API does not constrain
+    ::  This [=internal slot=] contains the [=credential ID=], chosen by the platform with help from the authenticator.
+        The [=credential ID=] is used to look up credentials for use, and is therefore expected to be globally unique
+        with high probability across all credentials of the same type, across all authenticators.
+
+        Note: This API does not constrain
         the format or length of this identifier, except that it must be sufficient for the platform to uniquely select a key.
         For example, an authenticator without on-board storage may create identifiers containing a [=credential private key=]
         wrapped with a symmetric key that is burned into the authenticator.


### PR DESCRIPTION
fixes #711


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/729.html" title="Last updated on Dec 19, 2017, 10:32 PM GMT (1651dcb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/729/986d627...1651dcb.html" title="Last updated on Dec 19, 2017, 10:32 PM GMT (1651dcb)">Diff</a>