### PR TITLE
CTAP2 definition fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -102,6 +102,10 @@ spec: credential-management-1; urlPrefix: https://w3c.github.io/webappsec-creden
         text: signal
         text: same-origin with its ancestors; url: same-origin-with-its-ancestors
 
+spec: Geolocation-API; urlPrefix: https://dev.w3.org/geo/api/spec-source.html
+    type: interface
+        text: Coordinates; url: coordinates_interface
+
 spec: mixed-content; urlPrefix: www.w3.org/TR/mixed-content/
     type: dfn
         text: a priori authenticated
@@ -3967,8 +3971,8 @@ WebAuthn [=[RP]=].
 :: None, except creating the authenticator extension input from the client extension input.
 
 : Client extension output
-:: Returns a JavaScript object that encodes the location information in the authenticator extension output as a Coordinates value,
-    as defined by [The W3C Geolocation API Specification](https://dev.w3.org/geo/api/spec-source.html#coordinates_interface).
+:: Returns a JavaScript object that encodes the location information in the authenticator extension output as a {{Coordinates}} value,
+    as defined by [[Geolocation-API]].
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
       Coordinates loc;
@@ -3983,8 +3987,8 @@ WebAuthn [=[RP]=].
 
 : Authenticator extension output
 :: A 
-    [The W3C Geolocation API Specification](https://dev.w3.org/geo/api/spec-source.html#coordinates_interface)
-    Coordinates record encoded as a CBOR map.
+    [[Geolocation-API]]
+    {{Coordinates}} record encoded as a CBOR map.
     Values represented by the "double" type in JavaScript are represented as 64-bit CBOR floating point numbers.
     Per the Geolocation specification, the "latitude", "longitude", and "accuracy" values are required
     and other values such as "altitude" are optional.

--- a/index.bs
+++ b/index.bs
@@ -117,7 +117,7 @@ spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
 
 spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html
     type: dfn
-        text: CTAP canonical CBOR encoding form; url: message-encoding
+        text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
 
 spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-appid-and-facets-v1.2-ps-20170411.html
     type: dfn
@@ -270,9 +270,9 @@ A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain the security
 ## All Conformance Classes ## {#conforming-all-classes}
 
 All [=CBOR=] encoding performed by the members of the above conformance classes MUST be done using the
-[=CTAP canonical CBOR encoding form=]. 
+[=CTAP2 canonical CBOR encoding form=].
 All decoders of the above conformance classes SHOULD reject CBOR that is not validly encoded
-in the [=CTAP canonical CBOR encoding form=] and SHOULD reject messages with duplicate map keys.
+in the [=CTAP2 canonical CBOR encoding form=] and SHOULD reject messages with duplicate map keys.
 
 
 # Dependencies # {#dependencies}
@@ -287,7 +287,7 @@ below and in [[#index-defined-elsewhere]].
 
 : CBOR
 :: A number of structures in this specification, including attestation statements and extensions, are encoded using the
-    [=CTAP canonical CBOR encoding form=] of the Compact Binary Object Representation (<dfn>CBOR</dfn>) [[!RFC7049]],
+    [=CTAP2 canonical CBOR encoding form=] of the Compact Binary Object Representation (<dfn>CBOR</dfn>) [[!RFC7049]],
     as defined in [[!FIDO-CTAP]].
 
 : CDDL
@@ -2582,7 +2582,7 @@ object=] for a given credential. It has the following format:
         <td>variable</td>
         <td>
             The [=credential public key=] encoded in COSE_Key format,
-            as defined in Section 7 of [[RFC8152]], using the [=CTAP canonical CBOR encoding form=].
+            as defined in Section 7 of [[RFC8152]], using the [=CTAP2 canonical CBOR encoding form=].
             The COSE_Key-encoded [=credential public key=] MUST contain the optional "alg" parameter and MUST NOT
             contain any other optional parameters. The "alg" parameter MUST contain a {{COSEAlgorithmIdentifier}} value.
             The encoded [=credential public key=] MUST also contain any additional required parameters stipulated by the
@@ -2621,7 +2621,7 @@ algorithm (ECDSA w/ SHA-256, see [[RFC8152]] [Section 8.1](https://tools.ietf.or
   }
 </pre>
 
-Below is the above Eliptic Curve public key encoded in the [=CTAP canonical CBOR encoding form=], whitespace and line breaks
+Below is the above Eliptic Curve public key encoded in the [=CTAP2 canonical CBOR encoding form=], whitespace and line breaks
 are included here for clarity and to match the [[CDDL]] presentation above:
 
 <pre class="example" highlight="json">


### PR DESCRIPTION
Fixes:

- Changed "CTAP Canonical CBOR" to "CTAP2 Canonical CBOR" to stay in step with proper definition of CTAP1 & CTAP2
- CTAP2 definition will link to the correct section in the next version of the spec

Bonus fixes:

- Added [biblio-reference](https://tabatkins.github.io/bikeshed/#biblio) for Geolocation spec, ensuring that it links properly and actually shows up in bibliography
- Added definition for Coordinates, ensuring that all occurrences link to the Geolocation spec correctly, including in the IDL block


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apowers313/webauthn/pull/783.html" title="Last updated on Feb 7, 2018, 6:07 AM GMT (9495c4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/783/5124c61...apowers313:9495c4a.html" title="Last updated on Feb 7, 2018, 6:07 AM GMT (9495c4a)">Diff</a>