### PR TITLE
Document prevention of attacks on privacy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4794,8 +4794,7 @@ use or provide any form of global identity, the following kinds of potentially c
 - The user's [=credential IDs=] and [=credential public keys=].
 
     These are registered by the [=[RP]=] and subsequently used by the user to prove possession of the corresponding [=credential
-    private key=], and thus ownership of the [=public key credential=] identified by the [=credential ID=]. They are also visible
-    to the [=client=] in the communication with the [=authenticator=].
+    private key=]. They are also visible to the [=client=] in the communication with the [=authenticator=].
 
 - The user's identities specific to each [=[RP]=], e.g., usernames and [=user handles=].
 
@@ -4856,9 +4855,10 @@ without a traditional username, further improving non-correlatability between [=
 
 [=Biometric authenticators=] perform the [=biometric recognition=] internally in the [=authenticator=] - though for [=platform
 authenticators=] the biometric data might also be visible to the [=client=], depending on the implementation. Biometric data is
-not revealed to the [=[RP]=]; it is only used as an additional layer of security for unlocking use of the [=authenticator=]. A
-malicious [=[RP]=] therefore cannot discover the user's personal identity via biometric data, and a security breach at a [=[RP]=]
-cannot expose biometric data for an attacker to use for forging logins at other [=[RPS]=].
+not revealed to the [=[RP]=]; it is used only locally to perform [=user verification=] authorizing the creation and
+[=registration=] of, or [=authentication=] using, a [=public key credential=]. A malicious [=[RP]=] therefore cannot discover the
+user's personal identity via biometric data, and a security breach at a [=[RP]=] cannot expose biometric data for an attacker to
+use for forging logins at other [=[RPS]=].
 
 In the case where a [=[RP]=] requires [=biometric recognition=], this is achieved by the [=biometric authenticator=] setting the
 [=UV=] [=flag=] in the signed [=assertion=] response, instead of revealing the biometric data itself to the [=[RP]=]. The [=[RP]=]

--- a/index.bs
+++ b/index.bs
@@ -4839,6 +4839,10 @@ shared between [=[RPS]=].
     not correlatable as having the same [=managing authenticator=]. A pair of malicious [=[RPS]=] thus cannot correlate users
     between their systems without additional information, e.g., a willfully reused username or e-mail address.
 
+- [=Authenticators=] ensure that their [=attestation certificates=] are not unique enough to identify a single [=authenticator=]
+    or a small group of [=authenticators=]. This is detailed further in [[#sec-attestation-privacy]]. A pair of malicious
+    [=[RPS]=] thus cannot correlate users between their systems by tracking individual [=authenticators=].
+
 Additionally, a [=public key credential=] with a [=client-side-resident credential private key=] can optionally include a [=user
 handle=] specified by the [=[RP]=]. The [=public key credential|credential=] can then be used to both identify and
 [=authentication|authenticate=] the user. This means that a privacy-conscious [=[RP]=] can allow the user to create an account

--- a/index.bs
+++ b/index.bs
@@ -147,10 +147,6 @@ spec: FIDO-Registry; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-2017
     type: dfn
         text: Section 3.6.2; url: public-key-representation-formats
 
-spec: Wikipedia-NaturalPerson; urlPrefix: https://en.wikipedia.org/wiki/Natural_person
-    type: dfn
-        text: natural person
-
 
 </pre> <!-- class=anchors -->
 
@@ -4787,9 +4783,9 @@ The privacy principles in [[!FIDO-Privacy-Principles]] also apply to this specif
 [INFORMATIVE]
 
 Many aspects of the design of the [=Web Authentication API=] are motivated by privacy concerns. The main concern considered in
-this specification is the protection of the user's personal identity, i.e., the identification of a [=natural person=] or a
-correlation of separate identities as belonging to the same [=natural person=]. Although the [=Web Authentication API=] does not
-use or provide any form of global identity, the following kinds of potentially correlatable identifiers are used:
+this specification is the protection of the user's personal identity, i.e., the identification of a human being or a correlation
+of separate identities as belonging to the same human being. Although the [=Web Authentication API=] does not use or provide any
+form of global identity, the following kinds of potentially correlatable identifiers are used:
 
 - The user's [=credential IDs=] and [=credential public keys=].
 

--- a/index.bs
+++ b/index.bs
@@ -4862,9 +4862,7 @@ use for forging logins at other [=[RPS]=].
 
 In the case where a [=[RP]=] requires [=biometric recognition=], this is performed locally by the [=biometric authenticator=]
 perfoming [=user verification=] and then signaling the result by setting the [=UV=] [=flag=] in the signed [=assertion=] response,
-instead of revealing the biometric data itself to the [=[RP]=]. The [=[RP]=] can trust the authenticity of the [=UV=] [=flag=] as
-long as it trusts the security guarantees of the [=attestation certificate=] presented when the [=biometric authenticator=] was
-[=registration|registered=].
+instead of revealing the biometric data itself to the [=[RP]=].
 
 
 ## Attestation Privacy ## {#sec-attestation-privacy}

--- a/index.bs
+++ b/index.bs
@@ -4785,7 +4785,7 @@ The privacy principles in [[!FIDO-Privacy-Principles]] also apply to this specif
 Many aspects of the design of the [=Web Authentication API=] are motivated by privacy concerns. The main concern considered in
 this specification is the protection of the user's personal identity, i.e., the identification of a human being or a correlation
 of separate identities as belonging to the same human being. Although the [=Web Authentication API=] does not use or provide any
-form of global identity, the following kinds of potentially correlatable identities are used:
+form of global identity, the following kinds of potentially correlatable identifiers are used:
 
 - The user's [=credential IDs=] and [=credential public keys=].
 
@@ -4798,7 +4798,7 @@ form of global identity, the following kinds of potentially correlatable identit
     These identities are obviously used by each [=[RP]=] to identify a user in their system. They are also visible to the
     [=client=] in the communication with the [=authenticator=].
 
-- The user's biometric information, e.g., fingerprints or facial recognition data.
+- The user's biometric characteristic(s), e.g., fingerprints or facial recognition data [[ISOBiometricVocabulary]].
 
     This is optionally used by the [=authenticator=] to perform [=user verification=]. It is not revealed to the [=[RP]=], but in
     the case of [=platform authenticators=], it might be visible to the [=client=] depending on the implementation.
@@ -4822,14 +4822,13 @@ prevent malicious [=[RPS]=] from using it to discover a user's personal identity
 [INFORMATIVE]
 
 Although [=Credential IDs=] and [=credential public keys=] are necessarily shared with the [=[RP]=] to enable strong
-authentication, the [=public key credentials=] employed in this specification are designed to be minimally identifying and never
-shared between [=[RPS]=].
+authentication, they are designed to be minimally identifying and not shared between [=[RPS]=].
 
 - [=Credential IDs=] and [=credential public keys=] are meaningless in isolation, as they only identify [=credential key pairs=]
     and not users directly.
 
-- Each [=public key credential=] is strictly bound to a specific [=[RP]=], and the [=client=] ensures that its existence is never
-    revealed to other [=[RPS]=]. A malicious [=[RP]=] thus cannot ask the [=client=] to reveal other identities owned by the user.
+- Each [=public key credential=] is strictly bound to a specific [=[RP]=], and the [=client=] ensures that its existence is not
+    revealed to other [=[RPS]=]. A malicious [=[RP]=] thus cannot ask the [=client=] to reveal a user's other identities.
 
 - The [=client=] also ensures that the existence of a [=public key credential=] is not revealed to the [=[RP]=] without [=user
     consent=]. This is detailed further in [[#sec-make-credential-privacy]] and [[#sec-assertion-privacy]]. A malicious [=[RP]=]
@@ -4855,12 +4854,12 @@ without a traditional username, further improving non-correlatability between [=
 authenticators=] the biometric data might also be visible to the [=client=], depending on the implementation. Biometric data is
 not revealed to the [=[RP]=]; it is only used as an additional layer of security for unlocking use of the [=authenticator=]. A
 malicious [=[RP]=] therefore cannot discover the user's personal identity via biometric data, and a security breach at a [=[RP]=]
-cannot expose biometric data for an attacker to use for forging logins at a different [=[RP]=].
+cannot expose biometric data for an attacker to use for forging logins at other [=[RPS]=].
 
-In the case where a [=[RP]=] requires [=biometric recognition=], this is instead achieved by the [=biometric authenticator=]
-setting the [=UV=] [=flag=] in the signed [=assertion=] response. The [=[RP]=] can trust the authenticity of this bit as long as
-it trusts the security guarantees of the [=attestation certificate=] presented when the [=biometric authenticator=] was
-[=registration|registered=].
+In the case where a [=[RP]=] requires [=biometric recognition=], this is achieved by the [=biometric authenticator=] setting the
+[=UV=] [=flag=] in the signed [=assertion=] response, instead of revealing the biometric data itself to the [=[RP]=]. The [=[RP]=]
+can trust the authenticity of the [=UV=] [=flag=] as long as it trusts the security guarantees of the [=attestation certificate=]
+presented when the [=biometric authenticator=] was [=registration|registered=].
 
 
 ## Attestation Privacy ## {#sec-attestation-privacy}

--- a/index.bs
+++ b/index.bs
@@ -4777,6 +4777,88 @@ which should make use of the existing browser permissions framework for the Geol
 
 The privacy principles in [[!FIDO-Privacy-Principles]] also apply to this specification.
 
+
+## De-anonymization prevention measures ## {#sctn-privacy-attacks}
+
+[INFORMATIVE]
+
+Many aspects of the design of the [=Web Authentication API=] are motivated by privacy concerns. The main concern considered in
+this specification is the protection of the user's personal identity, i.e., the identification of a physical person or a
+correlation of separate identities as belonging to the same physical person. Although the [=Web Authentication API=] does not use
+or provide and form of global identity, the following kinds of potentially correlatable identities are used:
+
+- The user's [=credential IDs=] and [=credential public keys=].
+
+    These are registered by the [=[RP]=] and subsequently used by the user to prove possession of the corresponding [=credential
+    private key=], and thus ownership of the [=public key credential=] identified by the [=credential ID=]. They are also visible
+    to the [=client=] in the communication with the [=authenticator=].
+
+- The user's identities specific to each [=[RP]=], e.g. usernames, [=user handles=] and similar aliases.
+
+    These identities are obviously used by each [=[RP]=] to identify a user in their system. They are also visible to the
+    [=client=] in the communication with the [=authenticator=].
+
+- The user's biometric information, e.g., fingerprints or facial recognition data.
+
+    This is optionally used by the [=authenticator=] to perform [=user verification=]. It is not revealed to the [=[RP]=], but in
+    the case of [=platform authenticators=] it might be visible to the [=client=] depending on the implementation.
+
+- The models of the user's [=authenticators=], e.g. product names.
+
+    This is exposed in the [=attestation statement=] provided to the [=[RP]=] during [=registration=]. It is also visible to the
+    [=client=] in the communication with the [=authenticator=].
+
+- The identities of the user's [=authenticators=], e.g. serial numbers.
+
+    This is possibly used by the [=client=] to enable communication with the [=authenticator=], but is not exposed to the
+    [=[RP]=].
+
+Some of the above information is necessarily shared with the [=[RP]=]. The following sections describe the measures taken to
+prevent malicious [=[RPS]=] from using it to discover a user's personal identity.
+
+
+## Anonymous, scoped, non-correlatable [=public key credentials=] ## {#sec-non-correlatable-credentials}
+
+[INFORMATIVE]
+
+Although [=Credential IDs=] and [=credential public keys=] are necessarily shared with the [=[RP]=] to enable strong
+authentication, the [=public key credentials=] employed in this specification are designed to be minimally identifying and never
+shared between [=[RPS]=].
+
+- [=Credential IDs=] and [=credential public keys=] are meaningless in isolation, as they only identify [=credential key pairs=]
+    and not users directly.
+
+- Each [=public key credential=] is strictly bound to a specific [=[RP]=], and the [=client=] ensures that its existence is never
+    revealed to other [=[RPS]=]. A malicious [=[RP]=] thus cannot ask the [=client=] to reveal other identities owned by the user.
+
+- The [=client=] also ensures that the existence of a [=public key credential=] is not revealed to the [=[RP]=] without [=user
+    consent=]. This is detailed further in [[#sec-make-credential-privacy]] and [[#sec-assertion-privacy]]. A malicious [=[RP]=]
+    thus cannot silently identify a user even if the user has a [=public key credential=] registered and available.
+
+- [=Authenticators=] ensure that the [=credential IDs=] and [=credential public keys=] of different [=public key credentials=] are
+    not correlatable as having the same [=managing authenticator=]. A pair of malicious [=[RPS]=] thus cannot correlate users
+    between their systems without additional information, e.g., a willfully reused username or e-mail address.
+
+Additionally, a [=public key credential=] with a [=client-side-resident credential private key=] can optionally include a [=user
+handle=] specified by the [=[RP]=]. The [=public key credential|credential=] can then be used to both identify and
+[=authentication|authenticate=] the user. This means that a privacy-conscious [=[RP]=] can allow the user to create an account
+without a traditional username, further improving non-correlatability between [=[RPS]=].
+
+
+## Authenticator-local [=biometric recognition=] ## {#sec-biometric-privacy}
+
+[=Biometric authenticators=] perform the [=biometric recognition=] internally in the [=authenticator=] - though for [=platform
+authenticators=] the biometric data might also be visible to the [=client=], depending on the implementation. Biometric data is
+not revealed to the [=[RP]=]; it is only used as an additional layer of security for unlocking use of the [=authenticator=]. A
+malicious [=[RP]=] therefore cannot discover the user's personal identity via biometric data, and a security breach at a [=[RP]=]
+cannot expose biometric data for an attacker to use for forging logins at a different [=[RP]=].
+
+In the case where a [=[RP]=] requires [=biometric recognition=], this is instead achieved by the [=biometric authenticator=]
+setting the [=UV=] [=flag=] in the signed [=assertion=] response. The [=[RP]=] can trust the authenticity of this bit as long as
+it trusts the security guarantees of the [=attestation certificate=] presented when the [=biometric authenticator=] was
+[=registration|registered=].
+
+
 ## Attestation Privacy ## {#sec-attestation-privacy}
 
 Attestation keys can be used to track users or link various online identities of the same user together. This can be mitigated

--- a/index.bs
+++ b/index.bs
@@ -4783,9 +4783,9 @@ The privacy principles in [[!FIDO-Privacy-Principles]] also apply to this specif
 [INFORMATIVE]
 
 Many aspects of the design of the [=Web Authentication API=] are motivated by privacy concerns. The main concern considered in
-this specification is the protection of the user's personal identity, i.e., the identification of a physical person or a
-correlation of separate identities as belonging to the same physical person. Although the [=Web Authentication API=] does not use
-or provide and form of global identity, the following kinds of potentially correlatable identities are used:
+this specification is the protection of the user's personal identity, i.e., the identification of a human being or a correlation
+of separate identities as belonging to the same human being. Although the [=Web Authentication API=] does not use or provide any
+form of global identity, the following kinds of potentially correlatable identities are used:
 
 - The user's [=credential IDs=] and [=credential public keys=].
 
@@ -4793,7 +4793,7 @@ or provide and form of global identity, the following kinds of potentially corre
     private key=], and thus ownership of the [=public key credential=] identified by the [=credential ID=]. They are also visible
     to the [=client=] in the communication with the [=authenticator=].
 
-- The user's identities specific to each [=[RP]=], e.g. usernames, [=user handles=] and similar aliases.
+- The user's identities specific to each [=[RP]=], e.g., usernames and [=user handles=].
 
     These identities are obviously used by each [=[RP]=] to identify a user in their system. They are also visible to the
     [=client=] in the communication with the [=authenticator=].
@@ -4801,14 +4801,14 @@ or provide and form of global identity, the following kinds of potentially corre
 - The user's biometric information, e.g., fingerprints or facial recognition data.
 
     This is optionally used by the [=authenticator=] to perform [=user verification=]. It is not revealed to the [=[RP]=], but in
-    the case of [=platform authenticators=] it might be visible to the [=client=] depending on the implementation.
+    the case of [=platform authenticators=], it might be visible to the [=client=] depending on the implementation.
 
-- The models of the user's [=authenticators=], e.g. product names.
+- The models of the user's [=authenticators=], e.g., product names.
 
     This is exposed in the [=attestation statement=] provided to the [=[RP]=] during [=registration=]. It is also visible to the
     [=client=] in the communication with the [=authenticator=].
 
-- The identities of the user's [=authenticators=], e.g. serial numbers.
+- The identities of the user's [=authenticators=], e.g., serial numbers.
 
     This is possibly used by the [=client=] to enable communication with the [=authenticator=], but is not exposed to the
     [=[RP]=].
@@ -4833,17 +4833,17 @@ shared between [=[RPS]=].
 
 - The [=client=] also ensures that the existence of a [=public key credential=] is not revealed to the [=[RP]=] without [=user
     consent=]. This is detailed further in [[#sec-make-credential-privacy]] and [[#sec-assertion-privacy]]. A malicious [=[RP]=]
-    thus cannot silently identify a user even if the user has a [=public key credential=] registered and available.
+    thus cannot silently identify a user, even if the user has a [=public key credential=] registered and available.
 
 - [=Authenticators=] ensure that the [=credential IDs=] and [=credential public keys=] of different [=public key credentials=] are
-    not correlatable as having the same [=managing authenticator=]. A pair of malicious [=[RPS]=] thus cannot correlate users
-    between their systems without additional information, e.g., a willfully reused username or e-mail address.
+    not correlatable as belonging to the same user. A pair of malicious [=[RPS]=] thus cannot correlate users between their
+    systems without additional information, e.g., a willfully reused username or e-mail address.
 
 - [=Authenticators=] ensure that their [=attestation certificates=] are not unique enough to identify a single [=authenticator=]
     or a small group of [=authenticators=]. This is detailed further in [[#sec-attestation-privacy]]. A pair of malicious
     [=[RPS]=] thus cannot correlate users between their systems by tracking individual [=authenticators=].
 
-Additionally, a [=public key credential=] with a [=client-side-resident credential private key=] can optionally include a [=user
+Additionally, a [=public key credential=] with a [=Client-side-resident Credential Private Key=] can optionally include a [=user
 handle=] specified by the [=[RP]=]. The [=public key credential|credential=] can then be used to both identify and
 [=authentication|authenticate=] the user. This means that a privacy-conscious [=[RP]=] can allow the user to create an account
 without a traditional username, further improving non-correlatability between [=[RPS]=].

--- a/index.bs
+++ b/index.bs
@@ -147,6 +147,10 @@ spec: FIDO-Registry; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-2017
     type: dfn
         text: Section 3.6.2; url: public-key-representation-formats
 
+spec: Wikipedia-NaturalPerson; urlPrefix: https://en.wikipedia.org/wiki/Natural_person
+    type: dfn
+        text: natural person
+
 
 </pre> <!-- class=anchors -->
 
@@ -4783,9 +4787,9 @@ The privacy principles in [[!FIDO-Privacy-Principles]] also apply to this specif
 [INFORMATIVE]
 
 Many aspects of the design of the [=Web Authentication API=] are motivated by privacy concerns. The main concern considered in
-this specification is the protection of the user's personal identity, i.e., the identification of a human being or a correlation
-of separate identities as belonging to the same human being. Although the [=Web Authentication API=] does not use or provide any
-form of global identity, the following kinds of potentially correlatable identifiers are used:
+this specification is the protection of the user's personal identity, i.e., the identification of a [=natural person=] or a
+correlation of separate identities as belonging to the same [=natural person=]. Although the [=Web Authentication API=] does not
+use or provide any form of global identity, the following kinds of potentially correlatable identifiers are used:
 
 - The user's [=credential IDs=] and [=credential public keys=].
 

--- a/index.bs
+++ b/index.bs
@@ -4860,10 +4860,11 @@ not revealed to the [=[RP]=]; it is used only locally to perform [=user verifica
 user's personal identity via biometric data, and a security breach at a [=[RP]=] cannot expose biometric data for an attacker to
 use for forging logins at other [=[RPS]=].
 
-In the case where a [=[RP]=] requires [=biometric recognition=], this is achieved by the [=biometric authenticator=] setting the
-[=UV=] [=flag=] in the signed [=assertion=] response, instead of revealing the biometric data itself to the [=[RP]=]. The [=[RP]=]
-can trust the authenticity of the [=UV=] [=flag=] as long as it trusts the security guarantees of the [=attestation certificate=]
-presented when the [=biometric authenticator=] was [=registration|registered=].
+In the case where a [=[RP]=] requires [=biometric recognition=], this is performed locally by the [=biometric authenticator=]
+perfoming [=user verification=] and then signaling the result by setting the [=UV=] [=flag=] in the signed [=assertion=] response,
+instead of revealing the biometric data itself to the [=[RP]=]. The [=[RP]=] can trust the authenticity of the [=UV=] [=flag=] as
+long as it trusts the security guarantees of the [=attestation certificate=] presented when the [=biometric authenticator=] was
+[=registration|registered=].
 
 
 ## Attestation Privacy ## {#sec-attestation-privacy}


### PR DESCRIPTION
Fixes #743. Fixes #382.

#140 is related, but requires a normative requirement that authenticators make credential IDs look like opaque random data.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/899.html" title="Last updated on Jun 20, 2018, 5:06 PM GMT (48d6579)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/899/b3aa419...48d6579.html" title="Last updated on Jun 20, 2018, 5:06 PM GMT (48d6579)">Diff</a>