### PR TITLE
Add registration/authentication extensions for cloud-assisted BLE

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1918,6 +1918,33 @@ SHOULD be aborted.
     loses focuses. If a hook is provided, the above paragraph will be updated to include the hook.
     See [WHATWG HTML WG Issue #2711](https://github.com/whatwg/html/issues/2711) for more details. 
 
+## Registration Extensions Client Inputs (typedef <dfn>RegistrationExtensionsClientInputs</dfn>) ## {#iface-registration-extensions-client-inputs}
+
+<xmp class="idl">
+    dictionary RegistrationExtensionsClientInputs {
+    };
+</xmp>
+
+This is a dictionary containing the [=client extension input=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
+
+
+## Registration Extensions Client Outputs (typedef <dfn>RegistrationExtensionsClientOutputs</dfn>) ## {#iface-registration-extensions-client-outputs}
+
+<xmp class="idl">
+    dictionary RegistrationExtensionsClientOutputs {
+    };
+</xmp>
+
+This is a dictionary containing the [=client extension output=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
+
+
+## Registration Extensions Authenticator Inputs (typedef <dfn>RegistrationExtensionsAuthenticatorInputs</dfn>) ## {#iface-registration-extensions-authenticator-inputs}
+
+<xmp class="idl">
+    typedef record<DOMString, DOMString> RegistrationExtensionsAuthenticatorInputs;
+</xmp>
+
+This is a dictionary containing the [=authenticator extension input=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
 
 ## Authentication Extensions Client Inputs (typedef <dfn>AuthenticationExtensionsClientInputs</dfn>) ## {#iface-authentication-extensions-client-inputs}
 
@@ -4319,7 +4346,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
       required BufferSource rpPublicKey;
     };
 
-    partial dictionary AuthenticationExtensionsClientInputs {
+    partial dictionary RegistrationExtensionsClientInputs {
       CableRegistrationData cableRegistration;
     };
     </xmp>

--- a/index.bs
+++ b/index.bs
@@ -4303,6 +4303,116 @@ as candidates to be employed in a [=registration=] ceremony.
 : Authenticator extension output
 :: None.
 
+## Cloud-Assisted BLE Registration Extension (cable) ## {#sctn-cable-registration-extension}
+
+This [=authenticator extension=] allows [=[RPS]=] to pass additional data to an
+authenticator that is needed to facilitate caBLE pairing for credential creation.
+
+: Extension identifier
+:: `cableRegistration`
+
+: Client extension input
+:: A Javascript object defined as follows:
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientInputs {
+      required long version;
+      required ArrayBuffer rpPublicKey;
+    };
+    </xmp>
+
+    The version is the protocol version requested.
+
+    The rpPublicKe is an ECDH P-256 public key.
+
+: Client extension processing
+::  1. If present in a {{CredentialsContainer/get()}} call, return a
+        "{{NotSupportedError}}" {{DOMException}}—this extension is only valid when
+        registering a credential.
+    1. ... TODO ... 
+
+: Client extension output
+:: Returns the authenticator extension output as an ArrayBuffer.
+
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientOutputs {
+      ArrayBuffer cableRegistration;
+    };
+    </xmp>
+
+: Authenticator extension input
+:: The client extension input encoded as a CBOR map.
+
+: Authenticator extension processing
+:: None.
+
+: Authenticator extension output
+:: A CBOR map:
+
+    ```
+    cableRegistration = {
+                           version: int,
+                           maxVersion: int,
+                           authnrPublicKey: bytes,
+                       }
+    ```
+
+    The version is the protocol version used by the authenticator.
+
+    The maxVersion is the highest version supported by the authenticator. This
+    is to identify a downgrade attack by a MITM.
+
+    The authnrPublicKey is the authenticator's public key.
+
+## Cloud-Assisted BLE authentication Extension (cable) ## {#sctn-cable-authentication-extension}
+
+This [=client extension=] allows [=[RPS]=] to provide the client with 
+additional data to needed to facilitate caBLE pairing during assertion requests.
+
+: Extension identifier
+:: `cableAuthentication`
+
+: Client extension input
+:: A Javascript object defined as follows:
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientInputs {
+      required long version;
+      required ArrayBuffer clientEid;
+      required ArrayBuffer authenticatorEid;
+      required ArrayBuffer sessionPreKey;
+    };
+    </xmp>
+
+    The version is the protocol version used during registration.
+
+    The clientEid is a 16-byte EID advertised by the Client.
+
+    The authenticatorEid is a 16-byte EID advertised by the Authenticator.
+
+    The sessionPreKey is a 32-byte AES session key.
+
+: Client extension processing
+::  1. If present in a {{CredentialsContainer/create()}} call, return a
+        "{{NotSupportedError}}" {{DOMException}}—this extension is only valid when
+        requesting an assertion.
+    1. ... TODO ...
+
+: Client extension output
+:: Returns the value `true` to indicate to the RP that the extension was acted upon.
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientOutputs {
+      boolean cableAuthentication;
+    };
+    </xmp>
+
+: Authenticator extension input
+:: None.
+
+: Authenticator extension processing
+:: ... TODO ... 
+
+: Authenticator extension output
+:: None.
+
 # IANA Considerations # {#sctn-IANA}
 
 ## WebAuthn Attestation Statement Format Identifier Registrations ## {#sctn-att-fmt-reg}

--- a/index.bs
+++ b/index.bs
@@ -1918,33 +1918,6 @@ SHOULD be aborted.
     loses focuses. If a hook is provided, the above paragraph will be updated to include the hook.
     See [WHATWG HTML WG Issue #2711](https://github.com/whatwg/html/issues/2711) for more details. 
 
-## Registration Extensions Client Inputs (typedef <dfn>RegistrationExtensionsClientInputs</dfn>) ## {#iface-registration-extensions-client-inputs}
-
-<xmp class="idl">
-    dictionary RegistrationExtensionsClientInputs {
-    };
-</xmp>
-
-This is a dictionary containing the [=client extension input=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
-
-
-## Registration Extensions Client Outputs (typedef <dfn>RegistrationExtensionsClientOutputs</dfn>) ## {#iface-registration-extensions-client-outputs}
-
-<xmp class="idl">
-    dictionary RegistrationExtensionsClientOutputs {
-    };
-</xmp>
-
-This is a dictionary containing the [=client extension output=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
-
-
-## Registration Extensions Authenticator Inputs (typedef <dfn>RegistrationExtensionsAuthenticatorInputs</dfn>) ## {#iface-registration-extensions-authenticator-inputs}
-
-<xmp class="idl">
-    typedef record<DOMString, DOMString> RegistrationExtensionsAuthenticatorInputs;
-</xmp>
-
-This is a dictionary containing the [=authenticator extension input=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
 
 ## Authentication Extensions Client Inputs (typedef <dfn>AuthenticationExtensionsClientInputs</dfn>) ## {#iface-authentication-extensions-client-inputs}
 
@@ -4332,7 +4305,7 @@ as candidates to be employed in a [=registration=] ceremony.
 
 ## Cloud-Assisted BLE Registration Extension (cable) ## {#sctn-cable-registration-extension}
 
-This [=authenticator extension=] allows [=[RPS]=] to pass additional data to an
+This [=registration extension=] allows [=[RPS]=] to pass additional data to an
 authenticator that is needed to facilitate caBLE pairing for credential creation.
 
 : Extension identifier
@@ -4346,7 +4319,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
       required BufferSource rpPublicKey;
     };
 
-    partial dictionary RegistrationExtensionsClientInputs {
+    partial dictionary AuthenticationExtensionsClientInputs {
       CableRegistrationData cableRegistration;
     };
     </xmp>

--- a/index.bs
+++ b/index.bs
@@ -4314,13 +4314,13 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
 : Client extension input
 :: A Javascript object defined as follows:
     <xmp class="idl">
-    dictionary CableRegistrationArg {
+    dictionary CableRegistrationData {
       required long version;
       required BufferSource rpPublicKey;
     };
 
     partial dictionary AuthenticationExtensionsClientInputs {
-      CableRegistrationArg cableRegistration;
+      CableRegistrationData cableRegistration;
     };
     </xmp>
 
@@ -4369,7 +4369,7 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
 : Client extension input
 :: A Javascript object defined as follows:
     <xmp class="idl">
-    dictionary CableAuthenticationArg {
+    dictionary CableAuthenticationData {
       required long version;
       required BufferSource clientEid;
       required BufferSource authenticatorEid;
@@ -4377,7 +4377,7 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
     };
 
     partial dictionary AuthenticationExtensionsClientInputs {
-      sequence<CableAuthenticationArg> cableAuthentication;
+      sequence<CableAuthenticationData> cableAuthentication;
     };
     </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -4316,7 +4316,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
     <xmp class="idl">
     dictionary cableRegistrationArg {
       required long version;
-      required ArrayBuffer rpPublicKey;
+      required BufferSource rpPublicKey;
     };
 
     partial dictionary AuthenticationExtensionsClientInputs {
@@ -4371,13 +4371,13 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
     <xmp class="idl">
     dictionary cableAuthenticationArg {
       required long version;
-      required ArrayBuffer clientEid;
-      required ArrayBuffer authenticatorEid;
-      required ArrayBuffer sessionPreKey;
+      required BufferSource clientEid;
+      required BufferSource authenticatorEid;
+      required BufferSource sessionPreKey;
     };
 
     partial dictionary AuthenticationExtensionsClientInputs {
-      cableAuthenticationArg cableAuthentication;
+      sequence<cableAuthenticationArg> cableAuthentication;
     };
     </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -4314,13 +4314,13 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
 : Client extension input
 :: A Javascript object defined as follows:
     <xmp class="idl">
-    dictionary cableRegistrationArg {
+    dictionary CableRegistrationArg {
       required long version;
       required BufferSource rpPublicKey;
     };
 
     partial dictionary AuthenticationExtensionsClientInputs {
-      cableRegistrationArg cableRegistration;
+      CableRegistrationArg cableRegistration;
     };
     </xmp>
 
@@ -4347,7 +4347,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
 :: A CBOR map:
 
     ```
-    cableRegistration = {
+    CableRegistration = {
                            version: int,
                            maxVersion: int,
                            authenticatorPublicKey: bytes,
@@ -4369,7 +4369,7 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
 : Client extension input
 :: A Javascript object defined as follows:
     <xmp class="idl">
-    dictionary cableAuthenticationArg {
+    dictionary CableAuthenticationArg {
       required long version;
       required BufferSource clientEid;
       required BufferSource authenticatorEid;
@@ -4377,7 +4377,7 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
     };
 
     partial dictionary AuthenticationExtensionsClientInputs {
-      sequence<cableAuthenticationArg> cableAuthentication;
+      sequence<CableAuthenticationArg> cableAuthentication;
     };
     </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -4314,36 +4314,34 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
 : Client extension input
 :: A Javascript object defined as follows:
     <xmp class="idl">
-    partial dictionary AuthenticationExtensionsClientInputs {
+    dictionary cableRegistrationArg {
       required long version;
       required ArrayBuffer rpPublicKey;
+    };
+
+    partial dictionary AuthenticationExtensionsClientInputs {
+      cableRegistrationArg cableRegistration;
     };
     </xmp>
 
     The version is the protocol version requested.
 
-    The rpPublicKe is an ECDH P-256 public key.
+    The rpPublicKey is an ECDH P-256 public key.
 
 : Client extension processing
 ::  1. If present in a {{CredentialsContainer/get()}} call, return a
         "{{NotSupportedError}}" {{DOMException}}—this extension is only valid when
         registering a credential.
-    1. ... TODO ... 
+    1. Otherwise, encode the values to the authenticator extension input.
 
 : Client extension output
-:: Returns the authenticator extension output as an ArrayBuffer.
-
-    <xmp class="idl">
-    partial dictionary AuthenticationExtensionsClientOutputs {
-      ArrayBuffer cableRegistration;
-    };
-    </xmp>
+:: None.
 
 : Authenticator extension input
 :: The client extension input encoded as a CBOR map.
 
 : Authenticator extension processing
-:: None.
+:: Refer to Section [[#cable-make-credential]]
 
 : Authenticator extension output
 :: A CBOR map:
@@ -4352,16 +4350,13 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
     cableRegistration = {
                            version: int,
                            maxVersion: int,
-                           authnrPublicKey: bytes,
+                           authenticatorPublicKey: bytes,
                        }
     ```
 
-    The version is the protocol version used by the authenticator.
-
-    The maxVersion is the highest version supported by the authenticator. This
-    is to identify a downgrade attack by a MITM.
-
-    The authnrPublicKey is the authenticator's public key.
+During <code>authenticatorGetAssertion()</code>, the RP provides the
+client with the necessary session data via the following extension.
+For details refer to Sections [[#cable-eid]] and [[#cable-encryption]].
 
 ## Cloud-Assisted BLE authentication Extension (cable) ## {#sctn-cable-authentication-extension}
 
@@ -4374,11 +4369,15 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
 : Client extension input
 :: A Javascript object defined as follows:
     <xmp class="idl">
-    partial dictionary AuthenticationExtensionsClientInputs {
+    dictionary cableAuthenticationArg {
       required long version;
       required ArrayBuffer clientEid;
       required ArrayBuffer authenticatorEid;
       required ArrayBuffer sessionPreKey;
+    };
+
+    partial dictionary AuthenticationExtensionsClientInputs {
+      cableAuthenticationArg cableAuthentication;
     };
     </xmp>
 
@@ -4394,21 +4393,18 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
 ::  1. If present in a {{CredentialsContainer/create()}} call, return a
         "{{NotSupportedError}}" {{DOMException}}—this extension is only valid when
         requesting an assertion.
-    1. ... TODO ...
+    1. Otherwise, perform caBLE discovery as per [[#cable-eid]], followed by a
+        caBLE encrypted channel as per [[#cable-encryption]], using the inputs
+        parameters from the extension.
 
 : Client extension output
-:: Returns the value `true` to indicate to the RP that the extension was acted upon.
-    <xmp class="idl">
-    partial dictionary AuthenticationExtensionsClientOutputs {
-      boolean cableAuthentication;
-    };
-    </xmp>
+:: None.
 
 : Authenticator extension input
 :: None.
 
 : Authenticator extension processing
-:: ... TODO ... 
+:: None.
 
 : Authenticator extension output
 :: None.

--- a/index.bs
+++ b/index.bs
@@ -4315,7 +4315,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
 :: A Javascript object defined as follows:
     <xmp class="idl">
     dictionary CableRegistrationData {
-      required long version;
+      required sequence<long> versions;
       required BufferSource rpPublicKey;
     };
 
@@ -4324,7 +4324,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
     };
     </xmp>
 
-    The version is the protocol version requested.
+    Versions is a list of protocol versions supported by the relying party.
 
     The rpPublicKey is an ECDH P-256 public key.
 
@@ -4341,7 +4341,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
 :: The client extension input encoded as a CBOR map.
 
 : Authenticator extension processing
-:: Refer to Section [[#cable-make-credential]]
+:: Refer to Section [#making-a-credential]
 
 : Authenticator extension output
 :: A CBOR map:
@@ -4356,7 +4356,7 @@ authenticator that is needed to facilitate caBLE pairing for credential creation
 
 During <code>authenticatorGetAssertion()</code>, the RP provides the
 client with the necessary session data via the following extension.
-For details refer to Sections [[#cable-eid]] and [[#cable-encryption]].
+For details refer to Sections [#cable-eid] and [#cable-encryption].
 
 ## Cloud-Assisted BLE authentication Extension (cable) ## {#sctn-cable-authentication-extension}
 
@@ -4393,8 +4393,8 @@ additional data to needed to facilitate caBLE pairing during assertion requests.
 ::  1. If present in a {{CredentialsContainer/create()}} call, return a
         "{{NotSupportedError}}" {{DOMException}}—this extension is only valid when
         requesting an assertion.
-    1. Otherwise, perform caBLE discovery as per [[#cable-eid]], followed by a
-        caBLE encrypted channel as per [[#cable-encryption]], using the inputs
+    1. Otherwise, perform caBLE discovery as per [#cable-eid], followed by a
+        caBLE encrypted channel as per [#cable-encryption], using the inputs
         parameters from the extension.
 
 : Client extension output


### PR DESCRIPTION
This is a counterpart to https://github.com/fido-alliance/fido-2-specs/pull/529/, the FIDO2 cloud-assisted BLE PR. We're not quite sure where the extension should live - FIDO2 or WebAuthN. We're leaning towards WebAuthN, since it is relevant to RPs, but hoping others have some thoughts.

Also, this PR currently has references to sections in the FIDO2 spec that I can either replace with complete explanations or update links to once they're available in the FIDO spec. We figured we would get eyes on it now and clean up along the way.

Note that since this is the first registration extension, this PR also adds RegistrationExtensionsClientInputs/Outputs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kpaulh/webauthn/pull/909.html" title="Last updated on May 1, 2019, 11:44 PM UTC (63be77d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/909/5d11e62...kpaulh:63be77d.html" title="Last updated on May 1, 2019, 11:44 PM UTC (63be77d)">Diff</a>