### PR TITLE
Clean up cross-spec refs in PR #861

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -76,6 +76,10 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
             text: internal method
             text: internal slot
 
+spec: RFC8152; urlPrefix: https://tools.ietf.org/html/rfc8152
+    type: dfn
+        text: Section 7; url: section-7
+
 spec: HTML52; urlPrefix: https://w3c.github.io/html/
     type: dfn
         urlPrefix: browsers.html
@@ -2621,7 +2625,7 @@ object=] for a given credential. It has the following format:
         <td>variable</td>
         <td>
             The [=credential public key=] encoded in COSE_Key format,
-            as defined in Section 7 of [[RFC8152]], using the [=CTAP2 canonical CBOR encoding form=].
+            as defined in [=Section 7=] of [[RFC8152]], using the [=CTAP2 canonical CBOR encoding form=].
             The COSE_Key-encoded [=credential public key=] MUST contain the optional "alg" parameter and MUST NOT
             contain any other optional parameters. The "alg" parameter MUST contain a {{COSEAlgorithmIdentifier}} value.
             The encoded [=credential public key=] MUST also contain any additional required parameters stipulated by the
@@ -2639,8 +2643,7 @@ object=] for a given credential. It has the following format:
 This section provides examples of COSE_Key-encoded Elliptic Curve and RSA public keys for the ES256, PS256, and RS256
 signature algorithms. These examples adhere to the rules defined above for the [=credentialPublicKey=] value, and are presented in [[CDDL]] for clarity. 
 
-[[RFC8152]] [Section 7](https://tools.ietf.org/html/rfc8152#section-7) defines the general framework for all
-COSE_Key-encoded keys.
+[[RFC8152]] [=Section 7=] defines the general framework for all COSE_Key-encoded keys.
 Specific key types for specific algorithms are defined in other sections of [[RFC8152]] as well as in other specifications,
 as noted below.
 
@@ -3537,7 +3540,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
         key over the P-256 curve, terminate this algorithm and return an appropriate error. 
     1. Extract the claimed |rpIdHash| from |authenticatorData|, and the claimed |credentialId| and |credentialPublicKey| from
         |authenticatorData|.<code>[=attestedCredentialData=]</code>.
-    1. Convert the COSE_KEY formatted |credentialPublicKey| (see Section 7 of [[!RFC8152]]) to CTAP1/U2F user public key
+    1. Convert the COSE_KEY formatted |credentialPublicKey| (see [=Section 7=] of [[!RFC8152]]) to CTAP1/U2F user public key
         format (see Section 4.3 of [[!FIDO-U2F-Message-Formats]]).
         - Let |x| be the value corresponding to the "-2" key (representing x coordinate) in |credentialPublicKey|, and confirm its
             size to be of 32 bytes.

--- a/index.bs
+++ b/index.bs
@@ -137,6 +137,11 @@ spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-201
         text: determining the FacetID of a calling application; url: determining-the-facetid-of-a-calling-application
         text: determining if a caller's FacetID is authorized for an AppID; url: determining-if-a-caller-s-facetid-is-authorized-for-an-appid
 
+spec: FIDO-U2F-Message-Formats; urlPrefix: https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html
+    type: dfn
+        text: Section 4.3; url: registration-response-message-success
+
+
 </pre> <!-- class=anchors -->
 
 <!-- L128 spec:webappsec-credential-management-1; type:dictionary; for:/; text:CredentialRequestOptions -->
@@ -3524,7 +3529,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     and let |clientDataHash| denote the [=hash of the serialized client data=]. (Since SHA-256 is used to hash the
     serialized client data, |clientDataHash| will be 32 bytes long.)
 
-    Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] section 4.3, with the application parameter set to the
+    Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] [=Section 4.3=], with the application parameter set to the
     SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |clientDataHash|, and the key handle
     parameter set to the [=credential ID=] of the given credential. Set the raw signature part of this Registration Response Message (i.e., without the [=user public key=],
     key handle, and attestation certificates) as |sig| and set the attestation certificates of
@@ -3541,7 +3546,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     1. Extract the claimed |rpIdHash| from |authenticatorData|, and the claimed |credentialId| and |credentialPublicKey| from
         |authenticatorData|.<code>[=attestedCredentialData=]</code>.
     1. Convert the COSE_KEY formatted |credentialPublicKey| (see [=Section 7=] of [[!RFC8152]]) to CTAP1/U2F user public key
-        format (see Section 4.3 of [[!FIDO-U2F-Message-Formats]]).
+        format (see [=Section 4.3=] of [[!FIDO-U2F-Message-Formats]]).
         - Let |x| be the value corresponding to the "-2" key (representing x coordinate) in |credentialPublicKey|, and confirm its
             size to be of 32 bytes.
             If size differs or "-2" key is not found, terminate this algorithm and return an appropriate error.
@@ -3552,7 +3557,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
 
             Note: This signifies uncompressed ECC key format.
     1. Let |verificationData| be the concatenation of (0x00 || |rpIdHash| ||
-        |clientDataHash| || |credentialId| || |publicKeyU2F|) (see Section 4.3 of [[!FIDO-U2F-Message-Formats]]).
+        |clientDataHash| || |credentialId| || |publicKeyU2F|) (see [=Section 4.3=] of [[!FIDO-U2F-Message-Formats]]).
     1. Verify the |sig| using |verificationData| and |certificate public key| per [[!SEC1]].
     1. If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
 


### PR DESCRIPTION
This would merge into PR #861; see also #872.

@equalsJeffH I'm not sure how to properly define the cross-link anchors - I didn't find anything better in the Bikeshed docs, but it feels like there could be a better way. This way they're treated as defined terms, which means they also show up in the biblio as

> [RFC8152] defines the following terms:
>    section 7 

and such, and it also means we couldn't have multiple "Section 7" definitions without disambiguating them. It's a bit ugly, but not the end of the world I suppose. Is this the way to do it?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/883.html" title="Last updated on Apr 25, 2018, 10:29 AM GMT (b05010d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/883/c137565...b05010d.html" title="Last updated on Apr 25, 2018, 10:29 AM GMT (b05010d)">Diff</a>