### PR TITLE
Add an “internal” AuthenticatorTransport.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2052,21 +2052,23 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     enum AuthenticatorTransport {
         "usb",
         "nfc",
-        "ble"
+        "ble",
+        "internal"
     };
 </pre>
 
 <div dfn-type="enum-value" dfn-for="AuthenticatorTransport">
-    Authenticators may communicate with clients using a variety of transports. This enumeration defines a hint as to how clients
-    might communicate with a particular authenticator in order to obtain an assertion for a specific credential. Note that these
-    hints represent the [=[RP]=]'s best belief as to how an authenticator may be reached. A [=[RP]=] may obtain a list of
-    transports hints from some [=attestation statement formats=] or via some out-of-band mechanism; it is outside the scope of
-    this specification to define that mechanism.
+    [=Authenticators=] may implement various [[#transport|transports]] for communicating with [=clients=]. This enumeration
+    defines hints as to how clients might communicate with a particular authenticator in order to obtain an assertion for a
+    specific credential. Note that these hints represent the [=[RP]=]'s best belief as to how an authenticator may be reached. A
+    [=[RP]=] may obtain a list of transports hints from some [=attestation statement formats=] or via some out-of-band mechanism;
+    it is outside the scope of this specification to define that mechanism.
 
     <ul>
-        <li><dfn>usb</dfn> - the respective authenticator can be contacted over USB.
+        <li><dfn>usb</dfn> - the respective authenticator can be contacted over removable USB.
         <li><dfn>nfc</dfn> - the respective authenticator can be contacted over Near Field Communication (NFC).
         <li><dfn>ble</dfn> - the respective authenticator can be contacted over Bluetooth Smart (Bluetooth Low Energy / BLE).
+        <li><dfn>internal</dfn> - the respective authenticator is contacted using a platform-specific transport. These authenticators are not removable from the platform.
     </ul>
 </div>
 


### PR DESCRIPTION
The motivating example is a built-in fingerprint reader. It might be
connected via an I²C bus or the like, but the current
AuthenticatorTransport enumeration cannot express anything like that.

This change adds a catch-all for these internal transports because, from
the point of view of the client, they're all the same: there's nothing
for the user to do if they're not there so no point prompting them.

It also clarifies that the “usb” type means a removable USB device. Some
built-in hardware (esp in laptops) is connected via an internal USB bus,
but a user would not know that and would not want to be prompted like it
was a removable device in that case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/903.html" title="Last updated on May 10, 2018, 11:51 PM GMT (6e4480e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/903/1c3dd46...agl:6e4480e.html" title="Last updated on May 10, 2018, 11:51 PM GMT (6e4480e)">Diff</a>