### PR TITLE
Trim unnecessary step from appId extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3852,10 +3852,7 @@ JavaScript APIs.
     </xmp>
 
 : Client extension processing
-::  1. If present in a {{CredentialsContainer/create()}} call, return a
-        "{{NotSupportedError}}" {{DOMException}}—this extension is only valid when
-        requesting an assertion.
-    1. Let |facetId| be the result of passing the caller's [=origin=] to the
+::  1. Let |facetId| be the result of passing the caller's [=origin=] to the
         FIDO algorithm for [=determining the FacetID of a calling application=].
     1. Let |appId| be the extension input.
     1. Pass |facetId| and |appId| to the FIDO algorithm for [=determining if a

--- a/index.bs
+++ b/index.bs
@@ -4007,10 +4007,9 @@ creation.
     </xmp>
 
 : Client extension processing
-:: This extension can only be used during {{CredentialsContainer/create()}}. If the client supports the Authenticator Selection
-    Extension, it MUST use the first available authenticator whose AAGUID is present in the {{AuthenticatorSelectionList}}. If
-    none of the available authenticators match a provided AAGUID, the client MUST select an authenticator from among the
-    available authenticators to generate the credential.
+:: If the client supports the Authenticator Selection Extension, it MUST use the first available authenticator whose AAGUID is
+    present in the {{AuthenticatorSelectionList}}. If none of the available authenticators match a provided AAGUID, the client
+    MUST select an authenticator from among the available authenticators to generate the credential.
 
 : Client extension output
 :: Returns the value `true` to indicate to the RP that the extension was acted upon.
@@ -4283,10 +4282,9 @@ as candidates to be employed in a [=registration=] ceremony.
     The FAR is the maximum false rejection rate for a biometric authenticator allowed by the [=[RP]=].
 
 : Client extension processing
-:: This extension can only be used during {{CredentialsContainer/create()}}. If the client supports this
-    extension, it MUST NOT use a biometric authenticator whose FAR or FRR does not match the bounds as provided.  The client
-    can obtain information about the biometric authenticator's performance from authoritative sources such as the FIDO
-    Metadata Service [[FIDOMetadataService]] (see Sec. 3.2 of [[FIDOUAFAuthenticatorMetadataStatements]]).  
+:: If the client supports this extension, it MUST NOT use a biometric authenticator whose FAR or FRR does not match the
+    bounds as provided.  The client can obtain information about the biometric authenticator's performance from authoritative
+    sources such as the FIDO Metadata Service [[FIDOMetadataService]] (see Sec. 3.2 of [[FIDOUAFAuthenticatorMetadataStatements]]).
 
 : Client extension output
 :: Returns the JSON value `true` to indicate to the RP that the extension was acted upon


### PR DESCRIPTION
It's not actually necessary to specify that the extension is only valid for getAssertion because it's already restricted by being part of AuthenticatorExtensionClientInputs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kpaulh/webauthn/pull/910.html" title="Last updated on May 30, 2018, 5:41 PM GMT (8e76351)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/910/1c3dd46...kpaulh:8e76351.html" title="Last updated on May 30, 2018, 5:41 PM GMT (8e76351)">Diff</a>