### PR TITLE
Fix #713: Refer JSON deserialization to Infra spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2744,8 +2744,8 @@ structures.
 When registering a new credential, represented by a {{AuthenticatorAttestationResponse}} structure |response|, as part of a
 [=registration=] [=ceremony=], a [=[RP]=] MUST proceed as follows:
 
-1. Perform JSON deserialization on <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> to extract the [=client data=]
-    |C| claimed as collected during the credential creation.
+1. Let |C|, the [=client data=] claimed as collected during the credential creation, be the result of [=parse JSON from
+    bytes|parsing JSON from the bytes=] in <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code>.
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/type}}</code> is `webauthn.create`.
 
@@ -2838,7 +2838,8 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
     {{AuthenticatorResponse/clientDataJSON}}, {{AuthenticatorAssertionResponse/authenticatorData}}, and
     {{AuthenticatorAssertionResponse/signature}} respectively.
 
-1. Perform JSON deserialization on |cData| to extract the [=client data=] |C| used for the signature.
+1. Let |C|, the [=client data=] used for the signature, be the result of [=parse JSON from
+    bytes|parsing JSON from the bytes=] in |cData|.
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/type}}</code> is the string `webauthn.get`.
 


### PR DESCRIPTION
These are the substantive changes from #718, isolated from the editorial changes that have now been merged as #752.

This fixes #713.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emlun/webauthn/pull/785.html" title="Last updated on Feb 7, 2018, 1:43 PM GMT (6eddb42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/785/8233396...emlun:6eddb42.html" title="Last updated on Feb 7, 2018, 1:43 PM GMT (6eddb42)">Diff</a>