### PR TITLE
update masthead and acknowledgements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -30,14 +30,16 @@ Editor: Michael B. Jones, w3cid 38745, Microsoft, mbj@microsoft.com
 Editor: Akshay Kumar, Microsoft, akshayku@microsoft.com
 Editor: Angelo Liao, Microsoft, huliao@microsoft.com
 Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
+Editor: Emil Lundberg, Yubico, emil@yubico.com
 Former Editor: Vijay Bharadwaj, w3cid 55440, Microsoft, vijay.bharadwaj@microsoft.com
 Former Editor: Arnar Birgisson, w3cid 87332, Google, arnarb@google.com
 Former Editor: Hubert Le Van Gong, w3cid 84817, PayPal, hlevangong@paypal.com
-!Contributors: Christiaan Brand
-!Contributors: Emil Lundberg
-!Contributors: Giridhar Mandyam
-!Contributors: Mike West
-!Contributors: Jeffrey Yasskin
+!Contributors: <a href="mailto:cbrand@google.com">Christiaan Brand</a> (Google)
+!Contributors: <a href="mailto:agl@google.com">Adam Langley</a> (Google)
+!Contributors: <a href="mailto:mandyam@qti.qualcomm.com">Giridhar Mandyam</a> (Qualcomm)
+!Contributors: <a href="mailto:mkwst@google.com">Mike West</a> (Google)
+!Contributors: <a href="mailto:Johan.Verrept@vasco.com">Johan Verrept</a> (VASCO Datasecurity)
+!Contributors: <a href="mailto:jyasskin@google.com">Jeffrey Yasskin</a> (Google)
 group: webauthn
 Issue Tracking: Github https://github.com/w3c/webauthn/issues
 !Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/webauthn>web-platform-tests webauthn/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/webauthn>ongoing work</a>)
@@ -4638,28 +4640,41 @@ thus conclude that at least one of the [=public key credential|credentials=] lis
 
 
 # Acknowledgements # {#acknowledgements}
-We thank the following people for their contributions to and thorough review of this specification:
+We thank the following people for their reviews of, and contributions to, this specification:
 Yuriy Ackermann,
+James Barclay,
 Richard Barnes,
 Dominic Battré,
 John Bradley,
 Domenic Denicola,
-John Fontana,
 Rahul Ghosh,
 Brad Hill,
 Jing Jin,
-Adam Langley,
+Wally Jones,
 Ian Kilpatrick,
-Anthony Nadalin,
 Axel Nennker,
+Yoshikazu Nojima,
 Kimberly Paulhamus,
 Adam Powers,
-Wendy Seltzer,
 Yaron Sheffer,
 Anne van Kesteren,
-Johan Verrept,
 and
 Boris Zbarsky.
+
+We thank
+Anthony Nadalin,
+John Fontana,
+and
+Richard Barnes
+for their contributions as co-chairs of the <a href="https://www.w3.org/Webauthn/">Web Authentication Working Group</a>.
+
+We also thank
+Wendy Seltzer,
+Samuel Weiler,
+and
+Harry Halpin
+for their contributions as our W3C Team Contacts.
+
 
 <pre class=biblio>
 {


### PR DESCRIPTION
Our masthead list of editors and contributors can use some modest updating

I'm nominating @emlun as an Editor -- he's been effectively acting in that role. 

This also updates contributors masthead subsection (add: @agl, @jovasco) based on review of the committers to this repo (and renders it such that it matches the Editors formatting-wise), and updates the acknowledgements section with some folks who've added commits, and also acks our co-chairs and Team Contacts. 

WDYT?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/788.html" title="Last updated on Feb 7, 2018, 7:44 PM GMT (81ad4c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/788/ca4cf0f...81ad4c0.html" title="Last updated on Feb 7, 2018, 7:44 PM GMT (81ad4c0)">Diff</a>