### PR TITLE
Fix #712: Refer to the JSON object as %JSON%

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -69,6 +69,7 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
         for: JSON; text: stringify; url: sec-json.stringify
     type: dfn
         text: %ArrayBuffer%; url: sec-arraybuffer-constructor
+        text: %JSON%; url: sec-json-object
         url: sec-object-internal-methods-and-internal-slots
             text: internal method
             text: internal slot
@@ -309,7 +310,7 @@ below and in [[#index-defined-elsewhere]].
 :: {{DOMException}} and the DOMException values used in this specification are defined in [[!DOM4]].
 
 : ECMAScript
-:: [=%ArrayBuffer%=] is defined in [[!ECMAScript]].
+:: [=%ArrayBuffer%=] and [=%JSON%=] are defined in [[!ECMAScript]].
 
 : HTML
 :: The concepts of [=relevant settings object=], [=origin=],
@@ -1962,7 +1963,7 @@ following Web IDL.
     This structure is used by the client to compute the following quantities:
 
     : <dfn dfn>JSON-serialized client data</dfn>
-    :: This is the [=UTF-8 encoding=] of the result of calling the initial value of {{JSON/stringify|JSON.stringify}} on a
+    :: This is the [=UTF-8 encoding=] of the result of calling [=%JSON%=].{{JSON/stringify|stringify}} on a
         {{CollectedClientData}} dictionary.
 
     : <dfn dfn>Hash of the serialized client data</dfn>


### PR DESCRIPTION
This fixes #712.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emlun/webauthn/pull/813.html" title="Last updated on Feb 21, 2018, 1:19 PM GMT (9a091f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/813/3a3700a...emlun:9a091f2.html" title="Last updated on Feb 21, 2018, 1:19 PM GMT (9a091f2)">Diff</a>