### PR TITLE
Add instructions for passing unknown extensions to authenticators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3531,24 +3531,24 @@ understand by encoding the [=authenticator extension output=] value into JSON, p
 present in JSON.
 
 When clients choose to pass through extensions they do not recognize,
-the JavaScript values in the [=client extension input=] values
-are converted to [=CBOR=] values in the [=authenticator extension input=] values.
-When the JavaScript input value is an [=%ArrayBuffer%=], it is converted to a [=CBOR=] byte array.
-When the JavaScript input value is a non-integer number, it is converted to a 64-bit CBOR floating point number.
-Otherwise, when the JavaScript input type corresponds to a JSON type, the conversion is done
+the JavaScript values in the [=client extension inputs=]
+are converted to [=CBOR=] values in the [=authenticator extension inputs=].
+When the JavaScript value is an [=%ArrayBuffer%=], it is converted to a [=CBOR=] byte array.
+When the JavaScript value is a non-integer number, it is converted to a 64-bit CBOR floating point number.
+Otherwise, when the JavaScript type corresponds to a JSON type, the conversion is done
 using the rules defined in Section 4.2 of [[RFC7049]] (Converting from JSON to CBOR),
-but operating on JavaScript inputs rather than JSON inputs.
+but operating on inputs of JavaScript type values rather than inputs of JSON type values.
 Once these conversions are done,
 canonicalization of the resulting [=CBOR=] MUST be performed using the [=CTAP2 canonical CBOR encoding form=].
 
 Likewise, when clients receive outputs from extensions they have passed through that they do not recognize,
-the [=CBOR=] values in the [=authenticator extension output=] values
-are converted to JavaScript values in the [=client extension output=] values.
-When the CBOR input value is a byte string, it is converted to a JavaScript [=%ArrayBuffer%=]
+the [=CBOR=] values in the [=authenticator extension outputs=]
+are converted to JavaScript values in the [=client extension outputs=].
+When the CBOR value is a byte string, it is converted to a JavaScript [=%ArrayBuffer%=]
 (rather than a base64url-encoded string).
-Otherwise, when the CBOR input type corresponds to a JSON type, the conversion is done
+Otherwise, when the CBOR type corresponds to a JSON type, the conversion is done
 using the rules defined in Section 4.1 of [[RFC7049]] (Converting from CBOR to JSON),
-but producing JavaScript outputs rather than JSON outputs.
+but producing outputs of JavaScript type values rather than outputs of JSON type values.
 
 The IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]] can be consulted
 for an up-to-date list of registered WebAuthn Extensions.

--- a/index.bs
+++ b/index.bs
@@ -3530,6 +3530,26 @@ operation. Likewise, clients can choose to produce a [=client extension output=]
 understand by encoding the [=authenticator extension output=] value into JSON, provided that the CBOR output uses only types
 present in JSON.
 
+When clients choose to pass through extensions they do not recognize,
+the JavaScript values in the [=client extension input=] values
+are converted to [=CBOR=] values in the [=authenticator extension input=] values.
+When the JavaScript input value is an [=%ArrayBuffer%=], it is converted to a [=CBOR=] byte array.
+When the JavaScript input value is a non-integer number, it is converted to a 64-bit CBOR floating point number.
+Otherwise, when the JavaScript input type corresponds to a JSON type, the conversion is done
+using the rules defined in Section 4.2 of [[RFC7049]] (Converting from JSON to CBOR),
+but operating on JavaScript inputs rather than JSON inputs.
+Once these conversions are done,
+canonicalization of the resulting [=CBOR=] MUST be performed using the [=CTAP2 canonical CBOR encoding form=].
+
+Likewise, when clients receive outputs from extensions they have passed through that they do not recognize,
+the [=CBOR=] values in the [=authenticator extension output=] values
+are converted to JavaScript values in the [=client extension output=] values.
+When the CBOR input value is a byte string, it is converted to a JavaScript [=%ArrayBuffer%=]
+(rather than a base64url-encoded string).
+Otherwise, when the CBOR input type corresponds to a JSON type, the conversion is done
+using the rules defined in Section 4.1 of [[RFC7049]] (Converting from CBOR to JSON),
+but producing JavaScript outputs rather than JSON outputs.
+
 The IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]] can be consulted
 for an up-to-date list of registered WebAuthn Extensions.
 

--- a/index.bs
+++ b/index.bs
@@ -3550,6 +3550,10 @@ Otherwise, when the CBOR type corresponds to a JSON type, the conversion is done
 using the rules defined in Section 4.1 of [[RFC7049]] (Converting from CBOR to JSON),
 but producing outputs of JavaScript type values rather than outputs of JSON type values.
 
+Note that some clients may choose to implement this pass-through capability under a feature flag.
+Supporting this capability can facilitate innovation, allowing authenticators to experiment with new extensions
+and [=[RPS]=] to use them before there is explicit support for them in clients.
+
 The IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]] can be consulted
 for an up-to-date list of registered WebAuthn Extensions.
 


### PR DESCRIPTION
Fixes #738


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/789.html" title="Last updated on Feb 12, 2018, 8:21 PM GMT (86f9f5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/789/ca4cf0f...selfissued:86f9f5b.html" title="Last updated on Feb 12, 2018, 8:21 PM GMT (86f9f5b)">Diff</a>