### PR TITLE
Change "with string-valued keys" to "whose keys are strings"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1932,7 +1932,7 @@ follows.
 ### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
 
 The <dfn>client data</dfn> represents the contextual bindings of both the [=[RP]=] and the client platform. It is a key-value
-mapping with string-valued keys. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
+mapping whose keys are strings. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
 following Web IDL.
 
 Note: The {{CollectedClientData}} may be extended in the future. Therefore it's critical when parsing to be tolerant of unknown keys and of any reordering of the keys.


### PR DESCRIPTION
This fixes #870.

This helps avoid confusion by reading "string-valued keys" as "keys mapped to values of string type".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/880.html" title="Last updated on Apr 24, 2018, 11:38 AM GMT (2c97d4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/880/b9af923...2c97d4c.html" title="Last updated on Apr 24, 2018, 11:38 AM GMT (2c97d4c)">Diff</a>