### PR TITLE
Change uses of acme.com to example.com

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,8 +27,8 @@ Editor: Alexei Czeskis, w3cid 87258, Google, aczeskis@google.com
 Editor: Jeff Hodges, w3cid 43843, PayPal, Jeff.Hodges@paypal.com
 Editor: J.C. Jones, w3cid 87240, Mozilla, jc@mozilla.com
 Editor: Michael B. Jones, w3cid 38745, Microsoft, mbj@microsoft.com
-Editor: Akshay Kumar, Microsoft, akshayku@microsoft.com
-Editor: Angelo Liao, Microsoft, huliao@microsoft.com
+Editor: Akshay Kumar, w3cid 99318, Microsoft, akshayku@microsoft.com
+Editor: Angelo Liao, w3cid 94342, Microsoft, huliao@microsoft.com
 Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
 Editor: Emil Lundberg, Yubico, emil@yubico.com
 Former Editor: Vijay Bharadwaj, w3cid 55440, Microsoft, vijay.bharadwaj@microsoft.com
@@ -1638,7 +1638,7 @@ associated.
             for display. For example, "ACME Corporation", "Wonderful Widgets, Inc." or "Awesome Site".
           - When inherited by {{PublicKeyCredentialUserEntity}}, it is a [=human palatability|human-palatable=] identifier for a
             user account. It is intended only for display, and SHOULD allow the user to easily tell the difference between user
-            accounts with similar {{PublicKeyCredentialUserEntity/displayName}}s. For example, "alexm", "alex.p.mueller@acme.com"
+            accounts with similar {{PublicKeyCredentialUserEntity/displayName}}s. For example, "alexm", "alex.p.mueller@example.com"
             or "+14255551234". The [=[RP]=] MAY let the user choose this, and MAY restrict the choice as needed or appropriate.
             For example, a [=[RP]=] might choose to map [=human palatability|human-palatable=] [=username=] account identifiers to
             the {{PublicKeyCredentialEntity/name}} member of {{PublicKeyCredentialUserEntity}}.
@@ -4439,7 +4439,7 @@ The sample code for generating and registering a new key follows:
         id: Uint8Array.from(window.atob("MIIBkzCCATigAwIBAjCCAZMwggE4oAMCAQIwggGTMII="), c=>c.charCodeAt(0)),
         name: "alex.p.mueller@example.com",
         displayName: "Alex P. Müller",
-        icon: "https://pics.acme.com/00/p/aBjjjpqPb.png"
+        icon: "https://pics.example.com/00/p/aBjjjpqPb.png"
       },
 
       // This Relying Party will accept either an ES256 or RS256 credential, but


### PR DESCRIPTION
The URL acme.com is not appropriate to use for examples because it is not reserved for this usage.  This PR changes uses of acme.com to example.com, which is reserved for use in examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/814.html" title="Last updated on Feb 22, 2018, 12:14 AM GMT (37ce38c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/814/3ceed42...selfissued:37ce38c.html" title="Last updated on Feb 22, 2018, 12:14 AM GMT (37ce38c)">Diff</a>