### PR TITLE
Add Dockerfile with Bikeshed installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install --editable ./bikeshed
 cp -R .spec-data/* ./bikeshed/bikeshed/spec-data
 ```
 
-Alternatively, you can use the [Vagrant VM with `bikeshed` already installed](vagrant/bikeshed).
+Alternatively, you can use the [Vagrant VM with `bikeshed` already installed](vagrant/bikeshed), or the [Docker image](docker/bikeshed).
 
 
 # Continuous Integration & Branches

--- a/docker/bikeshed/Dockerfile
+++ b/docker/bikeshed/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /spec
 
 RUN git clone --depth=1 --branch=master https://github.com/tabatkins/bikeshed.git /bikeshed
 RUN pip install --editable /bikeshed
-RUN ln -s /spec/.spec-data /bikeshed/spec-data
 
 ENTRYPOINT ["/usr/local/bin/bikeshed", "--print=console"]
 CMD ["spec"]

--- a/docker/bikeshed/Dockerfile
+++ b/docker/bikeshed/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:2
+
+VOLUME /spec
+WORKDIR /spec
+
+RUN git clone --depth=1 --branch=master https://github.com/tabatkins/bikeshed.git /bikeshed
+RUN pip install --editable /bikeshed
+RUN ln -s /spec/.spec-data /bikeshed/spec-data
+
+ENTRYPOINT ["/usr/local/bin/bikeshed", "--print=console"]
+CMD ["spec"]

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -1,0 +1,25 @@
+Docker image with `bikeshed`
+===
+
+Build the image:
+
+    alice@work $ cd webauthn/docker/bikeshed
+    alice@work $ docker build -t bikeshed .
+    alice@work $ cd ../..
+
+Then run it as `bikeshed` or `bikeshed watch`:
+
+- ```
+  alice@work $ docker run --name bikeshed-webauthn -it --volume $(pwd):/spec bikeshed
+  alice@work $ docker start --attach bikeshed-webauthn
+  ```
+
+- ```
+  alice@work $ docker run --name bikeshed-webauthn-watch -it --volume $(pwd):/spec bikeshed watch
+  ==============DONE==============
+  ^C
+  alice@work $ docker start --attach bikeshed-webauthn-watch
+  ==============DONE==============
+  ^C
+  alice@work $ docker stop bikeshed-webauthn-watch
+  ```

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -1,6 +1,8 @@
 Docker image with `bikeshed`
 ===
 
+This requires having [Docker][docker] installed.
+
 Build the image:
 
     alice@work $ docker build -t bikeshed docker/bikeshed --no-cache
@@ -26,3 +28,6 @@ Then run it as `bikeshed` or `bikeshed watch`:
   ^C
   alice@work $ docker stop bikeshed-webauthn-watch
   ```
+
+
+[docker]: https://www.docker.com/community-edition

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -32,4 +32,23 @@ on subsequent uses.
   ```
 
 
+Rebuilding
+---
+
+To rebuild the image with the latest Bikeshed version, run `docker build` again:
+
+    alice@work $ docker build -t bikeshed docker/bikeshed --no-cache
+
+This will create a new image and overwrite the `bikeshed` tag, but any existing
+container(s) will still be of the previous version of the image (which now no
+longer has a tag).
+
+So delete the existing container(s):
+
+    alice@work $ docker rm -v bikeshed-webauthn
+    alice@work $ docker rm -v bikeshed-webauthn-watch
+
+...and then re-run the `docker run` command(s) in the previous section.
+
+
 [docker]: https://www.docker.com/community-edition

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -9,12 +9,16 @@ Build the image:
 
 Then run it as `bikeshed` or `bikeshed watch`:
 
-- ```
+- Either in one-shot mode:
+
+  ```
   alice@work $ docker run --name bikeshed-webauthn -it --volume $(pwd):/spec bikeshed
   alice@work $ docker start --attach bikeshed-webauthn
   ```
 
-- ```
+- Or in continuous watch mode:
+
+  ```
   alice@work $ docker run --name bikeshed-webauthn-watch -it --volume $(pwd):/spec bikeshed watch
   ==============DONE==============
   ^C

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -3,9 +3,7 @@ Docker image with `bikeshed`
 
 Build the image:
 
-    alice@work $ cd webauthn/docker/bikeshed
-    alice@work $ docker build -t bikeshed . --no-cache
-    alice@work $ cd ../..
+    alice@work $ docker build -t bikeshed docker/bikeshed --no-cache
 
 Then run it as `bikeshed` or `bikeshed watch`:
 

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -12,6 +12,7 @@ Then run it as `bikeshed` or `bikeshed watch`:
   ```
   alice@work $ docker run --name bikeshed-webauthn -it --volume $(pwd):/spec bikeshed
   alice@work $ docker start --attach bikeshed-webauthn
+  alice@work $ $BROWSER index.html
   ```
 
 - Or in continuous watch mode:

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -4,7 +4,7 @@ Docker image with `bikeshed`
 Build the image:
 
     alice@work $ cd webauthn/docker/bikeshed
-    alice@work $ docker build -t bikeshed .
+    alice@work $ docker build -t bikeshed . --no-cache
     alice@work $ cd ../..
 
 Then run it as `bikeshed` or `bikeshed watch`:

--- a/docker/bikeshed/README.md
+++ b/docker/bikeshed/README.md
@@ -7,7 +7,9 @@ Build the image:
 
     alice@work $ docker build -t bikeshed docker/bikeshed --no-cache
 
-Then run it as `bikeshed` or `bikeshed watch`:
+Then run it as `bikeshed` or `bikeshed watch`. Use the `docker run` command the
+first time you run the image after building it, then the `docker start` command
+on subsequent uses.
 
 - Either in one-shot mode:
 


### PR DESCRIPTION
As noted in #936. The Dockerfile builds an image with the latest version of Bikeshed installed, to simplify local compilation of the spec. See the included README for usage instructions.