### PR TITLE
Fix #715 - add a conformance class note for FIDO U2F Attesation Types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -257,6 +257,11 @@ Agent=].
 As described in [[#use-cases]], an authenticator may be implemented in the operating system underlying the User Agent, or in
 external hardware, or a combination of both.
 
+### Backwards Compatibility with FIDO U2F ### {#conforming-authenticators-u2f}
+
+[=Authenticators=] that only support the [[#fido-u2f-attestation]] have no mechanism to store a
+[=user handle=], so the returned {{AuthenticatorAssertionResponse/userHandle}} will always be null.
+
 ## [RPS] ## {#conforming-relying-parties}
 
 A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain the security benefits offered by this specification.


### PR DESCRIPTION
Editorial fix: Note that U2F authenticators can't store-and-return a user handle.