### PR TITLE
fix #455: we are using CTAP canonical CBOR encoding form everywhere

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -250,8 +250,10 @@ A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain the security
 
 ## All Conformance Classes ## {#conforming-all-classes}
 
-All [=CBOR=] encoding and decoding performed by the members of the above conformance classes MUST be done using the
-[=CTAP canonical CBOR encoding form=].
+All [=CBOR=] encoding performed by the members of the above conformance classes MUST be done using the
+[=CTAP canonical CBOR encoding form=]. 
+All decoders of the above conformance classes SHOULD reject CBOR that is not validly encoded
+in the [=CTAP canonical CBOR encoding form=] and SHOULD reject messages with duplicate map keys.
 
 
 # Dependencies # {#dependencies}

--- a/index.bs
+++ b/index.bs
@@ -106,6 +106,11 @@ spec: page-visibility; urlPrefix: https://www.w3.org/TR/page-visibility/
 spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
     type: dfn 
         text: focus
+
+spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html
+    type: dfn
+        text: CTAP canonical CBOR encoding form; url: message-encoding
+
 </pre> <!-- class=anchors -->
 
 <!-- L128 spec:webappsec-credential-management-1; type:dictionary; for:/; text:CredentialRequestOptions -->
@@ -241,7 +246,13 @@ external hardware, or a combination of both.
 
 ## [RPS] ## {#conforming-relying-parties}
 
-A [=[RP]=] MUST behave as described in [[#rp-operations]] to get the security benefits offered by this specification.
+A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain the security benefits offered by this specification.
+
+## All Conformance Classes ## {#conforming-all-classes}
+
+All [=CBOR=] encoding and decoding performed by the members of the above conformance classes MUST be done using the
+[=CTAP canonical CBOR encoding form=].
+
 
 # Dependencies # {#dependencies}
 
@@ -254,11 +265,12 @@ below and in [[#index-defined-elsewhere]].
     inclusion of any line breaks, whitespace, or other additional characters.
 
 : CBOR
-:: A number of structures in this specification, including attestation statements and extensions, are encoded using the Compact
-    Binary Object Representation (<dfn>CBOR</dfn>) [[!RFC7049]].
+:: A number of structures in this specification, including attestation statements and extensions, are encoded using the
+    [=CTAP canonical CBOR encoding form=] of the Compact Binary Object Representation (<dfn>CBOR</dfn>) [[!RFC7049]],
+    as defined in [[!FIDO-CTAP]].
 
 : CDDL
-:: This specification describes the syntax of all CBOR-encoded data using the CBOR Data Definition Language (CDDL) [[!CDDL]].
+:: This specification describes the syntax of all [=CBOR=]-encoded data using the CBOR Data Definition Language (CDDL) [[!CDDL]].
 
 : COSE
 :: CBOR Object Signing and Encryption (COSE) [[!RFC8152]].  The IANA COSE Algorithms registry established by this specification is also used.
@@ -4385,8 +4397,8 @@ Axel Nennker, Kimberly Paulhamus, Adam Powers, Yaron Sheffer, Mike West, Jeffrey
   "FIDO-APPID": {
     "authors": ["D. Balfanz", "B. Hill", "R. Lindemann", "D. Baghdasaryan"],
     "title": "FIDO AppID and Facets",
-    "href": "https://fidoalliance.org/specs/fido-uaf-v1.1-rd-20161005/fido-appid-and-facets-v1.1-rd-20161005.html",
-    "status": "FIDO Alliance Review Draft"
+    "href": "https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-appid-and-facets-v2.0-ps-20170927.html",
+    "status": "FIDO Alliance Proposed Standard"
   },
 
   "FIDO-U2F-Message-Formats": {
@@ -4400,8 +4412,8 @@ Axel Nennker, Kimberly Paulhamus, Adam Powers, Yaron Sheffer, Mike West, Jeffrey
     "authors": ["R. Lindemann", "V. Bharadwaj", "A. Czeskis", "M. B. Jones", "J. Hodges", "A. Kumar", "C. Brand", "J. Verrept",
         "J. Ehrensvard"],
     "title": "FIDO 2.0: Client to Authenticator Protocol",
-    "href": "https://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-client-to-authenticator-protocol-v2.0-rd-20170927.html",
-    "status": "FIDO Alliance Review Draft"
+    "href": "https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html",
+    "status": "FIDO Alliance Proposed Standard"
   },
 
   "FIDO-UAF-AUTHNR-CMDS": {


### PR DESCRIPTION
see issue #455 consider requiring canonical CBOR thoughout.

see also: https://github.com/fido-alliance/fido-2-specs/pull/401

fix #455


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/731.html" title="Last updated on Dec 22, 2017, 12:57 AM GMT (c7149f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/731/986d627...c7149f7.html" title="Last updated on Dec 22, 2017, 12:57 AM GMT (c7149f7)">Diff</a>