### PR TITLE
Fix feature detection.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4370,7 +4370,7 @@ In this flow, the [=[RP]=] does not have a preference for [=platform authenticat
 The sample code for generating and registering a new key follows:
 
 <pre class="example" highlight="js">
-    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Platform not capable. Handle error. */ }
 
     var publicKey = {
       // The challenge must be produced by the server, see the Security Considerations
@@ -4436,7 +4436,7 @@ a [=user verification|user-verifying=] [=platform authenticator=].
     Upon successful credential creation, the RP script conveys the new credential to the server.
 
 <pre class="example" highlight="js">
-    if (!PublicKeyCredential) { /* Platform not capable of the API. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Platform not capable of the API. Handle error. */ }
 
     PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
         .then(function (userIntent) {
@@ -4501,7 +4501,7 @@ If the [=[RP]=] script does not have any hints available (e.g., from locally sto
 credentials, then the sample code for performing such an authentication might look like this:
 
 <pre class="example" highlight="js">
-    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Platform not capable. Handle error. */ }
 
     var options = {
                     // The challenge must be produced by the server, see the Security Considerations
@@ -4523,7 +4523,7 @@ performing such an authentication might look like the following. Note that this 
 extension for transaction authorization.
 
 <pre class="example" highlight="js">
-    if (!PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Platform not capable. Handle error. */ }
 
     var encoder = new TextEncoder();
     var acceptableCredential1 = {


### PR DESCRIPTION
The current feature detection code will throw a 'ReferenceError', as 'PublicKeyCredential'
doesn't exist. Adding 'window.' turns it into a property lookup, which fails gracefully.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mikewest/webauthn/pull/808.html" title="Last updated on Feb 19, 2018, 8:08 AM GMT (1fe138a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/808/05335d4...mikewest:1fe138a.html" title="Last updated on Feb 19, 2018, 8:08 AM GMT (1fe138a)">Diff</a>