### PR TITLE
fix |allowCredentialDescriptorList| warning from L3605

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3602,7 +3602,7 @@ JavaScript APIs.
         returning `SW_WRONG_DATA`) then the client MUST retry with the U2F application
         parameter set to the SHA-256 hash of |appId|. If this results in an applicable
         credential, the client MUST include the credential in
-        |allowCredentialDescriptorList|. The value of |appId| then replaces the `rpId`
+        <var ignore>allowCredentialDescriptorList</var>. The value of |appId| then replaces the `rpId`
         parameter of [=authenticatorGetAssertion=].
 
 : Client extension output


### PR DESCRIPTION
this fixes an annoying-but-trivial linking error.  with this fix the spec presently compiles cleanly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/761.html" title="Last updated on Jan 24, 2018, 2:36 AM GMT (5d7faa3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/761/1e77b42...5d7faa3.html" title="Last updated on Jan 24, 2018, 2:36 AM GMT (5d7faa3)">Diff</a>