### PR TITLE
Fix #720: Align user handle management with CTAP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -392,7 +392,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     * A [=Credential ID=].
     * A [=credential private key=].
     * The [=Relying Party Identifier=] for the [=[RP]=] that created this credential source.
-    * An optional [=user handle=] for the person who created this credential source.
+    * A [=user handle=] for the person who created this credential source.
     * Optional other information used by the authenticator to inform its UI. For example, this might include the user's
         {{displayName}}.
 

--- a/index.bs
+++ b/index.bs
@@ -392,7 +392,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     * A [=Credential ID=].
     * A [=credential private key=].
     * The [=Relying Party Identifier=] for the [=[RP]=] that created this credential source.
-    * A [=user handle=] for the person who created this credential source.
+    * An optional [=user handle=] for the person who created this credential source.
     * Optional other information used by the authenticator to inform its UI. For example, this might include the user's
         {{displayName}}.
 

--- a/index.bs
+++ b/index.bs
@@ -1245,8 +1245,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
-                ::  If |savedCredentialId| exists, set the value of [=userHandleResult=] to be the bytes of the [=user handle=]
-                    returned by the [=authenticator=]. Otherwise, set the value of [=userHandleResult=] to null.
+                ::  If the authenticator returned a [=user handle=], set the value of [=userHandleResult=] to be the bytes of that
+                    [=user handle=] returned by the [=authenticator=]. Otherwise, set the value of [=userHandleResult=] to null.
 
                 :   <code><dfn for="assertionCreationData">clientExtensionResults</dfn></code>
                 ::  whose value is an {{AuthenticationExtensions}} object containing [=extension identifier=] →
@@ -2340,16 +2340,14 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     Return to the user agent:
         - |selectedCredential|'s [=credential ID=], if either a [=list=] of credentials of [=list/size=] 2 or greater was supplied
             by the client, or no such [=list=] was supplied. Otherwise, return only the below values.
+
+            Note: If the client supplies a [=list=] of exactly one credential and it was successfully employed, then its
+                [=credential ID=] is not returned since the client already knows it. This saves transmitting these bytes over
+                what may be a constrained connection in what is likely a common case.
+
         - |authenticatorData|
         - |signature|
-        - The [=user handle=] associated with |selectedCredential|, if no [=list=] of credentials was supplied by the client, or
-            no such [=list=] was supplied. Otherwise, do not return this value.
-
-      Note: If the client supplies a [=list=] of exactly one credential and it was successfully employed, then its
-          [=credential ID=] and [=user handle=] are not returned since the [=[RP]=], having provided the [=credential ID=] to the
-          client, already knows the [=credential ID=] and the identity of the user. This saves transmitting these bytes over what
-          may be a constrained connection in what is likely a common case, and enables backwards compatibility with legacy
-          [=authenticators=] that cannot store the [=user handle=].
+        - The [=user handle=] associated with |selectedCredential|, if available.
     </li>
 
 If the authenticator cannot find any credential corresponding to the specified [=[RP]=] that matches the specified criteria, it

--- a/index.bs
+++ b/index.bs
@@ -2225,7 +2225,9 @@ When this operation is invoked, the [=authenticator=] must perform the following
     1. Let |credentialId| be a new identifier for this credential that is globally unique with high probability across all
         credentials with the same type across all authenticators.
     1. Let |userHandle| be <code>|userEntity|.{{PublicKeyCredentialUserEntity/id}}</code>.
-    1. Associate the |credentialId| and |privateKey| with <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and |userHandle|.
+    1. Associate the |credentialId| and |privateKey| with <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and
+        |userHandle|. The authenticator MAY discard |userHandle| from this association if |privateKey| is not a
+        [=Client-side-resident Credential Private Key=].
     1. Delete any older credentials with the same <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and |userHandle| that are stored locally by the [=authenticator=].
 1. If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.

--- a/index.bs
+++ b/index.bs
@@ -1245,8 +1245,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
-                ::  If the authenticator returned a [=user handle=], set the value of [=userHandleResult=] to be the bytes of that
-                    [=user handle=] returned by the [=authenticator=]. Otherwise, set the value of [=userHandleResult=] to null.
+                ::  If the [=authenticator=] returned a [=user handle=], set the value of [=userHandleResult=] to be the bytes of
+                    the returned [=user handle=]. Otherwise, set the value of [=userHandleResult=] to null.
 
                 :   <code><dfn for="assertionCreationData">clientExtensionResults</dfn></code>
                 ::  whose value is an {{AuthenticationExtensions}} object containing [=extension identifier=] →

--- a/index.bs
+++ b/index.bs
@@ -1245,7 +1245,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
-                ::  whose value is the bytes of the [=user handle=] returned by the [=authenticator=].
+                ::  If |savedCredentialId| exists, set the value of [=userHandleResult=] to be the bytes of the [=user handle=]
+                    returned by the [=authenticator=]. Otherwise, set the value of [=userHandleResult=] to null.
 
                 :   <code><dfn for="assertionCreationData">clientExtensionResults</dfn></code>
                 ::  whose value is an {{AuthenticationExtensions}} object containing [=extension identifier=] →
@@ -1278,7 +1279,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
                             <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
 
                         :   {{AuthenticatorAssertionResponse/userHandle}}
-                        ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
+                        ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this
+                            field to null. Otherwise, set this field to a new {{ArrayBuffer}}, created using |global|'s
+                            [=%ArrayBuffer%=], containing the bytes of
                             <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code>.
 
                     :   {{PublicKeyCredential/[[clientExtensionsResults]]}}
@@ -1423,7 +1426,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
-        [SameObject] readonly attribute ArrayBuffer      userHandle;
+        [SameObject] readonly attribute ArrayBuffer?     userHandle;
     };
 </pre>
 <div dfn-type="attribute" dfn-for="AuthenticatorAssertionResponse">
@@ -1440,7 +1443,8 @@ optionally evidence of [=user consent=] to a specific transaction.
     ::  This attribute contains the raw signature returned from the authenticator. See [[#op-get-assertion]].
 
     :   <dfn>userHandle</dfn>
-    ::  This attribute contains the [=user handle=] returned from the authenticator. See [[#op-get-assertion]].
+    ::  This attribute contains the [=user handle=] returned from the authenticator, or null if the authenticator did not return a
+        [=user handle=]. See [[#op-get-assertion]].
 </div>
 
 ## Parameters for Credential Generation (dictionary <dfn dictionary>PublicKeyCredentialParameters</dfn>) ## {#credential-params}
@@ -2336,14 +2340,16 @@ When this method is invoked, the [=authenticator=] must perform the following pr
     Return to the user agent:
         - |selectedCredential|'s [=credential ID=], if either a [=list=] of credentials of [=list/size=] 2 or greater was supplied
             by the client, or no such [=list=] was supplied. Otherwise, return only the below values.
-
-            Note: If the client supplies a [=list=] of exactly one credential and it was successfully employed, then its
-                [=credential ID=] is not returned since the client already knows it. This saves transmitting these bytes over
-                what may be a constrained connection in what is likely a common case.
-
         - |authenticatorData|
         - |signature|
-        - The [=user handle=] associated with |selectedCredential|.
+        - The [=user handle=] associated with |selectedCredential|, if no [=list=] of credentials was supplied by the client, or
+            no such [=list=] was supplied. Otherwise, do not return this value.
+
+      Note: If the client supplies a [=list=] of exactly one credential and it was successfully employed, then its
+          [=credential ID=] and [=user handle=] are not returned since the [=[RP]=], having provided the [=credential ID=] to the
+          client, already knows the [=credential ID=] and the identity of the user. This saves transmitting these bytes over what
+          may be a constrained connection in what is likely a common case, and enables backwards compatibility with legacy
+          [=authenticators=] that cannot store the [=user handle=].
     </li>
 
 If the authenticator cannot find any credential corresponding to the specified [=[RP]=] that matches the specified criteria, it


### PR DESCRIPTION
As stated in https://github.com/w3c/webauthn/pull/558#issuecomment-331537953. This resolves #720.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/730.html" title="Last updated on Jan 3, 2018, 5:18 PM GMT (f3e8afb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/730/33ac796...f3e8afb.html" title="Last updated on Jan 3, 2018, 5:18 PM GMT (f3e8afb)">Diff</a>