### PR TITLE
renamed authenticator-model to sctn-authenticator-model 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -255,7 +255,7 @@ A conforming User Agent MUST also be a conforming implementation of the IDL frag
 
 ## Authenticators ## {#conforming-authenticators}
 
-An [=authenticator=] MUST provide the operations defined by [[#authenticator-model]], and those operations MUST behave as
+An [=authenticator=] MUST provide the operations defined by [[#sctn-authenticator-model]], and those operations MUST behave as
 described there. This is a set of functional and security requirements for an authenticator to be usable by a [=Conforming User
 Agent=].
 
@@ -2056,7 +2056,7 @@ The value {{UserVerificationRequirement/discouraged}} indicates that the [=[RP]=
 during the operation (e.g., in the interest of minimizing disruption to the user interaction flow).
 
 
-# WebAuthn <dfn>Authenticator Model</dfn> # {#authenticator-model}
+# WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 
 [[#api|The Web Authentication API]] implies a specific abstract functional model for an [=authenticator=]. This section
 describes that [=authenticator model=].


### PR DESCRIPTION
avoid bikeshed warning regarding multiple elements with same ID


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/790.html" title="Last updated on Feb 8, 2018, 7:30 AM GMT (bfbc8a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/790/ca4cf0f...bfbc8a0.html" title="Last updated on Feb 8, 2018, 7:30 AM GMT (bfbc8a0)">Diff</a>