### PR TITLE
Clarify that authentication use case example requires pairing the phone first

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -218,8 +218,9 @@ scenarios. Additional scenarios, including sample code, are given later in [[#sa
 ### Authentication ### {#usecase-authentication}
 
 - On a laptop or desktop:
-    * User navigates to example.com in a browser, sees an option to "Sign in with your phone."
-    * User chooses this option and gets a message from the browser, "Please complete this action on your phone."
+    * User connects their phone to the laptop or desktop via Bluetooth.
+    * User navigates to example.com in a browser and initiates signing in.
+    * User gets a message from the browser, "Please complete this action on your phone."
 
 - Next, on their phone:
     * User sees a discrete prompt or notification, "Sign in to example.com."

--- a/index.bs
+++ b/index.bs
@@ -218,7 +218,7 @@ scenarios. Additional scenarios, including sample code, are given later in [[#sa
 ### Authentication ### {#usecase-authentication}
 
 - On a laptop or desktop:
-    * User connects their phone to the laptop or desktop via Bluetooth.
+    * User pairs their phone with the laptop or desktop via Bluetooth.
     * User navigates to example.com in a browser and initiates signing in.
     * User gets a message from the browser, "Please complete this action on your phone."
 


### PR DESCRIPTION
This fixes #874.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/881.html" title="Last updated on May 2, 2018, 10:46 AM GMT (f4575a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/881/b9af923...f4575a0.html" title="Last updated on May 2, 2018, 10:46 AM GMT (f4575a0)">Diff</a>