### PR TITLE
Add experimental Travis build with no Bikeshed cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - USE_BIKESHED_CACHE=true
   - USE_BIKESHED_CACHE=false
 matrix:
+  fast_finish: true
   allow_failures:
     - env: USE_BIKESHED_CACHE=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 python:
     - "2.7"
+env:
+  - USE_BIKESHED_CACHE=true
+  - USE_BIKESHED_CACHE=false
+matrix:
+  allow_failures:
+    - env: USE_BIKESHED_CACHE=false
+
 sudo: false
 cache: pip
 before_install:
@@ -10,10 +17,13 @@ install:
 - pip install pygments cssselect html5lib lxml
 - git clone --depth=100 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
 - pip install --editable ./bikeshed
-# Use cached copy of bikeshed data files to give consistent builds
-#- bikeshed update
-- cp -R .spec-data/* ./bikeshed/bikeshed/spec-data
-- cp -R .bikeshed-include/* ./bikeshed/bikeshed/boilerplate/webauthn
+- |
+  if "$USE_BIKESHED_CACHE"; then
+    # Use cached copy of bikeshed data files to give consistent builds
+    #- bikeshed update
+    cp -R .spec-data/* ./bikeshed/bikeshed/spec-data
+    cp -R .bikeshed-include/* ./bikeshed/bikeshed/boilerplate/webauthn
+  fi
 script: 'bikeshed spec'
 after_success:
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] && ./.deploy-output.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 - git clone --depth=100 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
 - pip install --editable ./bikeshed
 - |
-  if "$USE_BIKESHED_CACHE"; then
+  if "${USE_BIKESHED_CACHE}"; then
     # Use cached copy of bikeshed data files to give consistent builds
     #- bikeshed update
     cp -R .spec-data/* ./bikeshed/bikeshed/spec-data


### PR DESCRIPTION
This is the PR promised in https://github.com/w3c/webauthn/issues/936#issuecomment-396210678 .

This adds a second job to the Travis builds, in which the Bikeshed "cache" is not used. This should catch upstream changes faster than the standard build, but this job is also listed in `allow_failures` so that a failure in it does not fail the build as a whole.