### PR TITLE
Changed uses of JSON string to USVString

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3558,7 +3558,7 @@ JavaScript APIs.
 :: `appid`
 
 : Client extension input
-:: A single JSON string specifying a FIDO |AppID|.
+:: A single USVString specifying a FIDO |AppID|.
 
 : Client extension processing
 ::  1. If present in a {{CredentialsContainer/create()}} call, return a
@@ -3600,13 +3600,13 @@ This [=registration extension=] and [=authentication extension=] allows for a si
 :: `txAuthSimple`
 
 : Client extension input
-:: A single JSON string prompt.
+:: A single USVString prompt.
 
 : Client extension processing
 :: None, except creating the authenticator extension input from the client extension input.
 
 : Client extension output
-:: Returns the authenticator extension output string UTF-8 decoded into a JSON string
+:: Returns the authenticator extension output string UTF-8 decoded into a USVString
 
 : Authenticator extension input
 :: The client extension input encoded as a CBOR text string (major type 3).
@@ -3639,7 +3639,7 @@ as well. This allows authenticators without a font rendering engine to be used a
 :: None, except creating the authenticator extension input from the client extension input.
 
 : Client extension output
-:: Returns the base64url encoding of the authenticator extension output value as a JSON string
+:: Returns the base64url encoding of the authenticator extension output value as a USVString
 
 : Authenticator extension input
 :: The client extension input encoded as a CBOR map.
@@ -3738,7 +3738,7 @@ This [=registration extension=] and [=authentication extension=] enables use of 
 :: None, except creating the authenticator extension input from the client extension input.
 
 : Client extension output
-:: Returns a JSON string containing the base64url encoding of the authenticator extension output
+:: Returns a USVString containing the base64url encoding of the authenticator extension output
 
 : Authenticator extension input
 :: The Boolean value `true`, encoded in CBOR (major type 7, value 21).


### PR DESCRIPTION
Fixes #417


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/739.html" title="Last updated on Jan 10, 2018, 4:55 PM GMT (e9808a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/739/0ed6257...selfissued:e9808a7.html" title="Last updated on Jan 10, 2018, 4:55 PM GMT (e9808a7)">Diff</a>