### PR TITLE
Plumb CTAP's authorized "already registered" error through to RP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -939,8 +939,17 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 |authenticator| and [=set/remove=] it from |issuedRequests|.
             1. Return a {{DOMException}} whose name is "{{InvalidStateError}}" and terminate this algorithm.
 
+            Note: This error status is handled separately because the |authenticator| returns it only if
+            |excludeCredentialDescriptorList| identifies a credential bound to the |authenticator| and the user has confirmed
+            [=user consent|consent=] for the operation. Because of this consent, it is acceptable for this case to be
+            distinguishable to the [=[RP]=].
+
         :   If any |authenticator| returns an error status not equivalent to "{{InvalidStateError}}",
         ::  [=set/Remove=] |authenticator| from |issuedRequests|.
+
+            Note: This case does not imply [=user consent=] for the operation, so details about the error must be hidden from the
+            [=[RP]=] in order to prevent leak of potentially identifying information. See [[#sec-make-credential-privacy]] for
+            details.
 
         :   If any |authenticator| indicates success,
         ::  1.  [=set/Remove=] |authenticator| from |issuedRequests|.
@@ -4740,24 +4749,45 @@ in several ways, including:
     signature using the [=ECDAA-Issuer public key=], but the attestation signature does not serve as a global correlation handle.
 
 
-## Registration and Authentication Ceremonies Privacy ## {#sec-assertion-privacy}
+## Registration Ceremony Privacy ## {#sec-make-credential-privacy}
 
 In order to protect users from being identified without [=user consent|consent=], implementations of the
-{{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and
-{{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} methods need to take care to
-not leak information that could enable a malicious [=[RP]=] to distinguish between these cases, where "named" means that the
-[=public key credential|credential=] is listed by the [=[RP]=] in either {{MakePublicKeyCredentialOptions/excludeCredentials}}
-or {{PublicKeyCredentialRequestOptions/allowCredentials}}, as applicable:
+{{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method need to take care to not leak information that
+could enable a malicious [=[RP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
+credential|credentials=] listed by the [=[RP]=] in {{MakePublicKeyCredentialOptions/excludeCredentials}} is bound to the
+[=authenticator=]:
+
+- No [=authenticators=] are present.
+- At least one [=authenticator=] is present, and at least one present [=authenticator=] is excluded.
+
+If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing for
+which [=public key credential|credentials=] are available. For example, one such information leak is if the client returns a
+failure response as soon as an excluded [=authenticator=] becomes available. In this case - especially if the excluded
+[=authenticator=] is a [=platform authenticator=] - the [=[RP]=] could detect that the [=ceremony=] was canceled before the
+timeout and before the user could feasibly have canceled it manually, and thus conclude that at least one of the [=public key
+credential|credentials=] listed in the {{MakePublicKeyCredentialOptions/excludeCredentials}} parameter is available to the user.
+
+The above is not a concern, however, if the user has confirmed [=user consent|consent=] to create a new credential before a
+distinguishable error is returned, because in this case the user has confirmed intent to share the information that would be
+leaked.
+
+
+## Authentication Ceremony Privacy ## {#sec-assertion-privacy}
+
+In order to protect users from being identified without [=user consent|consent=], implementations of the
+{{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method need to take care to not
+leak information that could enable a malicious [=[RP]=] to distinguish between these cases, where "named" means that the [=public
+key credential|credential=] is listed by the [=[RP]=] in {{PublicKeyCredentialRequestOptions/allowCredentials}}:
 
 - A named [=public key credential|credential=] is not available.
 - A named [=public key credential|credential=] is available, but the user does not [=user consent|consent=] to use it.
 
 If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing
 for which [=public key credential|credentials=] are available. For example, one such information leak is if the client returns a
-failure response as soon as the user denies [=user consent|consent=] to proceed with a [=registration=] or [=authentication=]
-[=ceremony=]. In this case the [=[RP]=] could detect that the [=ceremony=] was canceled by the user and not the timeout, and
-thus conclude that at least one of the [=public key credential|credentials=] listed in the
-{{PublicKeyCredentialRequestOptions/allowCredentials}} parameter is available to the user.
+failure response as soon as the user denies [=user consent|consent=] to proceed with an [=authentication=] [=ceremony=]. In this
+case the [=[RP]=] could detect that the [=ceremony=] was canceled by the user and not the timeout, and thus conclude that at least
+one of the [=public key credential|credentials=] listed in the {{PublicKeyCredentialRequestOptions/allowCredentials}} parameter is
+available to the user.
 
 
 # Acknowledgements # {#acknowledgements}

--- a/index.bs
+++ b/index.bs
@@ -940,8 +940,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Return a {{DOMException}} whose name is "{{InvalidStateError}}" and terminate this algorithm.
 
             Note: This error status is handled separately because the |authenticator| returns it only if
-            |excludeCredentialDescriptorList| identifies a credential bound to the |authenticator| and the user has confirmed
-            [=user consent|consent=] for the operation. Because of this consent, it is acceptable for this case to be
+            |excludeCredentialDescriptorList| identifies a credential bound to the |authenticator| and the user has [=user
+            consent|consented=] to the operation. Given this explicit consent, it is acceptable for this case to be
             distinguishable to the [=[RP]=].
 
         :   If any |authenticator| returns an error status not equivalent to "{{InvalidStateError}}",
@@ -4767,7 +4767,7 @@ failure response as soon as an excluded [=authenticator=] becomes available. In 
 timeout and before the user could feasibly have canceled it manually, and thus conclude that at least one of the [=public key
 credential|credentials=] listed in the {{MakePublicKeyCredentialOptions/excludeCredentials}} parameter is available to the user.
 
-The above is not a concern, however, if the user has confirmed [=user consent|consent=] to create a new credential before a
+The above is not a concern, however, if the user has [=user consent|consented=] to create a new credential before a
 distinguishable error is returned, because in this case the user has confirmed intent to share the information that would be
 leaked.
 

--- a/index.bs
+++ b/index.bs
@@ -933,7 +933,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 Note: [=Authenticators=] may return an indication of "the user cancelled the entire operation".
                 How a user agent manifests this state to users is unspecified.
 
-        :   If any |authenticator| returns an error status,
+        :   If any |authenticator| returns an error status equivalent to "{{InvalidStateError}}",
+        ::  1. [=set/Remove=] |authenticator| from |issuedRequests|.
+            1. [=set/For each=] remaining |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on
+                |authenticator| and [=set/remove=] it from |issuedRequests|.
+            1. Return a {{DOMException}} whose name is "{{InvalidStateError}}" and terminate this algorithm.
+
+        :   If any |authenticator| returns an error status not equivalent to "{{InvalidStateError}}",
         ::  [=set/Remove=] |authenticator| from |issuedRequests|.
 
         :   If any |authenticator| indicates success,
@@ -2337,8 +2343,16 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
     1.  If [=credential id/looking up=] <code>|descriptor|.{{PublicKeyCredentialDescriptor/id}}</code> in this authenticator
         returns non-`null`, and the returned [=list/item=]'s [=RP ID=] and [=type=] match
         <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and
-        <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code> respectively, then
-        return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
+        <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code> respectively, then obtain [=user
+        consent=] for creating a new credential. The method of obtaining [=user consent=] MUST include a [=test
+        of user presence=]. If the user
+        <dl class="switch">
+            :   confirms consent to create a new credential
+            ::  return an error code equivalent to "{{InvalidStateError}}" and terminate the operation.
+
+            :   does not consent to create a new credential
+            ::  return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
+        </dl>
 
 1. If |requireResidentKey| is `true` and the authenticator cannot store a [=Client-side-resident Credential
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.


### PR DESCRIPTION
This fixes #806, and relates to #184, #204 and #777.

To do before merging
---

- [x] Review choice of `DOMException` error name

  I'm not sure [`InvalidStateError`][invalidstateerror] is the most suitable error name for this. Suggestions for other error names are very welcome.


Background
---

The [latest publicly published draft of CTAP2][ctap2-public] lists the first step of the `authenticatorMakeCredential` command as

>1. If the excludeList parameter is present and contains a credential ID that is present on this authenticator, terminate this procedure and return error code CTAP2_ERR_CREDENTIAL_EXCLUDED.

In WebAuthn this error condition is currently hidden from the RP, by making it indistinguishable from the operation timing out, in order to not leak potentially identifying information without the user's consent.

However as @leshi points out in #806, the current internal draft of CTAP2 instead lists this first step as

>1. If the excludeList parameter is present and contains a credential ID that is present on this authenticator and bound to the specified rpId, wait for user presence, then terminate this procedure and return error code CTAP2_ERR_CREDENTIAL_EXCLUDED. User presence check is required for CTAP2 authenticators before the RP gets told that the token is already registered to behave similarly to CTAP1/U2F authenticators.

Since the new language requires that the user authorizes returning the CTAP2_ERR_CREDENTIAL_EXCLUDED error, returning this error early no longer constitutes an undesirable information leak - because the user has clearly indicated consent to share the information that would be leaked. Making this error distinguishable enables the RP to detect if the user attempts to register an authenticator they have already registered, and help them retry with a different authenticator.

[ctap2-public]: https://fidoalliance.org/specs/fido-v2.0-rd-20170927/fido-client-to-authenticator-protocol-v2.0-rd-20170927.html#h3_authenticatorMakeCredential
[invalidstateerror]: https://heycam.github.io/webidl/#invalidstateerror


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emlun/webauthn/pull/809.html" title="Last updated on Feb 21, 2018, 7:26 PM GMT (5f96e03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/809/05335d4...emlun:5f96e03.html" title="Last updated on Feb 21, 2018, 7:26 PM GMT (5f96e03)">Diff</a>