### PR TITLE
Update FIDO references to newer documents

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -132,7 +132,7 @@ spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20170927
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
 
-spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-appid-and-facets-v1.2-ps-20170411.html
+spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-appid-and-facets-v2.0-ps-20170927.html
     type: dfn
         text: determining the FacetID of a calling application; url: determining-the-facetid-of-a-calling-application
         text: determining if a caller's FacetID is authorized for an AppID; url: determining-if-a-caller-s-facetid-is-authorized-for-an-appid

--- a/index.bs
+++ b/index.bs
@@ -5000,7 +5000,7 @@ for their contributions as our W3C Team Contacts.
     "title": "FIDO ECDAA Algorithm",
     "authors": ["R. Lindemann", "Jan Camenisch", "Manu Drijvers", "Alec Edgington", "Anja Lehmann", "Rainer Urian"],
     "status": "FIDO Alliance Implementation Draft",
-    "href": "https://fidoalliance.org/specs/fido-uaf-v1.1-id-20170202/fido-ecdaa-algorithm-v1.1-id-20170202.html"
+    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-ecdaa-algorithm-v2.0-id-20180227.html"
   },
 
   "SEC1": {
@@ -5011,9 +5011,9 @@ for their contributions as our W3C Team Contacts.
 
   "FIDOMetadataService": {
     "authors": ["R. Lindemann", "B. Hill", "D. Baghdasaryan"],
-    "title": "FIDO Metadata Service v1.0",
-    "href": "https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-metadata-service-v1.0-ps-20141208.html",
-    "status": "FIDO Alliance Proposed Standard"
+    "title": "FIDO Metadata Service",
+    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-metadata-service-v2.0-id-20180227.html",
+    "status": "FIDO Alliance Implementation Draft"
   },
   
   "FIDOUAFAuthenticatorMetadataStatements": {
@@ -5055,10 +5055,10 @@ for their contributions as our W3C Team Contacts.
   },
 
   "FIDOSecRef": {
-    "authors": ["R. Lindemann", "D. Baghdasaryan", "B. Hill"],
+    "authors": ["R. Lindemann", "D. Baghdasaryan", "B. Hill", "Dr. J. E. Hill", "D. Biggs"],
     "title": "FIDO Security Reference",
-    "href": "https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-security-ref-v1.2-ps-20170411.html",
-    "status": "FIDO Alliance Proposed Standard"
+    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-security-ref-v2.0-id-20180227.html",
+    "status": "FIDO Alliance Implementation Draft"
   },
 
   "FIDO-Registry": {

--- a/index.bs
+++ b/index.bs
@@ -128,11 +128,11 @@ spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
         text: focus
         text: username; url: attr-fe-autocomplete-username
 
-spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html
+spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
 
-spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-appid-and-facets-v2.0-ps-20170927.html
+spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html
     type: dfn
         text: determining the FacetID of a calling application; url: determining-the-facetid-of-a-calling-application
         text: determining if a caller's FacetID is authorized for an AppID; url: determining-if-a-caller-s-facetid-is-authorized-for-an-appid
@@ -143,7 +143,7 @@ spec: FIDO-U2F-Message-Formats; urlPrefix: https://fidoalliance.org/specs/fido-u
         text: Section 4.3; url: registration-response-message-success
         text: Section 5.4; url: authentication-response-message-success
 
-spec: FIDO-Registry; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-registry-v2.0-ps-20170927.html
+spec: FIDO-Registry; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html
     type: dfn
         text: Section 3.1 User Verification Methods; url: user-verification-methods
         text: Section 3.2 Key Protection Types; url: key-protection-types
@@ -5000,7 +5000,9 @@ for their contributions as our W3C Team Contacts.
     "title": "FIDO ECDAA Algorithm",
     "authors": ["R. Lindemann", "Jan Camenisch", "Manu Drijvers", "Alec Edgington", "Anja Lehmann", "Rainer Urian"],
     "status": "FIDO Alliance Implementation Draft",
-    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-ecdaa-algorithm-v2.0-id-20180227.html"
+    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-ecdaa-algorithm-v2.0-id-20180227.html",
+    "status": "FIDO Alliance Implementation Draft",
+    "date": "27 February 2018"
   },
 
   "SEC1": {
@@ -5013,7 +5015,8 @@ for their contributions as our W3C Team Contacts.
     "authors": ["R. Lindemann", "B. Hill", "D. Baghdasaryan"],
     "title": "FIDO Metadata Service",
     "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-metadata-service-v2.0-id-20180227.html",
-    "status": "FIDO Alliance Implementation Draft"
+    "status": "FIDO Alliance Implementation Draft",
+    "date": "27 February 2018"
   },
   
   "FIDOUAFAuthenticatorMetadataStatements": {
@@ -5058,22 +5061,24 @@ for their contributions as our W3C Team Contacts.
     "authors": ["R. Lindemann", "D. Baghdasaryan", "B. Hill", "Dr. J. E. Hill", "D. Biggs"],
     "title": "FIDO Security Reference",
     "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-security-ref-v2.0-id-20180227.html",
-    "status": "FIDO Alliance Implementation Draft"
+    "status": "FIDO Alliance Implementation Draft",
+    "date": "27 February 2018"
   },
 
   "FIDO-Registry": {
-    "authors": ["R. Lindemann"],
+    "authors": ["R. Lindemann", "D. Baghdasaryan", "B. Hill"],
     "title": "FIDO Registry of Predefined Values",
-    "href": "https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-registry-v2.0-ps-20170927.html",
-    "status": "FIDO Alliance Proposed Standard",
-    "date": "27 September 2017"
+    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html",
+    "status": "FIDO Alliance Implementation Draft",
+    "date": "27 February 2018"
   },
 
   "FIDO-APPID": {
     "authors": ["D. Balfanz", "B. Hill", "R. Lindemann", "D. Baghdasaryan"],
-    "title": "FIDO AppID and Facets",
-    "href": "https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-appid-and-facets-v2.0-ps-20170927.html",
-    "status": "FIDO Alliance Proposed Standard"
+    "title": "FIDO AppID and Facet Specification",
+    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html",
+    "status": "FIDO Alliance Implementation Draft",
+    "date": "27 February 2018"
   },
 
   "FIDO-U2F-Message-Formats": {
@@ -5084,11 +5089,12 @@ for their contributions as our W3C Team Contacts.
   },
 
   "FIDO-CTAP": {
-    "authors": ["R. Lindemann", "V. Bharadwaj", "A. Czeskis", "M. B. Jones", "J. Hodges", "A. Kumar", "C. Brand", "J. Verrept",
-        "J. Ehrensvard"],
-    "title": "FIDO 2.0: Client to Authenticator Protocol",
-    "href": "https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html",
-    "status": "FIDO Alliance Proposed Standard"
+    "authors": ["M. Antoine", "V. Bharadwaj", "C. Brand", "A. Czeskis", "J. Ehrensvärd", "J. Hodges", "M. B. Jones", "A. Kumar",
+        "R. Lindemann", "M. J. Ploch", "A. Powers", "J. Verrept"],
+    "title": "Client to Authenticator Protocol",
+    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html",
+    "status": "FIDO Alliance Implementation Draft",
+    "date": "27 February 2018"
   },
 
   "FIDO-UAF-AUTHNR-CMDS": {


### PR DESCRIPTION
This fixes #898.

@rlin1 notes in https://github.com/w3c/webauthn/issues/898#issuecomment-389495168 that [`[FIDOMetadataService]`](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-metadata-service-v2.0-id-20180227.html) has an even newer version in the works, so perhaps we want to hold off on merging this until that's done.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/913.html" title="Last updated on May 30, 2018, 5:33 PM GMT (f9b5981)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/913/454985f...f9b5981.html" title="Last updated on May 30, 2018, 5:33 PM GMT (f9b5981)">Diff</a>