### PR TITLE
Add two abort paths for getting an assertion

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1223,11 +1223,20 @@ When this method is invoked, the user agent MUST execute the following algorithm
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on
             |authenticator| and [=set/remove=] |authenticator| from |issuedRequests|.
 
+        :   If the user exercises a user-interface option to cancel the process,
+        ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
+            and [=set/remove=] |authenticator| from |issuedRequests|. Return a {{DOMException}} whose name is "{{NotAllowedError}}".
+
         :   If the {{CredentialRequestOptions/signal}} member is [=present=] and the [=AbortSignal/aborted flag=] is set to
             true,
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|. Then
             return a {{DOMException}} whose name is "{{AbortError}}" and terminate this algorithm.
+
+        :   If |issuedRequests| is empty, <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty, and no |authenticator| will become available for any [=public key credentials=] therein.
+        ::  Indicate to the user that the credential could not be found. When the user acknowledges the dialog, or once |lifetimeTimer| expires, return a {{DOMException}} whose name is "{{NotAllowedError}}".
+
+            Note: One way in which the platform may determine that no |authenticator| will become available is by using the <code>{{transports}}</code> members of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>. For example, if all credentials only list {{AuthenticatorTransport/internal}}, but all internal |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all credentials may require transports that the platform does not support.
 
         :   If an |authenticator| becomes available on this platform,
         ::  1. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code> is set to

--- a/index.bs
+++ b/index.bs
@@ -1274,9 +1274,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
             return a {{DOMException}} whose name is "{{AbortError}}" and terminate this algorithm.
 
         :   If |issuedRequests| is empty, <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty, and no |authenticator| will become available for any [=public key credentials=] therein,
-        ::  Indicate to the user that the credential could not be found. When the user acknowledges the dialog, or once |lifetimeTimer| expires, return a {{DOMException}} whose name is "{{NotAllowedError}}".
+        ::  Indicate to the user that no eligible credential could be found. When the user acknowledges the dialog, return a {{DOMException}} whose name is "{{NotAllowedError}}".
 
-            Note: One way in which the platform may determine that no |authenticator| will become available is by using the <code>{{transports}}</code> members of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>. For example, if all credentials only list {{AuthenticatorTransport/internal}}, but all internal |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all credentials may require transports that the platform does not support.
+            Note: One way a platform can determine that no |authenticator| will become available is by examining the <code>{{transports}}</code> members of the present <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>, if any. For example, if all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] list only <code>{{AuthenticatorTransport/internal}}</code>, but all internal |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] may list <code>{{transports}}</code> that the platform does not support.
 
         :   If an |authenticator| becomes available on this platform,
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.

--- a/index.bs
+++ b/index.bs
@@ -1233,7 +1233,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             and [=set/remove=] |authenticator| from |issuedRequests|. Then
             return a {{DOMException}} whose name is "{{AbortError}}" and terminate this algorithm.
 
-        :   If |issuedRequests| is empty, <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty, and no |authenticator| will become available for any [=public key credentials=] therein.
+        :   If |issuedRequests| is empty, <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty, and no |authenticator| will become available for any [=public key credentials=] therein,
         ::  Indicate to the user that the credential could not be found. When the user acknowledges the dialog, or once |lifetimeTimer| expires, return a {{DOMException}} whose name is "{{NotAllowedError}}".
 
             Note: One way in which the platform may determine that no |authenticator| will become available is by using the <code>{{transports}}</code> members of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>. For example, if all credentials only list {{AuthenticatorTransport/internal}}, but all internal |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all credentials may require transports that the platform does not support.


### PR DESCRIPTION
This change handles cases (1) and (3) of issue #905. Specifically it augments the process for getting an assertion to allow a client to abort based on (optional) UI, and to abort (after user notification) when it becomes aware that the process cannot be satisfied.

Updates #905


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/906.html" title="Last updated on Jun 19, 2018, 5:55 PM GMT (1e44ebd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/906/4fd5dd5...agl:1e44ebd.html" title="Last updated on Jun 19, 2018, 5:55 PM GMT (1e44ebd)">Diff</a>