### PR TITLE
Remove vestigial reference to CollectedClientData/clientExtensions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3744,7 +3744,7 @@ Note: Extensions should aim to define authenticator arguments that are as small 
 
 Extensions MAY define additional processing requirements on the client platform during the creation of credentials or the
 generation of an assertion. The [=client extension input=] for the extension is used an input to this client processing.
-For each supported [=client extension=], the client adds an entry to this dictionary with the
+For each supported [=client extension=], the client adds an entry to the |clientExtensions|  [=map=] with the
 [=extension identifier=] as the key, and the extension's [=client extension input=] as the value.
 
 Likewise, the [=client extension outputs=] are represented as a dictionary in the result of {{PublicKeyCredential/getClientExtensionResults()}}

--- a/index.bs
+++ b/index.bs
@@ -3743,7 +3743,7 @@ Note: Extensions should aim to define authenticator arguments that are as small 
 ## <dfn>Client extension processing</dfn> ## {#sctn-client-extension-processing}
 
 Extensions MAY define additional processing requirements on the client platform during the creation of credentials or the
-generation of an assertion. The [=client extension input=] for the extension is used an input to this client processing.
+generation of an assertion. The [=client extension input=] for the extension is used as an input to this client processing.
 For each supported [=client extension=], the client adds an entry to the |clientExtensions|  [=map=] with the
 [=extension identifier=] as the key, and the extension's [=client extension input=] as the value.
 

--- a/index.bs
+++ b/index.bs
@@ -3744,8 +3744,7 @@ Note: Extensions should aim to define authenticator arguments that are as small 
 
 Extensions MAY define additional processing requirements on the client platform during the creation of credentials or the
 generation of an assertion. The [=client extension input=] for the extension is used an input to this client processing.
-Supported [=client extensions=] are recorded as a dictionary in the [=client data=] with the key
-{{CollectedClientData/clientExtensions}}. For each such extension, the client adds an entry to this dictionary with the
+For each supported [=client extension=], the client adds an entry to this dictionary with the
 [=extension identifier=] as the key, and the extension's [=client extension input=] as the value.
 
 Likewise, the [=client extension outputs=] are represented as a dictionary in the result of {{PublicKeyCredential/getClientExtensionResults()}}


### PR DESCRIPTION
Fixes #828


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/835.html" title="Last updated on Mar 14, 2018, 5:42 PM GMT (28b7e27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/835/716a169...selfissued:28b7e27.html" title="Last updated on Mar 14, 2018, 5:42 PM GMT (28b7e27)">Diff</a>