### PR TITLE
Remove mention of a timeout for isUserVerifyingPlatformAuthenticatorAvailable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1470,19 +1470,9 @@ Based on the result, the [=[RP]=] can take further actions to guide the user to 
 
 This method has no arguments and returns a boolean value.
 
-If the promise will return <i>False</i>,
-the [=client=] SHOULD wait a fixed period of time from the invocation of the method before returning <i>False</i>.
-This is done so that callers cannot distinguish between
-the case where the user was unwilling to create a credential using one of the available [=user verification|user-verifying=] [=platform authenticators=] and
-the case where no [=user verification|user-verifying=] [=platform authenticator=] exists.
-Trying to make these cases indistinguishable is done in an attempt to not provide additional information that could be used for fingerprinting.
-A timeout value on the order of 10 minutes is recommended;
-this is enough time for successful user interactions to be performed
-but short enough that the dangling promise will still be resolved in a reasonably timely fashion.
-
 <pre class="idl">
     partial interface PublicKeyCredential {
-        static Promise < boolean > isUserVerifyingPlatformAuthenticatorAvailable();
+        static Promise&lt;boolean&gt; isUserVerifyingPlatformAuthenticatorAvailable();
     };
 </pre>
 


### PR DESCRIPTION
As discussed on the issue, implementations appear to be converging on
implementing this call without prompting the user and returning
immediately. The wording in this section is loose enough that
implementations that wish to continue using a timeout can find enough
slack to do so, but this change removes the firm suggestion to do so.

Also, align the spacing of “Promise<T>” to match the style used
elsewhere in the W3C specs.

Fixes #575


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/904.html" title="Last updated on Jun 19, 2018, 4:25 PM GMT (1678bbc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/904/4fd5dd5...agl:1678bbc.html" title="Last updated on Jun 19, 2018, 4:25 PM GMT (1678bbc)">Diff</a>