### PR TITLE
fix #497: add 'Dictionary' to Credential{Creation,Request}Options section titles

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -618,7 +618,7 @@ implementation of {{PublicKeyCredential/[[Create]](origin, options, sameOriginWi
 {{Credential/[[Store]](credential, sameOriginWithAncestors)}}.
 
 
-### `CredentialCreationOptions` Extension ### {#credentialcreationoptions-extension}
+### `CredentialCreationOptions` Dictionary Extension ### {#credentialcreationoptions-extension}
 
 To support registration via {{CredentialsContainer/create()|navigator.credentials.create()}}, this document extends
 the {{CredentialCreationOptions}} dictionary as follows:
@@ -629,7 +629,7 @@ the {{CredentialCreationOptions}} dictionary as follows:
     };
 </pre>
 
-### `CredentialRequestOptions` Extension ### {#credentialrequestoptions-extension}
+### `CredentialRequestOptions` Dictionary Extension ### {#credentialrequestoptions-extension}
 
 To support obtaining assertions via {{CredentialsContainer/get()|navigator.credentials.get()}}, this document extends the
 {{CredentialRequestOptions}} dictionary as follows:


### PR DESCRIPTION
this fixes issue #497


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/734.html" title="Last updated on Jan 2, 2018, 12:09 AM GMT (8b1b3da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/734/a6c0da2...8b1b3da.html" title="Last updated on Jan 2, 2018, 12:09 AM GMT (8b1b3da)">Diff</a>