### PR TITLE
Allow client to refuse too short challenges

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -758,6 +758,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
+1. If <code>|options|.{{PublicKeyCredentialCreationOptions/challenge}}</code> has a length less than 16 bytes, the [=client=] MAY
+    return a {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
+
 1. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present=], check if its value lies within a
     reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set a timer
     |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present|not
@@ -1106,6 +1109,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
     [[Feature-Policy]] once the latter specification becomes stably implemented in user agents.
 
 1. Let |options| be the value of <code>|options|.{{CredentialRequestOptions/publicKey}}</code>.
+
+1. If <code>|options|.{{PublicKeyCredentialRequestOptions/challenge}}</code> has a length less than 16 bytes, the [=client=] MAY
+    return a {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
 
 1. If the {{PublicKeyCredentialRequestOptions/timeout}} member of |options| is [=present=], check if its value lies
     within a reasonable range as defined by the platform and if not, correct it to the closest value lying within that range.
@@ -4705,8 +4711,8 @@ upon a client's behavior, e.g., the Relying Party SHOULD store the challenge tem
 until the operation is complete. Tolerating a mismatch will compromise the security
 of the protocol.
 
-In order to prevent replay attacks, the challenges MUST contain enough entropy to make guessing them infeasible. Challenges SHOULD
-therefore be at least 16 bytes long.
+In order to prevent replay attacks, the challenges MUST contain enough entropy to make guessing them infeasible. [=Clients=] MAY
+therefore refuse to accept challenges shorter than 16 bytes.
 
 ## Attestation Security Considerations ## {#sec-attestation-security-considerations}
 


### PR DESCRIPTION
As suggested in https://github.com/w3c/webauthn/issues/85#issuecomment-372309459 . This would merge into #858.

This would allow clients to refuse challenges that are clearly suspicious in their soundness, although it wouldn't help enforce any requirements on the actual randomness of the contents.

This is potentially breaking, depending on perspective. Clients will not need to change, but they may if they want to. RPs will need to change if at least one client does.

I will not object to closing this if it doesn't seem like a good idea.