### PR TITLE
fix 745: remove self attstn from U2F attstn format

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3365,7 +3365,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
 :: fido-u2f
 
 : Attestation types supported
-:: [=Basic Attestation=], [=Self Attestation=], [=Attestation CA=]
+:: [=Basic=], [=AttCA=]
 
 : Syntax
 :: The syntax of a FIDO U2F attestation statement is defined as follows:


### PR DESCRIPTION
fixes #745, related to PR #746 (merge latter before this one)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/781.html" title="Last updated on Feb 7, 2018, 4:18 PM GMT (d62e066)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/781/d56d1e7...d62e066.html" title="Last updated on Feb 7, 2018, 4:18 PM GMT (d62e066)">Diff</a>