### PR TITLE
Clarify the U2F Attestation format to have a single certificate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3494,7 +3494,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
                       )
 
     u2fStmtFormat = {
-                        x5c: [ attestnCert: bytes, * (caCert: bytes) ],
+                        x5c: [ attestnCert: bytes ],
                         sig: bytes
                     }
     ```
@@ -3502,8 +3502,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     The semantics of the above fields are as follows:
 
     : x5c
-    :: The elements of this array contain the attestation certificate and its certificate chain, each encoded in X.509 format.
-        The attestation certificate MUST be the first element in the array.
+    :: A single element array containing the attestation certificate in X.509 format.
 
     : sig
     :: The [=attestation signature=].  
@@ -3527,7 +3526,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     as follows:
     1. Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the
         contained fields.
-    1. Let |attCert| be the value of the first element of |x5c|. Let |certificate public key| be the public key
+    1. Check that |x5c| has exactly one element and let |attCert| be that element. Let |certificate public key| be the public key
         conveyed by |attCert|. If |certificate public key| is not an Elliptic Curve (EC) public 
         key over the P-256 curve, terminate this algorithm and return an appropriate error. 
     1. Extract the claimed |rpIdHash| from |authenticatorData|, and the claimed |credentialId| and |credentialPublicKey| from


### PR DESCRIPTION
The [U2F Raw Message Format](https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#h3_registration-response-message-success) only allows for a single attestation certificate in U2F responses.

This PR reflects this in the U2F Attestation Format to reduce the chance of misunderstanding when implementing the server verification.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arnar/webauthn/pull/836.html" title="Last updated on Mar 13, 2018, 1:06 AM GMT (4e19fe4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/836/9c60eed...arnar:4e19fe4.html" title="Last updated on Mar 13, 2018, 1:06 AM GMT (4e19fe4)">Diff</a>