### PR TITLE
Change from getClientExtensionResults function to clientExtensionResults attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -620,7 +620,7 @@ that are returned to the caller when a new credential is created, or a new asser
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
         [SameObject] readonly attribute AuthenticatorResponse    response;
-        AuthenticationExtensionsClientOutputs getClientExtensionResults();
+        [SameObject] readonly attribute AuthenticationExtensionsClientOutputs clientExtensionResults;
     };
 </xmp>
 <dl dfn-type="attribute" dfn-for="PublicKeyCredential">
@@ -639,8 +639,8 @@ that are returned to the caller when a new credential is created, or a new asser
         the {{PublicKeyCredential}} was created in response to {{CredentialsContainer/get()}}, and this attribute's value
         will be an {{AuthenticatorAssertionResponse}}.
 
-    :   {{PublicKeyCredential/getClientExtensionResults()}}
-    ::  This operation returns the value of {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing
+    :   <dfn>clientExtensionResults</dfn>
+    ::  The {{PublicKeyCredential/[[clientExtensionsResults]]}} value is a [=map=] containing
         [=extension identifier=] → [=client extension output=] entries produced by the extension's
         [=client extension processing=].
 
@@ -3688,7 +3688,7 @@ Supported [=client extensions=] are recorded as a dictionary in the [=client dat
 {{CollectedClientData/clientExtensions}}. For each such extension, the client adds an entry to this dictionary with the
 [=extension identifier=] as the key, and the extension's [=client extension input=] as the value.
 
-Likewise, the [=client extension outputs=] are represented as a dictionary in the result of {{PublicKeyCredential/getClientExtensionResults()}}
+Likewise, the [=client extension outputs=] are represented as a dictionary in the {{PublicKeyCredential/clientExtensionResults}} value,
 with [=extension identifiers=] as keys, and the <dfn>client extension output</dfn> value of each extension as the value.
 Like the [=client extension input=], the [=client extension output=] is a value that can be encoded in JSON.
 


### PR DESCRIPTION
Fixes part of #803


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/810.html" title="Last updated on Feb 21, 2018, 10:31 PM GMT (c6bb3fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/810/05335d4...selfissued:c6bb3fe.html" title="Last updated on Feb 21, 2018, 10:31 PM GMT (c6bb3fe)">Diff</a>