### PR TITLE
Revise §9.5. "Authenticator extension processing"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2290,8 +2290,8 @@ It takes the following input parameters:
     these are known to the authenticator, it should not create a new credential. |excludeCredentialDescriptorList| contains a 
     list of known credentials.
 : |extensions|
-:: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
-    extensions requested by the [=[RP]=], if any.
+:: A [=CBOR=] [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on
+    the extensions requested by the [=[RP]=], if any.
 
 Note: Before performing this operation, all other operations in progress in the [=authenticator session=] MUST be aborted by 
 running the [=authenticatorCancel=] operation.
@@ -2399,8 +2399,8 @@ It takes the following input parameters:
 : |requireUserVerification|
 :: The [=effective user verification requirement for assertion=], a Boolean value provided by the client.
 : |extensions|
-:: A [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on the
-    extensions requested by the [=[RP]=], if any.
+:: A [=CBOR=] [=map=] from [=extension identifiers=] to their [=authenticator extension inputs=], created by the client based on
+    the extensions requested by the [=[RP]=], if any.
 
 Note: Before performing this operation, all other operations in progress in the [=authenticator session=] must be aborted by running the [=authenticatorCancel=] operation.
 

--- a/index.bs
+++ b/index.bs
@@ -3613,16 +3613,18 @@ the process by which the [=CBOR=] [=authenticator extension output=] can be used
 
 ## <dfn>Authenticator extension processing</dfn> ## {#sctn-authenticator-extension-processing}
 
-The [=CBOR=] [=authenticator extension input=] value of each processed
-[=authenticator extension=] is included in the extensions data part of the authenticator request. This part is a CBOR map, with
-[=CBOR=] [=extension identifier=] values as keys, and the [=CBOR=] [=authenticator extension input=] value of each extension as
-the value.
+The [=CBOR=] [=authenticator extension input=] value of each processed [=authenticator extension=] is included in the |extensions|
+parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion=] operations. The |extensions| parameter is a
+[=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the [=authenticator extension input=]
+for that extension.
 
-Likewise, the extension output is represented in the [=authenticator data=] as a CBOR map with [=CBOR=] [=extension
-identifiers=] as keys, and the [=CBOR=] <dfn>authenticator extension output</dfn> value of each extension as the value.
+Likewise, the <dfn>authenticator extension output</dfn> value of each processed [=authenticator extension=] is represented by one
+key/value pair in [=authdataextensions|extensions=] part of the [=authenticator data=]. The [=authdataextensions|extensions=] part
+of the [=authenticator data=] is a [=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the
+[=authenticator extension output=] of that extension.
 
-The [=authenticator extension processing=] rules are used create the [=authenticator extension output=]
-from the [=authenticator extension input=], and possibly also other inputs, for each extension.
+For each supported extension, the [=authenticator extension processing=] rule for that extension is used create the
+[=authenticator extension output=] from the [=authenticator extension input=] and possibly also other inputs.
 
 
 # Defined Extensions # {#sctn-defined-extensions}

--- a/index.bs
+++ b/index.bs
@@ -3562,7 +3562,7 @@ extension=] that does not otherwise require any result values MUST return a valu
 An extension defines one or two request arguments. The <dfn>client extension input</dfn>,
 which is a value that can be encoded in JSON, is passed from the [=[RP]=] to the client
 in the {{CredentialsContainer/get()}} or {{CredentialsContainer/create()}} call,
-while the [=CBOR=] <dfn>authenticator extension input</dfn> is
+while the [=CBOR=] [=authenticator extension input=] is
 passed from the client to the authenticator for [=authenticator extensions=] during the processing of these calls.
 
 A [=[RP]=] simultaneously requests the use of an extension and sets its [=client extension input=] by including an entry in the
@@ -3613,10 +3613,10 @@ the process by which the [=CBOR=] [=authenticator extension output=] can be used
 
 ## <dfn>Authenticator extension processing</dfn> ## {#sctn-authenticator-extension-processing}
 
-The [=CBOR=] [=authenticator extension input=] value of each processed [=authenticator extension=] is included in the |extensions|
-parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion=] operations. The |extensions| parameter is a
-[=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the [=authenticator extension input=]
-for that extension.
+The [=CBOR=] <dfn>authenticator extension input</dfn> value of each processed [=authenticator extension=] is included in the
+|extensions| parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion=] operations. The |extensions|
+parameter is a [=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the [=authenticator
+extension input=] for that extension.
 
 Likewise, the <dfn>authenticator extension output</dfn> value of each processed [=authenticator extension=] is represented by one
 key/value pair in [=authdataextensions|extensions=] part of the [=authenticator data=]. The [=authdataextensions|extensions=] part

--- a/index.bs
+++ b/index.bs
@@ -3562,7 +3562,7 @@ extension=] that does not otherwise require any result values MUST return a valu
 An extension defines one or two request arguments. The <dfn>client extension input</dfn>,
 which is a value that can be encoded in JSON, is passed from the [=[RP]=] to the client
 in the {{CredentialsContainer/get()}} or {{CredentialsContainer/create()}} call,
-while the [=CBOR=] [=authenticator extension input=] is
+while the [=CBOR=] <dfn>authenticator extension input</dfn> is
 passed from the client to the authenticator for [=authenticator extensions=] during the processing of these calls.
 
 A [=[RP]=] simultaneously requests the use of an extension and sets its [=client extension input=] by including an entry in the
@@ -3613,10 +3613,10 @@ the process by which the [=CBOR=] [=authenticator extension output=] can be used
 
 ## <dfn>Authenticator extension processing</dfn> ## {#sctn-authenticator-extension-processing}
 
-The [=CBOR=] <dfn>authenticator extension input</dfn> value of each processed [=authenticator extension=] is included in the
-|extensions| parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion=] operations. The |extensions|
-parameter is a [=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the [=authenticator
-extension input=] for that extension.
+The [=CBOR=] [=authenticator extension input=] value of each processed [=authenticator extension=] is included in the |extensions|
+parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion=] operations. The |extensions| parameter is a
+[=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the [=authenticator extension input=]
+for that extension.
 
 Likewise, the <dfn>authenticator extension output</dfn> value of each processed [=authenticator extension=] is represented by one
 key/value pair in [=authdataextensions|extensions=] part of the [=authenticator data=]. The [=authdataextensions|extensions=] part

--- a/index.bs
+++ b/index.bs
@@ -3619,8 +3619,8 @@ parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion
 for that extension.
 
 Likewise, the extension output is represented in the [=authdataextensions|extensions=] part of the [=authenticator data=]. The
-[=authdataextensions|extensions=] part of the [=authenticator data=] is a CBOR map with [=CBOR=] [=extension identifiers=] as
-keys, and the [=CBOR=] <dfn>authenticator extension output</dfn> value of each extension as the value.
+[=authdataextensions|extensions=] part of the [=authenticator data=] is a CBOR map where each key is an [=extension identifier=]
+and the corresponding value is the <dfn>authenticator extension output</dfn> for that extension.
 
 For each supported extension, the [=authenticator extension processing=] rule for that extension is used create the
 [=authenticator extension output=] from the [=authenticator extension input=] and possibly also other inputs.

--- a/index.bs
+++ b/index.bs
@@ -2356,8 +2356,8 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
             decrypt it.
 1. If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
-1. Let |processedExtensions| be the result of [=authenticator extension processing=] for each supported [=extension identifier=]/input
-    pair in |extensions|.
+1. Let |processedExtensions| be the result of [=authenticator extension processing=] [=map/for each=] supported <var
+    ignore>extensionId</var> → <var ignore>authenticatorExtensionInput</var> in |extensions|.
 1. If the [=authenticator=] supports:
     <dl class="switch">
         :   a per-[=RP ID=] [=signature counter=]
@@ -2431,8 +2431,8 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     If the user does not [=user consent|consent=], return an error code equivalent to
     "{{NotAllowedError}}" and terminate the operation.
 
-1. Let |processedExtensions| be the result of [=authenticator extension processing=] for each supported [=extension
-    identifier=]/input pair in |extensions|.
+1. Let |processedExtensions| be the result of [=authenticator extension processing=] [=map/for each=] supported <var
+    ignore>extensionId</var> → <var ignore>authenticatorExtensionInput</var> in |extensions|.
 1. Increment the [=RP ID=]-associated
     [=signature counter=] or the global [=signature counter=] value, depending on 
     which approach is implemented by the [=authenticator=], by some positive value.

--- a/index.bs
+++ b/index.bs
@@ -2356,8 +2356,8 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
             decrypt it.
 1. If any error occurred while creating the new credential object, return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
-1. Let |processedExtensions| be the result of [=authenticator extension processing=] [=map/for each=] supported <var
-    ignore>extensionId</var> → <var ignore>authenticatorExtensionInput</var> in |extensions|.
+1. Let |processedExtensions| be the result of [=authenticator extension processing=] [=map/for each=] supported [=extension
+    identifier=] → [=authenticator extension input=] in |extensions|.
 1. If the [=authenticator=] supports:
     <dl class="switch">
         :   a per-[=RP ID=] [=signature counter=]
@@ -2431,8 +2431,8 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     If the user does not [=user consent|consent=], return an error code equivalent to
     "{{NotAllowedError}}" and terminate the operation.
 
-1. Let |processedExtensions| be the result of [=authenticator extension processing=] [=map/for each=] supported <var
-    ignore>extensionId</var> → <var ignore>authenticatorExtensionInput</var> in |extensions|.
+1. Let |processedExtensions| be the result of [=authenticator extension processing=] [=map/for each=] supported [=extension
+    identifier=] → [=authenticator extension input=] in |extensions|.
 1. Increment the [=RP ID=]-associated
     [=signature counter=] or the global [=signature counter=] value, depending on 
     which approach is implemented by the [=authenticator=], by some positive value.
@@ -3618,10 +3618,9 @@ parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion
 [=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the [=authenticator extension input=]
 for that extension.
 
-Likewise, the <dfn>authenticator extension output</dfn> value of each processed [=authenticator extension=] is represented by one
-key/value pair in [=authdataextensions|extensions=] part of the [=authenticator data=]. The [=authdataextensions|extensions=] part
-of the [=authenticator data=] is a [=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the
-[=authenticator extension output=] of that extension.
+Likewise, the extension output is represented in the [=authdataextensions|extensions=] part of the [=authenticator data=]. The
+[=authdataextensions|extensions=] part of the [=authenticator data=] is a CBOR map with [=CBOR=] [=extension identifiers=] as
+keys, and the [=CBOR=] <dfn>authenticator extension output</dfn> value of each extension as the value.
 
 For each supported extension, the [=authenticator extension processing=] rule for that extension is used create the
 [=authenticator extension output=] from the [=authenticator extension input=] and possibly also other inputs.


### PR DESCRIPTION
This aims to fix #775.

I'm not entirely happy with it, but I think it's at least an improvement of section §9.5. What bugs me most is that it feels like "the result of authenticator extension processing" could be taken to mean processing the entire map or just one of the key/value pairs. It feels like it should be possible to rephrase the

>Let _processedExtensions_ be the result of **authenticator extension processing** for each supported _extensionId_ → _authenticatorExtensionInput_ in _extensions_.

steps of the authenticator operations so they don't require iterating over the map, but "authenticator extension processing" currently refers specifically to the processing for a single extension.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/776.html" title="Last updated on Feb 6, 2018, 9:29 PM GMT (894c2f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/776/572446d...894c2f5.html" title="Last updated on Feb 6, 2018, 9:29 PM GMT (894c2f5)">Diff</a>