### PR TITLE
Update CDDL to reflect packed, self-attestation.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2821,6 +2821,10 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
                            alg: COSEAlgorithmIdentifier, (-260 for ED256 / -261 for ED512)
                            sig: bytes,
                            ecdaaKeyId: bytes
+                       } //
+                       {
+                           alg: COSEAlgorithmIdentifier
+                           sig: bytes,
                        }
     ```
 


### PR DESCRIPTION
The verification process for the packed attestation format deals with a
case where both `x5c` and `ecdaaKeyId` elements are absent, but the CDDL
doesn't reflect that possibility.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/751.html" title="Last updated on Jan 17, 2018, 5:58 PM GMT (f0224aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/751/c64bdaf...agl:f0224aa.html" title="Last updated on Jan 17, 2018, 5:58 PM GMT (f0224aa)">Diff</a>