### PR TITLE
fix 746: uniformly define attestation type short identifiers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3050,16 +3050,16 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
                 extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
             - If successful, return attestation type [=Basic=] and [=attestation trust path=] |x5c|.
 
-        1. If |ecdaaKeyId| is present, then the attestation type is ECDAA. In this case:
+        1. If |ecdaaKeyId| is present, then the attestation type is [=ECDAA=]. In this case:
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using
                 ECDAA-Verify with [=ECDAA-Issuer public key=] identified by |ecdaaKeyId| (see [[!FIDOEcdaaAlgorithm]]).
-            - If successful, return attestation type ECDAA and [=attestation trust path=] |ecdaaKeyId|.
+            - If successful, return attestation type [=ECDAA=] and [=attestation trust path=] |ecdaaKeyId|.
 
         1. If neither |x5c| nor |ecdaaKeyId| is present, [=self attestation=] is in use.
             - Validate that |alg| matches the algorithm of the <code>[=credentialPublicKey=]</code> in |authenticatorData|.
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using the
                 credential public key with |alg|.
-            - If successful, return attestation type Self and empty [=attestation trust path=].
+            - If successful, return attestation type [=Self=] and empty [=attestation trust path=].
 
 
 ### Packed attestation statement certificate requirements ### {#packed-attestation-cert-requirements}
@@ -3108,7 +3108,7 @@ engine.
 :: tpm
 
 : Attestation types supported
-:: [=Attestation CA=], [=ECDAA=]
+:: [=AttCA=], [=ECDAA=]
 
 : Syntax
 :: The syntax of a TPM Attestation statement is as follows:
@@ -3199,11 +3199,11 @@ engine.
     - Verify that |x5c| meets the requirements in [[#tpm-cert-requirements]].
     - If |x5c| contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify that the value of this
         extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
-    - If successful, return attestation type [=Attestation CA=] and [=attestation trust path=] |x5c|.
+    - If successful, return attestation type [=AttCA=] and [=attestation trust path=] |x5c|.
 
     If |ecdaaKeyId| is present, then the attestation type is [=ECDAA=].
     - Perform ECDAA-Verify on |sig| to verify that it is a valid signature over |certInfo| (see [[!FIDOEcdaaAlgorithm]]).
-    - If successful, return attestation type ECDAA and the [=identifier of the ECDAA-Issuer public key=] |ecdaaKeyId|.
+    - If successful, return attestation type [=ECDAA=] and the [=identifier of the ECDAA-Issuer public key=] |ecdaaKeyId|.
 
 
 ### TPM attestation statement certificate requirements ### {#tpm-cert-requirements}
@@ -3459,7 +3459,7 @@ The <dfn>none attestation statement format</dfn> is used to replace any [=authen
 :: Return the fixed attestation statement defined above.
 
 : Verification procedure
-:: Return attestation type None with an empty trust path.
+:: Return attestation type [=None=] with an empty trust path.
 
 # WebAuthn Extensions # {#extensions}
 

--- a/index.bs
+++ b/index.bs
@@ -2708,17 +2708,17 @@ The initial list of specified [=attestation statement formats=] is in [[#defined
 
 WebAuthn supports multiple attestation types:
 
-: <dfn>Basic Attestation</dfn>
+: <dfn>Basic Attestation</dfn> (<dfn>Basic</dfn>)
 :: In the case of basic attestation [[UAFProtocol]], the authenticator's attestation key pair is specific to an
     authenticator model.  Thus, authenticators of the same model often share the same attestation key pair. See
     [[#sec-attestation-privacy]] for futher information.
 
-: <dfn>Self Attestation</dfn>
+: <dfn>Self Attestation</dfn> (<dfn>Self</dfn>)
 :: In the case of [=self attestation=], also known as surrogate basic attestation [[UAFProtocol]], the Authenticator does not have
     any specific attestation key. Instead it uses the credential private key to create the attestation signature.
     Authenticators without meaningful protection measures for an attestation private key typically use this attestation type.
 
-: <dfn>Attestation CA</dfn>
+: <dfn>Attestation CA</dfn> (<dfn>AttCA</dfn>)
 :: In this case, an [=authenticator=] is based on a Trusted Platform Module (TPM) and holds an authenticator-specific
     "endorsement key" (EK). This key is used to securely communicate with a trusted third party, the [=Attestation CA=]
     [[!TCG-CMCProfile-AIKCertEnroll]] (formerly known as a "Privacy CA"). The [=authenticator=] can generate multiple

--- a/index.bs
+++ b/index.bs
@@ -2709,7 +2709,7 @@ The initial list of specified [=attestation statement formats=] is in [[#defined
 WebAuthn supports multiple attestation types:
 
 : <dfn>Basic Attestation</dfn> (<dfn>Basic</dfn>)
-:: In the case of basic attestation [[UAFProtocol]], the authenticator's attestation key pair is specific to an
+:: In the case of basic attestation [[UAFProtocol]], the authenticator's [=attestation key pair=] is specific to an
     authenticator model.  Thus, authenticators of the same model often share the same attestation key pair. See
     [[#sec-attestation-privacy]] for futher information.
 
@@ -3020,9 +3020,9 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
         1. Let |authenticatorData| denote the [=authenticator data for the attestation=], 
             and let |clientDataHash| denote the [=hash of the serialized client data=].
 
-        1. If Basic or [=Attestation CA=] attestation is in use, the authenticator produces the |sig| by concatenating |authenticatorData| and
-            |clientDataHash|, and signing the result using an attestation private key selected through an authenticator-specific
-            mechanism. It sets |x5c| to the certificate chain of the attestation public key and |alg| to the algorithm of the
+        1. If [=Basic=] or [=AttCA=] [=attestation=] is in use, the authenticator produces the |sig| by concatenating |authenticatorData| and
+            |clientDataHash|, and signing the result using an [=attestation private key=] selected through an authenticator-specific
+            mechanism. It sets |x5c| to the certificate chain of the [=attestation public key=] and |alg| to the algorithm of the
             attestation private key.
 
         1. If [=ECDAA=] is in use, the authenticator produces |sig| by concatenating |authenticatorData| and |clientDataHash|, and
@@ -3048,7 +3048,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
             - Verify that |x5c| meets the requirements in [[#packed-attestation-cert-requirements]].
             - If |x5c| contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (`id-fido-gen-ce-aaguid`) verify that the value of this
                 extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
-            - If successful, return attestation type Basic and [=attestation trust path=] |x5c|.
+            - If successful, return attestation type [=Basic=] and [=attestation trust path=] |x5c|.
 
         1. If |ecdaaKeyId| is present, then the attestation type is ECDAA. In this case:
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using
@@ -3240,7 +3240,7 @@ the attestation=] is consistent with the fields of the attestation certificate's
 :: android-key
 
 : Attestation types supported
-:: [=Basic Attestation=]
+:: [=Basic=]
 
 : Syntax
 :: An Android key attestation statement consists simply of the Android attestation statement, which is a series of
@@ -3290,7 +3290,7 @@ the attestation=] is consistent with the fields of the attestation certificate's
             [=RP ID=].
         - The value in the `AuthorizationList.origin` field is equal to `KM_TAG_GENERATED`.
         - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
-    - If successful, return attestation type Basic with the [=attestation trust path=] set to |x5c|.
+    - If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
 
 
 ## Android SafetyNet Attestation Statement Format ## {#android-safetynet-attestation}
@@ -3307,7 +3307,7 @@ even if the SafetyNet API is also present.
 :: android-safetynet
 
 : Attestation types supported
-:: [=Basic Attestation=]
+:: [=Basic=]
 
 : Syntax
 :: The syntax of an Android Attestation statement is defined as follows:
@@ -3353,7 +3353,7 @@ even if the SafetyNet API is also present.
     - Verify that the attestation certificate is issued to the hostname "attest.android.com" (see
         [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response)).
     - Verify that the `ctsProfileMatch` attribute in the payload of |response| is true.
-    - If successful, return attestation type Basic with the [=attestation trust path=] set to the above attestation certificate.
+    - If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to the above attestation certificate.
 
 
 ## FIDO U2F Attestation Statement Format ## {#fido-u2f-attestation}
@@ -3365,7 +3365,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
 :: fido-u2f
 
 : Attestation types supported
-:: [=Basic Attestation=], [=Self Attestation=], [=Attestation CA=]
+:: [=Basic=], [=Self=], [=AttCA=]
 
 : Syntax
 :: The syntax of a FIDO U2F attestation statement is defined as follows:
@@ -3431,7 +3431,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     1. Let |verificationData| be the concatenation of (0x00 || |rpIdHash| ||
         |clientDataHash| || |credentialId| || |publicKeyU2F|) (see Section 4.3 of [[!FIDO-U2F-Message-Formats]]).
     1. Verify the |sig| using |verificationData| and |certificate public key| per [[!SEC1]].
-    1. If successful, return attestation type Basic with the [=attestation trust path=] set to |x5c|.
+    1. If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
 
 ## None Attestation Statement Format ## {#none-attestation}
 


### PR DESCRIPTION
fixes https://github.com/w3c/webauthn/issues/746 "attestation type identifiers and their use is only implicitly defined"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/780.html" title="Last updated on Feb 6, 2018, 10:15 PM GMT (e0f0c67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/780/f13e030...e0f0c67.html" title="Last updated on Feb 6, 2018, 10:15 PM GMT (e0f0c67)">Diff</a>