### PR TITLE
Specify extension types in listing instead of prose

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3882,7 +3882,7 @@ These are RECOMMENDED for implementation by user agents targeting broad interope
 
 ## FIDO <dfn>AppID</dfn> Extension (appid) ## {#sctn-appid-extension}
 
-This [=client extension=] allows [=[RPS]=] that have previously registered a
+This extension allows [=[RPS]=] that have previously registered a
 credential using the legacy FIDO JavaScript APIs to request an [=assertion=]. The
 FIDO APIs use an alternative identifier for [=relying parties=] called an |AppID|
 [[FIDO-APPID]], and any credentials created using those APIs will be bound to
@@ -3895,6 +3895,9 @@ JavaScript APIs.
 
 : Extension identifier
 :: `appid`
+
+: Extension type
+:: [=authentication extension|Authentication=]
 
 : Client extension input
 :: A single USVString specifying a FIDO |AppID|.
@@ -3939,11 +3942,14 @@ JavaScript APIs.
 
 ## Simple Transaction Authorization Extension (txAuthSimple) ## {#sctn-simple-txauth-extension}
 
-This [=registration extension=] and [=authentication extension=] allows for a simple form of transaction authorization. A
+This extension allows for a simple form of transaction authorization. A
 [=[RP]=] can specify a prompt string, intended for display on a trusted device on the authenticator.
 
 : Extension identifier
 :: `txAuthSimple`
+
+: Extension type
+:: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
 :: A single USVString prompt.
@@ -3986,11 +3992,14 @@ txAuthSimpleOutput = (tstr)
 
 ## Generic Transaction Authorization Extension (txAuthGeneric) ## {#sctn-generic-txauth-extension}
 
-This [=registration extension=] and [=authentication extension=] allows images to be used as transaction authorization prompts
+This extension allows images to be used as transaction authorization prompts
 as well. This allows authenticators without a font rendering engine to be used and also supports a richer visual appearance.
 
 : Extension identifier
 :: `txAuthGeneric`
+
+: Extension type
+:: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
 :: A JavaScript object defined as follows:
@@ -4031,12 +4040,15 @@ as well. This allows authenticators without a font rendering engine to be used a
 
 ## Authenticator Selection Extension (authnSel) ## {#sctn-authenticator-selection-extension}
 
-This [=registration extension=] allows a [=[RP]=] to guide the selection of the authenticator that will be leveraged when
+This extension allows a [=[RP]=] to guide the selection of the authenticator that will be leveraged when
 creating the credential. It is intended primarily for [=[RPS]=] that wish to tightly control the experience around credential
 creation.
 
 : Extension identifier
 :: `authnSel`
+
+: Extension type
+:: [=registration extension|Registration=]
 
 : Client extension input
 :: A sequence of AAGUIDs:
@@ -4083,10 +4095,13 @@ creation.
 
 ## Supported Extensions Extension (exts) ## {#sctn-supported-extensions-extension}
 
-This [=registration extension=] enables the [=[RP]=] to determine which extensions the authenticator supports.
+This extension enables the [=[RP]=] to determine which extensions the authenticator supports.
 
 : Extension identifier
 :: `exts`
+
+: Extension type
+:: [=registration extension|Registration=]
 
 : Client extension input
 :: The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].
@@ -4122,10 +4137,13 @@ This [=registration extension=] enables the [=[RP]=] to determine which extensio
 
 ## User Verification Index Extension (uvi) ## {#sctn-uvi-extension}
 
-This [=registration extension=] and [=authentication extension=] enables use of a user verification index.
+This extension enables use of a user verification index.
 
 : Extension identifier
 :: `uvi`
+
+: Extension type
+:: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
 :: The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].
@@ -4185,11 +4203,13 @@ This [=registration extension=] and [=authentication extension=] enables use of 
 
 ## Location Extension (loc) ## {#sctn-location-extension}
 
-The location [=registration extension=] and [=authentication extension=] provides the authenticator's current location to the
-WebAuthn [=[RP]=].  
+This extension provides the [=authenticator=]'s current location to the WebAuthn [=[RP]=].
 
 : Extension identifier
 :: `loc`
+
+: Extension type
+:: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
 :: The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].
@@ -4227,10 +4247,13 @@ WebAuthn [=[RP]=].
 
 ## User Verification Method Extension (uvm) ## {#sctn-uvm-extension}
 
-This [=registration extension=] and [=authentication extension=] enables use of a user verification method.
+This extension enables use of a user verification method.
 
 : Extension identifier
 :: `uvm`
+
+: Extension type
+:: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
 :: The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].
@@ -4314,11 +4337,14 @@ This [=registration extension=] and [=authentication extension=] enables use of 
 
 ## Biometric Authenticator Performance Bounds Extension (biometricPerfBounds) ## {#sctn-authenticator-biometric-criteria-extension}
 
-This [=registration extension=] allows [=[RPS]=] to specify the desired performance bounds for selecting [=biometric authenticators=]
+This extension allows [=[RPS]=] to specify the desired performance bounds for selecting [=biometric authenticators=]
 as candidates to be employed in a [=registration=] ceremony. 
 
 : Extension identifier
 :: `biometricPerfBounds`
+
+: Extension type
+:: [=registration extension|Registration=]
 
 : Client extension input
 :: Biometric performance bounds:

--- a/index.bs
+++ b/index.bs
@@ -3896,7 +3896,7 @@ JavaScript APIs.
 : Extension identifier
 :: `appid`
 
-: Extension type
+: Operation applicability
 :: [=authentication extension|Authentication=]
 
 : Client extension input
@@ -3948,7 +3948,7 @@ This extension allows for a simple form of transaction authorization. A
 : Extension identifier
 :: `txAuthSimple`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
@@ -3998,7 +3998,7 @@ as well. This allows authenticators without a font rendering engine to be used a
 : Extension identifier
 :: `txAuthGeneric`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
@@ -4047,7 +4047,7 @@ creation.
 : Extension identifier
 :: `authnSel`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=]
 
 : Client extension input
@@ -4100,7 +4100,7 @@ This extension enables the [=[RP]=] to determine which extensions the authentica
 : Extension identifier
 :: `exts`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=]
 
 : Client extension input
@@ -4142,7 +4142,7 @@ This extension enables use of a user verification index.
 : Extension identifier
 :: `uvi`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
@@ -4208,7 +4208,7 @@ This extension provides the [=authenticator=]'s current location to the WebAuthn
 : Extension identifier
 :: `loc`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
@@ -4252,7 +4252,7 @@ This extension enables use of a user verification method.
 : Extension identifier
 :: `uvm`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
@@ -4343,7 +4343,7 @@ as candidates to be employed in a [=registration=] ceremony.
 : Extension identifier
 :: `biometricPerfBounds`
 
-: Extension type
+: Operation applicability
 :: [=registration extension|Registration=]
 
 : Client extension input

--- a/index.bs
+++ b/index.bs
@@ -3949,7 +3949,7 @@ This extension allows for a simple form of transaction authorization. A
 :: `txAuthSimple`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|authentication=]
+:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
 
 : Client extension input
 :: A single USVString prompt.
@@ -3999,7 +3999,7 @@ as well. This allows authenticators without a font rendering engine to be used a
 :: `txAuthGeneric`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|authentication=]
+:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
 
 : Client extension input
 :: A JavaScript object defined as follows:
@@ -4143,7 +4143,7 @@ This extension enables use of a user verification index.
 :: `uvi`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|authentication=]
+:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
 
 : Client extension input
 :: The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].
@@ -4209,7 +4209,7 @@ This extension provides the [=authenticator=]'s current location to the WebAuthn
 :: `loc`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|authentication=]
+:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
 
 : Client extension input
 :: The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].
@@ -4253,7 +4253,7 @@ This extension enables use of a user verification method.
 :: `uvm`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|authentication=]
+:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
 
 : Client extension input
 :: The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].


### PR DESCRIPTION
I think this makes it easier to identify the type(s) of the extensions. Since the extension types are referenced in [create()][create] and [get()][get], it seems preferable to specify them clearly and formally instead of in the prose description as is currently done.

The term "extension type" is currently left without a formal definition, though. I'm thinking one probably isn't necessary, but I can add one if it is.

This PR currently has no accompanying issue.

[create]: https://w3c.github.io/webauthn/#ref-for-registration-extension
[get]: https://w3c.github.io/webauthn/#ref-for-authentication-extension


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/941.html" title="Last updated on Jun 20, 2018, 4:42 PM GMT (b971c66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/941/b0ca15f...b971c66.html" title="Last updated on Jun 20, 2018, 4:42 PM GMT (b971c66)">Diff</a>