### PR TITLE
Emphasise that the CollectedClientData can be extended.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1926,7 +1926,7 @@ follows.
 
 The <dfn>client data</dfn> represents the contextual bindings of both the [=[RP]=] and the client platform. It is a key-value
 mapping with string-valued keys. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
-following Web IDL.
+following Web IDL but it's important to note that it may be extended in the future. Therefore it's critical when parsing to be tolerant of unknown keys and of any reordering of the keys.
 
 <pre class="idl">
     dictionary CollectedClientData {

--- a/index.bs
+++ b/index.bs
@@ -1926,7 +1926,9 @@ follows.
 
 The <dfn>client data</dfn> represents the contextual bindings of both the [=[RP]=] and the client platform. It is a key-value
 mapping with string-valued keys. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
-following Web IDL but it's important to note that it may be extended in the future. Therefore it's critical when parsing to be tolerant of unknown keys and of any reordering of the keys.
+following Web IDL.
+
+Note: The {{CollectedClientData}} may be extended in the future. Therefore it's critical when parsing to be tolerant of unknown keys and of any reordering of the keys.
 
 <pre class="idl">
     dictionary CollectedClientData {


### PR DESCRIPTION
There is a risk that RPs will implement overly simplistic parsing of the `CollectedClientData` and end up intolerant of any future additions. This change emphasises the need to parse it properly and will be coupled with a behaviour in Chrome that inserts a key (`new_keys_may_be_added_here`) in a random 20% of cases.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/827.html" title="Last updated on Mar 13, 2018, 6:40 PM GMT (200f12a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/827/716a169...agl:200f12a.html" title="Last updated on Mar 13, 2018, 6:40 PM GMT (200f12a)">Diff</a>