### PR TITLE
Reference the FIDO 100k batch sizes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4466,7 +4466,10 @@ in several ways, including:
 
 - A WebAuthn [=authenticator=] manufacturer may choose to ship all of their devices with the same (or a fixed number of)
     attestation key(s) (called [=Basic Attestation=]). This will anonymize the user at the risk of not being able to revoke a
-    particular attestation key if its WebAuthn Authenticator be compromised.
+    particular attestation key if its private key is compromised.
+
+    [[UAFProtocol]] requires that at least 100,000 devices share the same attestation certificate in order to produce
+    sufficiently large groups. This may serve as guidance about suitable batch sizes.
 
 - A WebAuthn Authenticator may be capable of dynamically generating different attestation keys (and requesting related
     certificates) per [=origin=] (following the [=Privacy CA=] approach). For example, a WebAuthn Authenticator can ship with a


### PR DESCRIPTION
PING suggested referencing the FIDO 100k requirement as guideance on
suitable batch sizing for attestation certificates.

Fixes #749


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/767.html" title="Last updated on Jan 26, 2018, 7:39 PM GMT (719f33b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/767/e5c8c4f...agl:719f33b.html" title="Last updated on Jan 26, 2018, 7:39 PM GMT (719f33b)">Diff</a>