### PR TITLE
fix linking errors, ref PublicKeyCredentialCreationOptions rather than…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4790,7 +4790,7 @@ in several ways, including:
 In order to protect users from being identified without [=user consent|consent=], implementations of the
 {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method need to take care to not leak information that
 could enable a malicious [=[RP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
-credential|credentials=] listed by the [=[RP]=] in {{MakePublicKeyCredentialOptions/excludeCredentials}} is bound to the
+credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is bound to the
 [=authenticator=]:
 
 - No [=authenticators=] are present.
@@ -4801,7 +4801,7 @@ which [=public key credential|credentials=] are available. For example, one such
 failure response as soon as an excluded [=authenticator=] becomes available. In this case - especially if the excluded
 [=authenticator=] is a [=platform authenticator=] - the [=[RP]=] could detect that the [=ceremony=] was canceled before the
 timeout and before the user could feasibly have canceled it manually, and thus conclude that at least one of the [=public key
-credential|credentials=] listed in the {{MakePublicKeyCredentialOptions/excludeCredentials}} parameter is available to the user.
+credential|credentials=] listed in the {{PublicKeyCredentialCreationOptions/excludeCredentials}} parameter is available to the user.
 
 The above is not a concern, however, if the user has [=user consent|consented=] to create a new credential before a
 distinguishable error is returned, because in this case the user has confirmed intent to share the information that would be


### PR DESCRIPTION
…MakePublicKeyCredentialOptions

fixes #828 (all the way this time) -- the spec was still building with the following error:
> LINK ERROR:\033[0m No 'idl' refs found for 'excludeCredentials' with for='MakePublicKeyCredentialOptions'.
{{MakePublicKeyCredentialOptions/excludeCredentials}}

see https://github.com/w3c/webauthn/issues/828#issuecomment-373127081


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/840.html" title="Last updated on Mar 14, 2018, 6:31 PM GMT (c9ae90a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/840/c53c1d1...c9ae90a.html" title="Last updated on Mar 14, 2018, 6:31 PM GMT (c9ae90a)">Diff</a>