### PR TITLE
Rename MakePublicKeyCredentialOptions to PublicKeyCredentialCreateOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -674,7 +674,7 @@ the {{CredentialCreationOptions}} dictionary as follows:
 
 <pre class="idl">
     partial dictionary CredentialCreationOptions {
-        MakePublicKeyCredentialOptions      publicKey;
+        PublicKeyCredentialCreateOptions      publicKey;
     };
 </pre>
 
@@ -712,7 +712,7 @@ This [=internal method=] accepts three arguments:
 
     :   <dfn>options</dfn>
     ::  This argument is a {{CredentialCreationOptions}} object whose
-        <code>|options|.{{CredentialCreationOptions/publicKey}}</code> member contains a {{MakePublicKeyCredentialOptions}}
+        <code>|options|.{{CredentialCreationOptions/publicKey}}</code> member contains a {{PublicKeyCredentialCreateOptions}}
         object specifying the desired attributes of the to-be-created [=public key credential=].
 
     :   <dfn>sameOriginWithAncestors</dfn>
@@ -742,9 +742,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
-1. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present=], check if its value lies within a
+1. If the {{PublicKeyCredentialCreateOptions/timeout}} member of |options| is [=present=], check if its value lies within a
     reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set a timer
-    |lifetimeTimer| to this adjusted value. If the {{MakePublicKeyCredentialOptions/timeout}} member of |options| is [=present|not
+    |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialCreateOptions/timeout}} member of |options| is [=present|not
     present=], then set |lifetimeTimer| to a platform-specific default.
 
 1. Let |callerOrigin| be {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/origin}}. If |callerOrigin| is an [=opaque origin=], return a {{DOMException}} whose name is
@@ -762,30 +762,30 @@ When this method is invoked, the user agent MUST execute the following algorithm
 -->
     <li id='CreateCred-DetermineRpId'>
 
-        If <code>|options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+        If <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
             <dl class="switch">
 
                 :   Is [=present=]
-                ::  If <code>|options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> [=is not a
+                ::  If <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> [=is not a
                     registrable domain suffix of and is not equal to=] |effectiveDomain|, return a {{DOMException}} whose name
                     is "{{SecurityError}}", and terminate this algorithm.
 
                 :   Is [=present|not present=]
-                ::  Set <code>|options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to
+                ::  Set <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to
                     |effectiveDomain|.
             </dl>
 
-        Note: <code>|options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> represents the
+        Note: <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> represents the
             caller's [=RP ID=]. The [=RP ID=] defaults to being the caller's [=environment settings object/origin=]'s
             [=effective domain=] unless the caller has explicitly set
-            <code>|options|.{{MakePublicKeyCredentialOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> when calling
+            <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> when calling
             {{CredentialsContainer/create()}}.
     </li>
 
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
     a {{COSEAlgorithmIdentifier}}.
 
-1. [=list/For each=] |current| of <code>|options|.{{MakePublicKeyCredentialOptions/pubKeyCredParams}}</code>:
+1. [=list/For each=] |current| of <code>|options|.{{PublicKeyCredentialCreateOptions/pubKeyCredParams}}</code>:
 
     1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
         by this implementation, then [=continue=].
@@ -793,13 +793,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
     1. [=list/Append=] the pair of <code>|current|.{{PublicKeyCredentialParameters/type}}</code> and |alg| to
         |credTypesAndPubKeyAlgs|.
 
-1. If |credTypesAndPubKeyAlgs| [=list/is empty=] and <code>|options|.{{MakePublicKeyCredentialOptions/pubKeyCredParams}}</code>
+1. If |credTypesAndPubKeyAlgs| [=list/is empty=] and <code>|options|.{{PublicKeyCredentialCreateOptions/pubKeyCredParams}}</code>
     [=list/is not empty=], return a {{DOMException}} whose name is "{{NotSupportedError}}", and terminate this algorithm.
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
 
-1. If the {{MakePublicKeyCredentialOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
-    |extensionId| → |clientExtensionInput| of <code>|options|.{{MakePublicKeyCredentialOptions/extensions}}</code>:
+1. If the {{PublicKeyCredentialCreateOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
+    |extensionId| → |clientExtensionInput| of <code>|options|.{{PublicKeyCredentialCreateOptions/extensions}}</code>:
     1. If |extensionId| is not supported by this client platform or is not a [=registration extension=], then [=continue=].
 
     1. [=map/Set=] |clientExtensions|[|extensionId|] to |clientExtensionInput|.
@@ -815,7 +815,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     : {{CollectedClientData/type}}
     :: The string "webauthn.create".
     : {{CollectedClientData/challenge}}
-    :: The [=base64url encoding=] of |options|.{{MakePublicKeyCredentialOptions/challenge}}.
+    :: The [=base64url encoding=] of |options|.{{PublicKeyCredentialCreateOptions/challenge}}.
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/tokenBindingId}}
@@ -845,20 +845,20 @@ When this method is invoked, the user agent MUST execute the following algorithm
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}</code> is [=present=]:
+    1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}</code> is [=present=]:
 
-          1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
+          1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
             [=present|present=] and its value is not equal to |authenticator|'s attachment modality, [=iteration/continue=].
-          1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is set to
+          1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is set to
             `true` and the |authenticator| is not capable of storing a [=Client-Side-Resident Credential Private Key=],
             [=iteration/continue=].
-          1. If <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
+          1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
             set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
             verification=], [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
         as follows. If
-        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
+        <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
 
             <dl class="switch">
 
@@ -885,7 +885,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
-    1. [=list/For each=] credential descriptor |C| in <code>|options|.{{MakePublicKeyCredentialOptions/excludeCredentials}}</code>:
+    1. [=list/For each=] credential descriptor |C| in <code>|options|.{{PublicKeyCredentialCreateOptions/excludeCredentials}}</code>:
         1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
             mentioned in <code>|C|.{{transports}}</code>, the client MAY [=continue=].
         1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
@@ -893,8 +893,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 <!-- @@EDITOR-ANCHOR-01A: KEEP THIS LIST SYNC'D WITH THE LIST UP AT @@EDITOR-ANCHOR-01B -->
     1. Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
         |clientDataHash|,
-        <code>|options|.{{MakePublicKeyCredentialOptions/rp}}</code>, <code>|options|.{{MakePublicKeyCredentialOptions/user}}</code>,
-        <code>|options|.{{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
+        <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}</code>, <code>|options|.{{PublicKeyCredentialCreateOptions/user}}</code>,
+        <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
         |userPresence|,
         |userVerification|,
         |credTypesAndPubKeyAlgs|,
@@ -941,7 +941,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is the bytes of |clientDataJSON|.
 
                 :   <code><dfn for="credentialCreationData">attestationConveyancePreferenceOption</dfn></code>
-                ::  whose value is the value of |options|.{{MakePublicKeyCredentialOptions/attestation}}.
+                ::  whose value is the value of |options|.{{PublicKeyCredentialCreateOptions/attestation}}.
 
                 :   <code><dfn for="credentialCreationData">clientExtensionResults</dfn></code>
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
@@ -1542,10 +1542,10 @@ optionally evidence of [=user consent=] to a specific transaction.
         a message to the authenticator, which may be sent over a low-bandwidth link.
 </div>
 
-## Options for Credential Creation (dictionary <dfn dictionary>MakePublicKeyCredentialOptions</dfn>) ## {#dictionary-makecredentialoptions}
+## Options for Credential Creation (dictionary <dfn dictionary>PublicKeyCredentialCreateOptions</dfn>) ## {#dictionary-makecredentialoptions}
 
 <xmp class="idl">
-    dictionary MakePublicKeyCredentialOptions {
+    dictionary PublicKeyCredentialCreateOptions {
         required PublicKeyCredentialRpEntity         rp;
         required PublicKeyCredentialUserEntity       user;
 
@@ -1559,7 +1559,7 @@ optionally evidence of [=user consent=] to a specific transaction.
         AuthenticationExtensionsClientInputs         extensions;
     };
 </xmp>
-<div dfn-type="dict-member" dfn-for="MakePublicKeyCredentialOptions">
+<div dfn-type="dict-member" dfn-for="PublicKeyCredentialCreateOptions">
     :   <dfn>rp</dfn>
     ::  This member contains data about the [=[RP]=] responsible for the request.
 
@@ -2280,7 +2280,7 @@ It takes the following input parameters:
 : |userEntity|
 :: The user account's {{PublicKeyCredentialUserEntity}}, containing the [=user handle=] given by the [=[RP]=].
 : |requireResidentKey|
-:: The {{MakePublicKeyCredentialOptions/authenticatorSelection}}.{{requireResidentKey}} value given by the [=[RP]=].
+:: The {{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{requireResidentKey}} value given by the [=[RP]=].
 : |requireUserPresence|
 :: A Boolean value provided by the client, which in invocations from a [=[WAC]=]'s
     {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method is always set to the inverse of
@@ -2843,7 +2843,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 
 1. If the attestation statement |attStmt| verified successfully and is found to be trustworthy, then register the new
     credential with the account that was denoted in the
-    {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/options}}.{{MakePublicKeyCredentialOptions/user}} passed to
+    {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/options}}.{{PublicKeyCredentialCreateOptions/user}} passed to
     {{CredentialsContainer/create()}}, by associating it with the <code>[=credentialId=]</code> and
     <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|, as appropriate for the
     [=[RP]=]'s system.
@@ -3572,7 +3572,7 @@ while the [=CBOR=] <dfn>authenticator extension input</dfn> is
 passed from the client to the authenticator for [=authenticator extensions=] during the processing of these calls.
 
 A [=[RP]=] simultaneously requests the use of an extension and sets its [=client extension input=] by including an entry in the
-{{MakePublicKeyCredentialOptions/extensions}} option to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} call.
+{{PublicKeyCredentialCreateOptions/extensions}} option to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} call.
 The entry key is the [=extension identifier=] and the value is the [=client extension input=].
 
 <pre class="example" highlight="js">
@@ -4500,7 +4500,7 @@ The below subsections comprise the current Web Authentication-specific security 
 ## Cryptographic Challenges ## {#cryptographic-challenges}
 
 As a cryptographic protocol, Web Authentication is dependent upon randomized challenges
-to avoid replay attacks. Therefore, both {{MakePublicKeyCredentialOptions/challenge}}'s
+to avoid replay attacks. Therefore, both {{PublicKeyCredentialCreateOptions/challenge}}'s
 and {{PublicKeyCredentialRequestOptions/challenge}}'s value MUST be randomly generated
 by [=[RPS]=] in an environment they trust (e.g., on the server-side), and the
 returned challenge value in the client's

--- a/index.bs
+++ b/index.bs
@@ -674,7 +674,7 @@ the {{CredentialCreationOptions}} dictionary as follows:
 
 <pre class="idl">
     partial dictionary CredentialCreationOptions {
-        PublicKeyCredentialCreateOptions      publicKey;
+        PublicKeyCredentialCreationOptions      publicKey;
     };
 </pre>
 
@@ -712,7 +712,7 @@ This [=internal method=] accepts three arguments:
 
     :   <dfn>options</dfn>
     ::  This argument is a {{CredentialCreationOptions}} object whose
-        <code>|options|.{{CredentialCreationOptions/publicKey}}</code> member contains a {{PublicKeyCredentialCreateOptions}}
+        <code>|options|.{{CredentialCreationOptions/publicKey}}</code> member contains a {{PublicKeyCredentialCreationOptions}}
         object specifying the desired attributes of the to-be-created [=public key credential=].
 
     :   <dfn>sameOriginWithAncestors</dfn>
@@ -742,9 +742,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
-1. If the {{PublicKeyCredentialCreateOptions/timeout}} member of |options| is [=present=], check if its value lies within a
+1. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present=], check if its value lies within a
     reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set a timer
-    |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialCreateOptions/timeout}} member of |options| is [=present|not
+    |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present|not
     present=], then set |lifetimeTimer| to a platform-specific default.
 
 1. Let |callerOrigin| be {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/origin}}. If |callerOrigin| is an [=opaque origin=], return a {{DOMException}} whose name is
@@ -762,30 +762,30 @@ When this method is invoked, the user agent MUST execute the following algorithm
 -->
     <li id='CreateCred-DetermineRpId'>
 
-        If <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+        If <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
             <dl class="switch">
 
                 :   Is [=present=]
-                ::  If <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> [=is not a
+                ::  If <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> [=is not a
                     registrable domain suffix of and is not equal to=] |effectiveDomain|, return a {{DOMException}} whose name
                     is "{{SecurityError}}", and terminate this algorithm.
 
                 :   Is [=present|not present=]
-                ::  Set <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to
+                ::  Set <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to
                     |effectiveDomain|.
             </dl>
 
-        Note: <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> represents the
+        Note: <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> represents the
             caller's [=RP ID=]. The [=RP ID=] defaults to being the caller's [=environment settings object/origin=]'s
             [=effective domain=] unless the caller has explicitly set
-            <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> when calling
+            <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> when calling
             {{CredentialsContainer/create()}}.
     </li>
 
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
     a {{COSEAlgorithmIdentifier}}.
 
-1. [=list/For each=] |current| of <code>|options|.{{PublicKeyCredentialCreateOptions/pubKeyCredParams}}</code>:
+1. [=list/For each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
 
     1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
         by this implementation, then [=continue=].
@@ -793,13 +793,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
     1. [=list/Append=] the pair of <code>|current|.{{PublicKeyCredentialParameters/type}}</code> and |alg| to
         |credTypesAndPubKeyAlgs|.
 
-1. If |credTypesAndPubKeyAlgs| [=list/is empty=] and <code>|options|.{{PublicKeyCredentialCreateOptions/pubKeyCredParams}}</code>
+1. If |credTypesAndPubKeyAlgs| [=list/is empty=] and <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>
     [=list/is not empty=], return a {{DOMException}} whose name is "{{NotSupportedError}}", and terminate this algorithm.
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
 
-1. If the {{PublicKeyCredentialCreateOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
-    |extensionId| → |clientExtensionInput| of <code>|options|.{{PublicKeyCredentialCreateOptions/extensions}}</code>:
+1. If the {{PublicKeyCredentialCreationOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
+    |extensionId| → |clientExtensionInput| of <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>:
     1. If |extensionId| is not supported by this client platform or is not a [=registration extension=], then [=continue=].
 
     1. [=map/Set=] |clientExtensions|[|extensionId|] to |clientExtensionInput|.
@@ -815,7 +815,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     : {{CollectedClientData/type}}
     :: The string "webauthn.create".
     : {{CollectedClientData/challenge}}
-    :: The [=base64url encoding=] of |options|.{{PublicKeyCredentialCreateOptions/challenge}}.
+    :: The [=base64url encoding=] of |options|.{{PublicKeyCredentialCreationOptions/challenge}}.
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/tokenBindingId}}
@@ -845,20 +845,20 @@ When this method is invoked, the user agent MUST execute the following algorithm
     Resolving this with good definitions or some other means will be addressed by resolving
     [Issue #613](https://github.com/w3c/webauthn/issues/613).
 
-    1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}</code> is [=present=]:
+    1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}</code> is [=present=]:
 
-          1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
+          1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
             [=present|present=] and its value is not equal to |authenticator|'s attachment modality, [=iteration/continue=].
-          1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is set to
+          1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is set to
             `true` and the |authenticator| is not capable of storing a [=Client-Side-Resident Credential Private Key=],
             [=iteration/continue=].
-          1. If <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
+          1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
             set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
             verification=], [=iteration/continue=].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
         as follows. If
-        <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
+        <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
 
             <dl class="switch">
 
@@ -885,7 +885,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
-    1. [=list/For each=] credential descriptor |C| in <code>|options|.{{PublicKeyCredentialCreateOptions/excludeCredentials}}</code>:
+    1. [=list/For each=] credential descriptor |C| in <code>|options|.{{PublicKeyCredentialCreationOptions/excludeCredentials}}</code>:
         1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
             mentioned in <code>|C|.{{transports}}</code>, the client MAY [=continue=].
         1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
@@ -893,8 +893,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 <!-- @@EDITOR-ANCHOR-01A: KEEP THIS LIST SYNC'D WITH THE LIST UP AT @@EDITOR-ANCHOR-01B -->
     1. Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
         |clientDataHash|,
-        <code>|options|.{{PublicKeyCredentialCreateOptions/rp}}</code>, <code>|options|.{{PublicKeyCredentialCreateOptions/user}}</code>,
-        <code>|options|.{{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
+        <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}</code>, <code>|options|.{{PublicKeyCredentialCreationOptions/user}}</code>,
+        <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
         |userPresence|,
         |userVerification|,
         |credTypesAndPubKeyAlgs|,
@@ -941,7 +941,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is the bytes of |clientDataJSON|.
 
                 :   <code><dfn for="credentialCreationData">attestationConveyancePreferenceOption</dfn></code>
-                ::  whose value is the value of |options|.{{PublicKeyCredentialCreateOptions/attestation}}.
+                ::  whose value is the value of |options|.{{PublicKeyCredentialCreationOptions/attestation}}.
 
                 :   <code><dfn for="credentialCreationData">clientExtensionResults</dfn></code>
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
@@ -1542,10 +1542,10 @@ optionally evidence of [=user consent=] to a specific transaction.
         a message to the authenticator, which may be sent over a low-bandwidth link.
 </div>
 
-## Options for Credential Creation (dictionary <dfn dictionary>PublicKeyCredentialCreateOptions</dfn>) ## {#dictionary-makecredentialoptions}
+## Options for Credential Creation (dictionary <dfn dictionary>PublicKeyCredentialCreationOptions</dfn>) ## {#dictionary-makecredentialoptions}
 
 <xmp class="idl">
-    dictionary PublicKeyCredentialCreateOptions {
+    dictionary PublicKeyCredentialCreationOptions {
         required PublicKeyCredentialRpEntity         rp;
         required PublicKeyCredentialUserEntity       user;
 
@@ -1559,7 +1559,7 @@ optionally evidence of [=user consent=] to a specific transaction.
         AuthenticationExtensionsClientInputs         extensions;
     };
 </xmp>
-<div dfn-type="dict-member" dfn-for="PublicKeyCredentialCreateOptions">
+<div dfn-type="dict-member" dfn-for="PublicKeyCredentialCreationOptions">
     :   <dfn>rp</dfn>
     ::  This member contains data about the [=[RP]=] responsible for the request.
 
@@ -2280,7 +2280,7 @@ It takes the following input parameters:
 : |userEntity|
 :: The user account's {{PublicKeyCredentialUserEntity}}, containing the [=user handle=] given by the [=[RP]=].
 : |requireResidentKey|
-:: The {{PublicKeyCredentialCreateOptions/authenticatorSelection}}.{{requireResidentKey}} value given by the [=[RP]=].
+:: The {{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}} value given by the [=[RP]=].
 : |requireUserPresence|
 :: A Boolean value provided by the client, which in invocations from a [=[WAC]=]'s
     {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method is always set to the inverse of
@@ -2843,7 +2843,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 
 1. If the attestation statement |attStmt| verified successfully and is found to be trustworthy, then register the new
     credential with the account that was denoted in the
-    {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/options}}.{{PublicKeyCredentialCreateOptions/user}} passed to
+    {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/options}}.{{PublicKeyCredentialCreationOptions/user}} passed to
     {{CredentialsContainer/create()}}, by associating it with the <code>[=credentialId=]</code> and
     <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|, as appropriate for the
     [=[RP]=]'s system.
@@ -3572,7 +3572,7 @@ while the [=CBOR=] <dfn>authenticator extension input</dfn> is
 passed from the client to the authenticator for [=authenticator extensions=] during the processing of these calls.
 
 A [=[RP]=] simultaneously requests the use of an extension and sets its [=client extension input=] by including an entry in the
-{{PublicKeyCredentialCreateOptions/extensions}} option to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} call.
+{{PublicKeyCredentialCreationOptions/extensions}} option to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} call.
 The entry key is the [=extension identifier=] and the value is the [=client extension input=].
 
 <pre class="example" highlight="js">
@@ -4500,7 +4500,7 @@ The below subsections comprise the current Web Authentication-specific security 
 ## Cryptographic Challenges ## {#cryptographic-challenges}
 
 As a cryptographic protocol, Web Authentication is dependent upon randomized challenges
-to avoid replay attacks. Therefore, both {{PublicKeyCredentialCreateOptions/challenge}}'s
+to avoid replay attacks. Therefore, both {{PublicKeyCredentialCreationOptions/challenge}}'s
 and {{PublicKeyCredentialRequestOptions/challenge}}'s value MUST be randomly generated
 by [=[RPS]=] in an environment they trust (e.g., on the server-side), and the
 returned challenge value in the client's


### PR DESCRIPTION
Fixes #773


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/779.html" title="Last updated on Feb 7, 2018, 6:10 PM GMT (5047625)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/779/f13e030...selfissued:5047625.html" title="Last updated on Feb 7, 2018, 6:10 PM GMT (5047625)">Diff</a>