### PR TITLE
fix non-`null` breakage by using plain "non-null"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2345,7 +2345,7 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
 1. [=list/For each=] |descriptor| of |excludeCredentialDescriptorList|:
 
     1.  If [=credential id/looking up=] <code>|descriptor|.{{PublicKeyCredentialDescriptor/id}}</code> in this authenticator
-        returns non-`null`, and the returned [=list/item=]'s [=RP ID=] and [=type=] match
+        returns non-null, and the returned [=list/item=]'s [=RP ID=] and [=type=] match
         <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and
         <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code> respectively, then obtain [=user
         consent=] for creating a new credential. The method of obtaining [=user consent=] MUST include a [=test


### PR DESCRIPTION
fix non-`null` breakage by using plain "non-null"  -- I'm gonna just merge this if no one screams in the next hour or so...   (all the failing PR builds due to this are becoming annoying...)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/890.html" title="Last updated on May 1, 2018, 4:45 PM GMT (9cc342a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/890/b9af923...9cc342a.html" title="Last updated on May 1, 2018, 4:45 PM GMT (9cc342a)">Diff</a>