### PR TITLE
fix 855: add link to CR

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13,6 +13,7 @@ Status: ED
 Prepare for TR: true
 TR: https://www.w3.org/TR/webauthn/
 ED: https://w3c.github.io/webauthn/
+Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180320/
 Previous Version: https://www.w3.org/TR/2018/WD-webauthn-20180315/
 Previous Version: https://www.w3.org/TR/2018/WD-webauthn-20180306/
 Previous Version: https://www.w3.org/TR/2017/WD-webauthn-20171205/


### PR DESCRIPTION
just merge this?
fixes #855


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/856.html" title="Last updated on Mar 28, 2018, 8:16 PM GMT (644a581)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/856/60000a4...644a581.html" title="Last updated on Mar 28, 2018, 8:16 PM GMT (644a581)">Diff</a>