### PR TITLE
improve #936: existing linking lint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3008,10 +3008,10 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
     is maintained in the in the IANA registry of the same name [[!WebAuthn-Registries]].
 
 1. Verify that |attStmt| is a correct [=attestation statement=], conveying a valid [=attestation signature=], by using the
-    [=attestation statement format=] |fmt|'s verification procedure given |attStmt|, |authData| and the [=hash of the serialized
+    [=attestation statement format=] |fmt|'s [=verification procedure=] given |attStmt|, |authData| and the [=hash of the serialized
     client data=] computed in step 7.
 
-    Note: Each [=attestation statement format=] specifies its own verification procedure. See [[#defined-attestation-formats]] for
+    Note: Each [=attestation statement format=] specifies its own [=verification procedure=]. See [[#defined-attestation-formats]] for
     the initially-defined formats, and [[!WebAuthn-Registries]] for the up-to-date list.
 
 1. If validation is successful, obtain a list of acceptable trust anchors (attestation root certificates or [=ECDAA-Issuer
@@ -3019,11 +3019,11 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
     example, the FIDO Metadata Service [[FIDOMetadataService]] provides one way to obtain such information, using the
     <code>[=aaguid=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|.
 
-1. Assess the attestation trustworthiness using the outputs of the verification procedure in step 14, as follows:
+1. Assess the attestation trustworthiness using the outputs of the [=verification procedure=] in step 14, as follows:
         - If [=self attestation=] was used, check if [=self attestation=] is acceptable under [=[RP]=] policy.
         - If [=ECDAA=] was used, verify that the [=identifier of the ECDAA-Issuer public key=] used is included in the set of
             acceptable trust anchors obtained in step 15.
-        - Otherwise, use the X.509 certificates returned by the verification procedure to verify that the attestation public key
+        - Otherwise, use the X.509 certificates returned by the [=verification procedure=] to verify that the attestation public key
             correctly chains up to an acceptable root certificate.
 
 1. Check that the <code>[=credentialId=]</code> is not yet registered to any other user. If registration 
@@ -3251,7 +3251,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
             omits the other fields.
 
 : Verification procedure
-:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the verification procedure is
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
     as follows:
 
         1. Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract
@@ -3390,7 +3390,7 @@ engine.
     same name, and the |sig| field to the signature obtained from the above procedure.
 
 : Verification procedure
-:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the verification procedure is
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
     as follows:
 
     Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the
@@ -3496,7 +3496,7 @@ the attestation=] is consistent with the fields of the attestation certificate's
 
 
 : Verification procedure
-:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the verification procedure is
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
     as follows:
     - Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the
         contained fields.
@@ -3565,7 +3565,7 @@ even if the SafetyNet API is also present.
     the version of Google Play Services running in the authenticator.
 
 : Verification procedure
-:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the verification procedure is
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
     as follows:
     - Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the
         contained fields.
@@ -3626,7 +3626,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     the attestation public key as |x5c|.
 
 : Verification procedure
-:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the verification procedure is
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
     as follows:
     1. Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the
         contained fields.

--- a/index.bs
+++ b/index.bs
@@ -2867,7 +2867,7 @@ WebAuthn supports multiple attestation types:
         is called "active".
 
 : <dfn>Elliptic Curve based Direct Anonymous Attestation</dfn> (<dfn>ECDAA</dfn>)
-:: In this case, the Authenticator receives direct anonymous attestation (<dfn>DAA</dfn>) credentials from a single DAA-Issuer.
+:: In this case, the Authenticator receives direct anonymous attestation (DAA) credentials from a single DAA-Issuer.
     These DAA credentials are used along with blinding to sign the [=attested credential data=]. The concept of blinding avoids
     the DAA credentials being misused as global correlation handle. WebAuthn supports DAA using elliptic curve cryptography and
     bilinear pairings, called [=ECDAA=] (see [[FIDOEcdaaAlgorithm]]) in this specification. Consequently we denote the DAA-Issuer

--- a/index.bs
+++ b/index.bs
@@ -1933,7 +1933,7 @@ SHOULD be aborted.
     See [WHATWG HTML WG Issue #2711](https://github.com/whatwg/html/issues/2711) for more details. 
 
 
-## Authentication Extensions Client Inputs (typedef <dfn>AuthenticationExtensionsClientInputs</dfn>) ## {#iface-authentication-extensions-client-inputs}
+## Authentication Extensions Client Inputs (typedef AuthenticationExtensionsClientInputs) ## {#iface-authentication-extensions-client-inputs}
 
 <xmp class="idl">
     dictionary AuthenticationExtensionsClientInputs {
@@ -1943,7 +1943,7 @@ SHOULD be aborted.
 This is a dictionary containing the [=client extension input=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
 
 
-## Authentication Extensions Client Outputs (typedef <dfn>AuthenticationExtensionsClientOutputs</dfn>) ## {#iface-authentication-extensions-client-outputs}
+## Authentication Extensions Client Outputs (typedef AuthenticationExtensionsClientOutputs) ## {#iface-authentication-extensions-client-outputs}
 
 <xmp class="idl">
     dictionary AuthenticationExtensionsClientOutputs {
@@ -1953,7 +1953,7 @@ This is a dictionary containing the [=client extension input=] values for zero o
 This is a dictionary containing the [=client extension output=] values for zero or more WebAuthn extensions, as defined in [[#extensions]].
 
 
-## Authentication Extensions Authenticator Inputs (typedef <dfn>AuthenticationExtensionsAuthenticatorInputs</dfn>) ## {#iface-authentication-extensions-authenticator-inputs}
+## Authentication Extensions Authenticator Inputs (typedef AuthenticationExtensionsAuthenticatorInputs) ## {#iface-authentication-extensions-authenticator-inputs}
 
 <xmp class="idl">
     typedef record<DOMString, DOMString> AuthenticationExtensionsAuthenticatorInputs;
@@ -2119,7 +2119,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 </div>
 
 
-### Cryptographic Algorithm Identifier (typedef <dfn>COSEAlgorithmIdentifier</dfn>) ### {#alg-identifier}
+### Cryptographic Algorithm Identifier (typedef COSEAlgorithmIdentifier) ### {#alg-identifier}
 
 <pre class="idl">
     typedef long COSEAlgorithmIdentifier;

--- a/index.bs
+++ b/index.bs
@@ -3653,7 +3653,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
 
 ## None Attestation Statement Format ## {#none-attestation}
 
-The <dfn>none attestation statement format</dfn> is used to replace any [=authenticator=]-provided [=attestation statement=] when a [=[RP]=] indicates it does not wish to receive attestation information, see  [[#attestation-convey]].
+The none attestation statement format is used to replace any [=authenticator=]-provided [=attestation statement=] when a [=[RP]=] indicates it does not wish to receive attestation information, see  [[#attestation-convey]].
 
 : Attestation statement format identifier
 :: none


### PR DESCRIPTION
This improves issue #936 by removing "unused" \<dfn> tags, and adding links to some terms' occurances. 

this does not address all the "Unexported dfn that's not referenced locally" **warnings** because the ones that remain will likely be addressed when cleaning up terminology such as "client-side ....".  And also because these are just warnings and are not apparently breaking the travisCI build.
