### PR TITLE
Fix #593 - Refer to RFC 8266 for RP-controlled UI strings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1656,6 +1656,10 @@ associated.
             For example, a [=[RP]=] might choose to map [=human palatability|human-palatable=] [=username=] account identifiers to
             the {{PublicKeyCredentialEntity/name}} member of {{PublicKeyCredentialUserEntity}}.
 
+        Wherever [=Conforming User Agents=] display the {{PublicKeyCredentialEntity/name}}, they
+        SHOULD abide by the [[RFC8266]] Nickname Profile to protect users against potentially confusing
+        strings.
+
         [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialEntity/name}} member's
         value. Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value to a length equal to or greater
         than 64 bytes.
@@ -1703,6 +1707,10 @@ credential.
     :   <dfn>displayName</dfn>
     ::  A human-friendly name for the user account, intended only for display. For example, "Alex P. Müller" or "田中 倫". The
         [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
+
+        Wherever [=Conforming User Agents=] display the {{PublicKeyCredentialUserEntity/displayName}}, they
+        SHOULD abide by the [[RFC8266]] Nickname Profile to protect users against potentially confusing
+        strings.
 
         [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialUserEntity/displayName}}
         member's value. Authenticators MAY truncate a {{PublicKeyCredentialUserEntity/displayName}} member's value to a length


### PR DESCRIPTION
The RP provides 'PublicKeyCredentialUserEntity/displayName' and 'PublicKeyCredentialEntity/name',
both of which are intended for display by User Agent. As DOMString objects, these could be
manipulated by a malicious RP to try and confuse the user about what is being displayed, so
User Agents should be careful in how they display these fields.

This PR points to RFC 8266 for its guidance on showing those fields. This is guidance that
browser vendors already follow for other specifications, so it's nothing new -- it merely
codifies what should be.