### PR TITLE
Add RP conformance section on ignoring attestation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ external hardware, or a combination of both.
 ## [RPS] ## {#conforming-relying-parties}
 
 A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain all the security benefits offered by this specification. See
-[[#sctn-rp-benefits]] for a detailed discussion of this.
+[[#sctn-rp-benefits]] for further discussion of this.
 
 
 ## All Conformance Classes ## {#conforming-all-classes}
@@ -4758,28 +4758,30 @@ The main benefits offered to [=[RPS]=] by this specification include:
 1. The [=[RP]=] can automatically support multiple types of [=user verification=] - for example PIN, biometrics and/or future
     methods - with little or no code change, and can let each user decide which they prefer to use via their choice of
     [=authenticator=].
-1. The [=[RP]=] does not need to store any secrets or sensitive information in order to gain the above benefits.
+1. The [=[RP]=] does not need to store additional secrets in order to gain the above benefits.
 
 As stated in the [[#conforming-relying-parties|Conformance]] section, the [=[RP]=] MUST behave as described in [[#rp-operations]]
 to obtain all of the above security benefits. However, one notable use case that departs slightly from this is described in the
 next section.
 
 
-### Self Attestation and Ignoring Attestation ### {#sctn-no-attestation-security-attestation}
+### Considerations for Self and None Attestation Types and Ignoring Attestation ### {#sctn-no-attestation-security-attestation}
 
 When [[#registering-a-new-credential|registering a new credential]], the [=[RP]=] MAY choose to accept an [=attestation
-statement=] with [=self attestation=] or [=no attestation statement|no attestation=], or to not verify the [=attestation
-statement=] at all. In all of these cases the [=[RP]=] loses much of benefit (3) listed above, but retains the other benefits.
+statement=] of [[#sctn-attestation-types|type]] [=self attestation|Self=] or [=no attestation statement|None=], or to not verify
+the [=attestation statement=]. In all of these cases the [=[RP]=] loses much of benefit (3) listed above, but retains the other
+benefits.
 
 In these cases it is possible for a [=man-in-the-middle attack|man-in-the-middle attacker=] - for example, a malicious [=client=]
-or script - to replace the [=credential public key=] to be registered, and subsequently tamper with any future [=assertion=]
-[=ceremony=] that passes through the same attacker. [=Authentication=] [=ceremonies=] are still highly resistant to
-[=man-in-the-middle attacks=], but only against attackers that were not present at the time of [=registration=]. Accepting these
-kinds of [=attestation statements=] therefore constitutes a [=leap of faith=]. Note, however, that such an attack would be easy to
-detect and very difficult to maintain, since any [=assertion=] [=ceremony=] that the same attacker does not or cannot tamper with
-would always fail.
+or script - to replace the [=credential public key=] to be registered, and subsequently tamper with future [=authentication
+assertions=] bound for the same [=[RP]=] and passing through the same attacker. Accepting these [[#sctn-attestation-types|types]]
+of [=attestation statements=] therefore constitutes a [=leap of faith=]. In cases where [=registration=] was accomplished
+securely, subsequent [=authentication=] [=ceremonies=] remain resistant to [=man-in-the-middle attacks=], i.e., benefit (3) is
+retained. Note, however, that such an attack would be easy to detect and very difficult to maintain, since any [=authentication=]
+[=ceremony=] that the same attacker does not or cannot tamper with would always fail.
 
-The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [=attestation statements=] to accept.
+The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [[#sctn-attestation-types|attestation
+types]] to accept or whether to ignore [=attestation=].
 
 
 ## credentialId Unsigned ## {#credentialIdSecurity}

--- a/index.bs
+++ b/index.bs
@@ -4751,7 +4751,9 @@ The main benefits offered to [=[RPS]=] by this specification include:
 
 1. Users and accounts can be secured using widely compatible, easy-to-use multi-factor authentication.
 1. The [=[RP]=] does not need to provision [=authenticator=] hardware to its users. Instead, each user can independently obtain
-    any conforming [=authenticator=] and use that same [=authenticator=] with any number of [=[RPS]=].
+    any conforming [=authenticator=] and use that same [=authenticator=] with any number of [=[RPS]=]. The [=[RP]=] can optionally
+    enforce requirements on [=authenticators=]' security properties by inspecting the [=attestation statements=] returned from the
+    [=authenticators=].
 1. [=Registration=] and [=authentication=] [=ceremonies=] are highly resistant to [=man-in-the-middle attacks=].
 1. The [=[RP]=] can automatically support multiple types of [=user verification=] - for example PIN, biometrics and/or future
     methods - with little or no code change, and can let each user decide which they prefer to use via their choice of

--- a/index.bs
+++ b/index.bs
@@ -132,6 +132,7 @@ spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-201
 
 spec: RFC4949; urlPrefix: https://tools.ietf.org/html/rfc4949
     type: dfn
+        text: leap of faith; url: page-182
         text: man-in-the-middle attack; url: page-186
 
 </pre> <!-- class=anchors -->
@@ -4771,9 +4772,10 @@ statement=] at all. In all of these cases the [=[RP]=] loses much of benefit (3)
 In these cases it is possible for a [=man-in-the-middle attack|man-in-the-middle attacker=] - for example, a malicious [=client=]
 or script - to replace the [=credential public key=] to be registered, and subsequently tamper with any future [=assertion=]
 [=ceremony=] that passes through the same attacker. [=Authentication=] [=ceremonies=] are still highly resistant to
-[=man-in-the-middle attacks=], but only against attackers that were not present at the time of [=registration=]. Note, however,
-that such an attack would be easy to detect and very difficult to maintain, since any [=assertion=] [=ceremony=] that the same
-attacker does not or cannot tamper with would always fail.
+[=man-in-the-middle attacks=], but only against attackers that were not present at the time of [=registration=]. Accepting these
+kinds of [=attestation statements=] therefore constitutes a [=leap of faith=]. Note, however, that such an attack would be easy to
+detect and very difficult to maintain, since any [=assertion=] [=ceremony=] that the same attacker does not or cannot tamper with
+would always fail.
 
 The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [=attestation statements=] to accept.
 

--- a/index.bs
+++ b/index.bs
@@ -4783,6 +4783,10 @@ retained. Note, however, that such an attack would be easy to detect and very di
 The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [[#sctn-attestation-types|attestation
 types]] to accept or whether to ignore [=attestation=].
 
+Note: The default [[#sctn-attestation-types|attestation type]] is [=None=], since the above issues will likely not be a major
+concern in most [=[RPS]=]' threat models. For example, the [=man-in-the-middle attack=] described above is more difficult than a
+[=man-in-the-middle attack=] against a [=[RP]=] that only uses conventional password authentication.
+
 
 ## credentialId Unsigned ## {#credentialIdSecurity}
 

--- a/index.bs
+++ b/index.bs
@@ -283,6 +283,22 @@ main benefits include:
     [=authenticator=].
 1. The [=[RP]=] does not need to store any secrets or sensitive information in order to gain the above benefits.
 
+### Ignoring Attestation ### {#sctn-conformance-ignoring-attestation}
+
+When [[#registering-a-new-credential|registering a new credential]], the [=[RP]=] MAY choose to accept an [=attestation
+statement=] with [=self attestation=] or [=no attestation statement|no attestation=], or to not verify the [=attestation
+statement=] at all. In all of these cases the [=[RP]=] loses much of benefit (3) above, but retains the other benefits.
+
+In these cases it is possible for a man-in-the-middle attacker - for example, a malicious [=client=] or script - to replace the
+[=credential public key=] to be registered, and subsequently tamper with any future [=assertion=] [=ceremony=] that passes through
+the same attacker. [=Authentication=] [=ceremonies=] are still highly resistant to man-in-the-middle attacks, but only against
+attackers that were not present at the time of [=registration=]. Note, however, that such an attack would be easy to detect and
+very difficult to maintain, since any [=assertion=] [=ceremony=] that the same attacker does not or cannot tamper with would
+always fail.
+
+The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [=attestation statements=] to accept.
+
+
 
 ## All Conformance Classes ## {#conforming-all-classes}
 

--- a/index.bs
+++ b/index.bs
@@ -271,33 +271,8 @@ external hardware, or a combination of both.
 
 ## [RPS] ## {#conforming-relying-parties}
 
-A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain all the security benefits offered by this specification. The
-main benefits include:
-
-1. Users and accounts can be secured using widely compatible, easy-to-use multi-factor authentication.
-1. The [=[RP]=] does not need to provision [=authenticator=] hardware to its users. Instead, each user can independently obtain
-    any conforming [=authenticator=] and use that same [=authenticator=] with any number of [=[RPS]=].
-1. [=Registration=] and [=authentication=] [=ceremonies=] are highly resistant to man-in-the-middle attacks.
-1. The [=[RP]=] can automatically support multiple types of [=user verification=] - for example PIN, biometrics and/or future
-    methods - with little or no code change, and can let each user decide which they prefer to use via their choice of
-    [=authenticator=].
-1. The [=[RP]=] does not need to store any secrets or sensitive information in order to gain the above benefits.
-
-### Ignoring Attestation ### {#sctn-conformance-ignoring-attestation}
-
-When [[#registering-a-new-credential|registering a new credential]], the [=[RP]=] MAY choose to accept an [=attestation
-statement=] with [=self attestation=] or [=no attestation statement|no attestation=], or to not verify the [=attestation
-statement=] at all. In all of these cases the [=[RP]=] loses much of benefit (3) above, but retains the other benefits.
-
-In these cases it is possible for a man-in-the-middle attacker - for example, a malicious [=client=] or script - to replace the
-[=credential public key=] to be registered, and subsequently tamper with any future [=assertion=] [=ceremony=] that passes through
-the same attacker. [=Authentication=] [=ceremonies=] are still highly resistant to man-in-the-middle attacks, but only against
-attackers that were not present at the time of [=registration=]. Note, however, that such an attack would be easy to detect and
-very difficult to maintain, since any [=assertion=] [=ceremony=] that the same attacker does not or cannot tamper with would
-always fail.
-
-The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [=attestation statements=] to accept.
-
+A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain all the security benefits offered by this specification. See
+[[#sctn-rp-benefits]] for a detailed discussion of this.
 
 
 ## All Conformance Classes ## {#conforming-all-classes}
@@ -4763,6 +4738,40 @@ If an [=ECDAA=] attestation key has been compromised, it can be added to the Rog
 authenticators) maintained by the related ECDAA-Issuer. The [=[RP]=] SHOULD verify whether an authenticator belongs to the
 RogueList when performing ECDAA-Verify (see section 3.6 in [[!FIDOEcdaaAlgorithm]]). For example, the FIDO Metadata Service
 [[FIDOMetadataService]] provides one way to access such information.
+
+
+## Security Benefits for [RPS] ## {#sctn-rp-benefits}
+
+The main benefits offered to [=[RPS]=] by this specification include:
+
+1. Users and accounts can be secured using widely compatible, easy-to-use multi-factor authentication.
+1. The [=[RP]=] does not need to provision [=authenticator=] hardware to its users. Instead, each user can independently obtain
+    any conforming [=authenticator=] and use that same [=authenticator=] with any number of [=[RPS]=].
+1. [=Registration=] and [=authentication=] [=ceremonies=] are highly resistant to man-in-the-middle attacks.
+1. The [=[RP]=] can automatically support multiple types of [=user verification=] - for example PIN, biometrics and/or future
+    methods - with little or no code change, and can let each user decide which they prefer to use via their choice of
+    [=authenticator=].
+1. The [=[RP]=] does not need to store any secrets or sensitive information in order to gain the above benefits.
+
+As stated in the [[#conforming-relying-parties|Conformance]] section, the [=[RP]=] MUST behave as described in [[#rp-operations]]
+to obtain all of the above security benefits. However, one notable use case that departs slightly from this is described in the
+next section.
+
+
+### Self Attestation and Ignoring Attestation ### {#sctn-no-attestation-security-attestation}
+
+When [[#registering-a-new-credential|registering a new credential]], the [=[RP]=] MAY choose to accept an [=attestation
+statement=] with [=self attestation=] or [=no attestation statement|no attestation=], or to not verify the [=attestation
+statement=] at all. In all of these cases the [=[RP]=] loses much of benefit (3) listed above, but retains the other benefits.
+
+In these cases it is possible for a man-in-the-middle attacker - for example, a malicious [=client=] or script - to replace the
+[=credential public key=] to be registered, and subsequently tamper with any future [=assertion=] [=ceremony=] that passes through
+the same attacker. [=Authentication=] [=ceremonies=] are still highly resistant to man-in-the-middle attacks, but only against
+attackers that were not present at the time of [=registration=]. Note, however, that such an attack would be easy to detect and
+very difficult to maintain, since any [=assertion=] [=ceremony=] that the same attacker does not or cannot tamper with would
+always fail.
+
+The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [=attestation statements=] to accept.
 
 
 ## credentialId Unsigned ## {#credentialIdSecurity}

--- a/index.bs
+++ b/index.bs
@@ -271,7 +271,18 @@ external hardware, or a combination of both.
 
 ## [RPS] ## {#conforming-relying-parties}
 
-A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain the security benefits offered by this specification.
+A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain all the security benefits offered by this specification. The
+main benefits include:
+
+1. Users and accounts can be secured using widely compatible, easy-to-use multi-factor authentication.
+1. The [=[RP]=] does not need to provision [=authenticator=] hardware to its users. Instead, each user can independently obtain
+    any conforming [=authenticator=] and use that same [=authenticator=] with any number of [=[RPS]=].
+1. [=Registration=] and [=authentication=] [=ceremonies=] are highly resistant to man-in-the-middle attacks.
+1. The [=[RP]=] can automatically support multiple types of [=user verification=] - for example PIN, biometrics and/or future
+    methods - with little or no code change, and can let each user decide which they prefer to use via their choice of
+    [=authenticator=].
+1. The [=[RP]=] does not need to store any secrets or sensitive information in order to gain the above benefits.
+
 
 ## All Conformance Classes ## {#conforming-all-classes}
 

--- a/index.bs
+++ b/index.bs
@@ -4791,7 +4791,7 @@ The main benefits offered to [=[RPS]=] by this specification include:
     any conforming [=authenticator=] and use that same [=authenticator=] with any number of [=[RPS]=]. The [=[RP]=] can optionally
     enforce requirements on [=authenticators=]' security properties by inspecting the [=attestation statements=] returned from the
     [=authenticators=].
-1. [=Registration=] and [=authentication=] [=ceremonies=] are highly resistant to [=man-in-the-middle attacks=].
+1. [=Registration=] and [=authentication=] [=ceremonies=] are resistant to [=man-in-the-middle attacks=].
 1. The [=[RP]=] can automatically support multiple types of [=user verification=] - for example PIN, biometrics and/or future
     methods - with little or no code change, and can let each user decide which they prefer to use via their choice of
     [=authenticator=].

--- a/index.bs
+++ b/index.bs
@@ -130,6 +130,10 @@ spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-201
         text: determining the FacetID of a calling application; url: determining-the-facetid-of-a-calling-application
         text: determining if a caller's FacetID is authorized for an AppID; url: determining-if-a-caller-s-facetid-is-authorized-for-an-appid
 
+spec: RFC4949; urlPrefix: https://tools.ietf.org/html/rfc4949
+    type: dfn
+        text: man-in-the-middle attack; url: page-186
+
 </pre> <!-- class=anchors -->
 
 <!-- L128 spec:webappsec-credential-management-1; type:dictionary; for:/; text:CredentialRequestOptions -->
@@ -4747,7 +4751,7 @@ The main benefits offered to [=[RPS]=] by this specification include:
 1. Users and accounts can be secured using widely compatible, easy-to-use multi-factor authentication.
 1. The [=[RP]=] does not need to provision [=authenticator=] hardware to its users. Instead, each user can independently obtain
     any conforming [=authenticator=] and use that same [=authenticator=] with any number of [=[RPS]=].
-1. [=Registration=] and [=authentication=] [=ceremonies=] are highly resistant to man-in-the-middle attacks.
+1. [=Registration=] and [=authentication=] [=ceremonies=] are highly resistant to [=man-in-the-middle attacks=].
 1. The [=[RP]=] can automatically support multiple types of [=user verification=] - for example PIN, biometrics and/or future
     methods - with little or no code change, and can let each user decide which they prefer to use via their choice of
     [=authenticator=].
@@ -4764,12 +4768,12 @@ When [[#registering-a-new-credential|registering a new credential]], the [=[RP]=
 statement=] with [=self attestation=] or [=no attestation statement|no attestation=], or to not verify the [=attestation
 statement=] at all. In all of these cases the [=[RP]=] loses much of benefit (3) listed above, but retains the other benefits.
 
-In these cases it is possible for a man-in-the-middle attacker - for example, a malicious [=client=] or script - to replace the
-[=credential public key=] to be registered, and subsequently tamper with any future [=assertion=] [=ceremony=] that passes through
-the same attacker. [=Authentication=] [=ceremonies=] are still highly resistant to man-in-the-middle attacks, but only against
-attackers that were not present at the time of [=registration=]. Note, however, that such an attack would be easy to detect and
-very difficult to maintain, since any [=assertion=] [=ceremony=] that the same attacker does not or cannot tamper with would
-always fail.
+In these cases it is possible for a [=man-in-the-middle attack|man-in-the-middle attacker=] - for example, a malicious [=client=]
+or script - to replace the [=credential public key=] to be registered, and subsequently tamper with any future [=assertion=]
+[=ceremony=] that passes through the same attacker. [=Authentication=] [=ceremonies=] are still highly resistant to
+[=man-in-the-middle attacks=], but only against attackers that were not present at the time of [=registration=]. Note, however,
+that such an attack would be easy to detect and very difficult to maintain, since any [=assertion=] [=ceremony=] that the same
+attacker does not or cannot tamper with would always fail.
 
 The [=[RP]=] SHOULD consider the above in its threat model when deciding its policy on what [=attestation statements=] to accept.
 


### PR DESCRIPTION
This fixes #576.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/emlun/webauthn/pull/829.html" title="Last updated on May 9, 2018, 11:41 AM GMT (f80ea1a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/829/b3aa419...emlun:f80ea1a.html" title="Last updated on May 9, 2018, 11:41 AM GMT (f80ea1a)">Diff</a>