### PR TITLE
Remove (probably) outdated inline issue 2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1020,10 +1020,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                         :   "direct"
                         ::  Convey the [=authenticator=]'s [=AAGUID=] and [=attestation statement=], unaltered, to the RP.
-
-                        Issue: @balfanz wishes to add to the "direct" case:
-                            If the [=authenticator=] violates the privacy requirements of the [=attestation type=] it is using, 
-                            the client SHOULD terminate this algorithm with an "AttestationNotPrivateError".
                     </dl>
 
                 1.  Let |attestationObject| be a new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the


### PR DESCRIPTION
This closes #454; see https://github.com/w3c/webauthn/issues/454#issuecomment-388061234

NOTE: I'm not entirely sure this inline issue is fixed. @agl or @balfanz please confirm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/908.html" title="Last updated on May 15, 2018, 11:54 AM GMT (2582344)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/908/1c3dd46...2582344.html" title="Last updated on May 15, 2018, 11:54 AM GMT (2582344)">Diff</a>