### PR TITLE
Include an AuthenticatorTransport when creating a new credential.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1021,6 +1021,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         :   {{AuthenticatorAttestationResponse/attestationObject}}
                         ::  |attestationObject|
 
+                        :   {{AuthenticatorAttestationResponse/transport}}
+                        ::  A value of type {{AuthenticatorTransport}} specifying how |authenticator| was contacted.
+
                     :   {{PublicKeyCredential/[[clientExtensionsResults]]}}
                     ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                         <code>|credentialCreationData|.[=credentialCreationData/clientExtensionResults=]</code>.
@@ -1490,7 +1493,8 @@ during registration.
 <pre class="idl">
     [SecureContext, Exposed=Window]
     interface AuthenticatorAttestationResponse : AuthenticatorResponse {
-        [SameObject] readonly attribute ArrayBuffer      attestationObject;
+        [SameObject] readonly attribute ArrayBuffer            attestationObject;
+        [SameObject] readonly attribute AuthenticatorTransport transport;
     };
 </pre>
 <div dfn-type="attribute" dfn-for="AuthenticatorAttestationResponse">
@@ -1509,6 +1513,9 @@ during registration.
         [=attestation statement=], as well as to decode and validate the [=authenticator data=] along with the
         [=JSON-serialized client data=]. For more details, see [[#sctn-attestation]], [[#generating-an-attestation-object]],
         and [Figure 3](#fig-attStructs).
+
+    :   <dfn>transport</dfn>
+    ::  This attribute indicates which [transport](#transport) the client used to communicate with the authenticator.
 </div>
 
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}
@@ -2024,21 +2031,30 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     enum AuthenticatorTransport {
         "usb",
         "nfc",
-        "ble"
+        "ble",
+        "internal"
     };
 </pre>
 
 <div dfn-type="enum-value" dfn-for="AuthenticatorTransport">
-    Authenticators may communicate with clients using a variety of transports. This enumeration defines a hint as to how clients
-    might communicate with a particular authenticator in order to obtain an assertion for a specific credential. Note that these
-    hints represent the [=[RP]=]'s best belief as to how an authenticator may be reached. A [=[RP]=] may obtain a list of
-    transports hints from some [=attestation statement formats=] or via some out-of-band mechanism; it is outside the scope of
-    this specification to define that mechanism.
+    Authenticators may communicate with clients using a variety of transports. This enumeration defines a hint as to how
+    clients might communicate with a particular authenticator. It is used in two contexts: from client to RP when
+    [creating a new credential](#createCredential), and from RP to client when when [requesting an
+    assertion](#getAssertion).
+
+    In the first context, the RP might store this information in order to present appropriate instructions to the user
+    in the future. For example, instructing the user to press an NFC authenticator to the reader. (A [=[RP]=] may also
+    obtain a list of transports hints from some [=attestation statement formats=] or via some other out-of-band
+    mechanism; it is outside the scope of this specification to define such mechanisms.)
+
+    In the second context, this is a hint representing the [=[RP]=]'s best belief as to how an authenticator may be
+    reached.
 
     <ul>
         <li><dfn>usb</dfn> - the respective authenticator can be contacted over USB.
         <li><dfn>nfc</dfn> - the respective authenticator can be contacted over Near Field Communication (NFC).
         <li><dfn>ble</dfn> - the respective authenticator can be contacted over Bluetooth Smart (Bluetooth Low Energy / BLE).
+        <li><dfn>internal</dfn> - the respective authenticator is contacted using a platform-specific transport. These authenticators are usually not removable from the platform.
     </ul>
 </div>
 


### PR DESCRIPTION
FIDO U2F found it neccessary to wedge the authenticator transport in an
X.509 extension of the attestation certificate in order to communicate
this information to the RP.

In Webauthn, we currently note that it's possible that an RP might learn
this information from the attestation, but now have several kinds of
attesattion and it seems dumb to define ways to wedge this information
in each.

Instead, have the client include the transport in the
AuthenticatorAttestationResponse. Also, define another transport type
for cases where a non-standard protocol is used to communicate with a
platform authenticator.

Since interface attributes cannot be optional, this technically defines a
breaking change, although I don't believe that it will break anything in
practice. Still, this could also be punted to an extension if we wished.
However, given that U2F found it to be central, I've gone this route.