### PR TITLE
Tighten up the specification of packed X.509 certificates.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2978,7 +2978,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using the
                 attestation public key in |x5c| with the algorithm specified in |alg|.
             - Verify that |x5c| meets the requirements in [[#packed-attestation-cert-requirements]].
-            - If |x5c| contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify that the value of this
+            - If |x5c| contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (`id-fido-gen-ce-aaguid`) verify that the value of this
                 extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
             - If successful, return attestation type Basic and [=attestation trust path=] |x5c|.
 
@@ -2998,21 +2998,33 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
 
 The attestation certificate MUST have the following fields/extensions:
 
-- Version MUST be set to 3.
+- Version MUST be set to 3 (which is indicated by an ASN.1 INTEGER with value 2).
 - Subject field MUST be set to:
     : Subject-C
-    :: Country where the Authenticator vendor is incorporated
+    :: ISO 3166 code specifying the country where the Authenticator vendor is incorporated (UTF8String)
     : Subject-O
-    :: Legal name of the Authenticator vendor
+    :: Legal name of the Authenticator vendor (UTF8String)
     : Subject-OU
-    :: Authenticator Attestation
+    :: Literal string “Authenticator Attestation” (UTF8String)
     : Subject-CN
-    :: No stipulation.
+    :: A UTF8String of the vendor's choosing
 
 - If the related attestation root certificate is used for multiple authenticator models, the Extension OID
-    `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) MUST be present, containing the AAGUID as value.
+    1.3.6.1.4.1.45724.1.1.4 (`id-fido-gen-ce-aaguid`) MUST be present, containing the AAGUID as a 16-byte OCTET STRING.
+    The extension MUST NOT be marked as critical.
 
-- The Basic Constraints extension MUST have the CA component set to false
+    Note that an X.509 Extension encodes the DER-encoding of the value in an OCTET STRING. Thus the AAGUID must be wrapped in <i>two</i> OCTET STRINGS to be valid. Here is a sample, encoded Extension structure:
+
+    <pre>
+  30 21                                     -- SEQUENCE
+    06 0b 2b 06 01 04 01 82 e5 1c 01 01 04  -- 1.3.6.1.4.1.45724.1.1.4
+    04 12                                   -- OCTET STRING
+      04 10                                 -- OCTET STRING
+        cd 8c 39 5c 26 ed ee de             -- AAGUID
+        65 3b 00 79 7d 03 ca 3c
+    </pre>
+
+- The Basic Constraints extension MUST have the CA component set to false.
 
 - An Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension [[RFC5280]]
     are both OPTIONAL as the status of many attestation certificates is available through authenticator metadata services.


### PR DESCRIPTION
Fixes #768.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/769.html" title="Last updated on Jan 26, 2018, 10:24 PM GMT (d51fbe9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/769/e5c8c4f...agl:d51fbe9.html" title="Last updated on Jan 26, 2018, 10:24 PM GMT (d51fbe9)">Diff</a>