### PR TITLE
hmac-secret extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3991,6 +3991,72 @@ This [=registration extension=] and [=authentication extension=] enables use of 
                     01           -- Subitem 3: CBOR short for Matcher Protection Type Software
     </pre>
 
+## HMAC Secret Extension (hmac-secret) ## {#sctn-hmac-secret-extension}
+
+This [=registration extension=] and [=authentication extension=] allows for a getting a symmetric secret from the authenticator.
+
+: Extension identifier
+:: `hmac-secret`
+
+: Client extension input
+:: {{CredentialsContainer/create()}} : A boolean value to indicate that this extension is requested by the Relying Party.
+      <pre class="idl">
+          partial dictionary AuthenticationExtensionsClientInputs {
+            bool hmacCreateSecret;
+          };
+      </pre>
+:: {{CredentialsContainer/get()}} : A JavaScript object defined as follows:
+      <pre class="idl">
+        dictionary HMACGetSecretInput {
+          required ArrayBuffer salt1;
+          optional ArrayBuffer salt2;
+        };
+
+        partial dictionary AuthenticationExtensionsClientInputs {
+          HMACGetSecretInput hmacGetSecret;
+        };
+      </pre>
+: Client extension processing
+::  1. If present in a {{CredentialsContainer/create()}}:
+        1. If set to false, do not process this extension.
+        1. If set to true, pass this value to authenticator input.
+    
+    1. If present in a {{CredentialsContainer/get()}}:
+        1. Verify that salt1 is a valid 32 byte ArrayBuffer
+        1. If salt2 is present, verify that is is a valid 32 byte ArrayBuffer
+        1. Pass salt1 and salt2 to authenticator input
+
+: Client extension output
+:: {{CredentialsContainer/create()}} : Boolean value indicated that the authenticator has processed the extension.
+
+      <pre class="idl">
+        partial dictionary AuthenticationExtensionsClientOutputs {
+          bool hmacCreateSecret;
+        };
+      </pre>
+
+:: {{CredentialsContainer/get()}} : A dictionary with the following data
+
+      <pre class="idl">
+        dictionary HMACGetSecretOutput { 
+          required ArrayBuffer OfflineCurrentHash;
+          optional ArrayBuffer OfflineNewHash;
+        };
+
+        partial dictionary AuthenticationExtensionsClientOutputs {
+          HMACGetSecretOutput hmacGetSecret;
+        };
+      </pre>
+
+: Authenticator extension input
+:: Refer to the FIDO 2.0 Client to Authenticator Protocol.
+
+: Authenticator extension processing
+:: Refer to the FIDO 2.0 Client to Authenticator Protocol.
+
+: Authenticator extension output
+:: Refer to the FIDO 2.0 Client to Authenticator Protocol.
+
 # IANA Considerations # {#sctn-IANA}
 
 ## WebAuthn Attestation Statement Format Identifier Registrations ## {#sctn-att-fmt-reg}


### PR DESCRIPTION
Description for hmac-secret extension.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/772.html" title="Last updated on Feb 1, 2018, 11:36 PM GMT (60ed25f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/772/1fc8906...60ed25f.html" title="Last updated on Feb 1, 2018, 11:36 PM GMT (60ed25f)">Diff</a>