### PR TITLE
Replace <pre class="idl">s with <xmp>s

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -716,22 +716,22 @@ implementation of {{PublicKeyCredential/[[Create]](origin, options, sameOriginWi
 To support registration via {{CredentialsContainer/create()|navigator.credentials.create()}}, this document extends
 the {{CredentialCreationOptions}} dictionary as follows:
 
-<pre class="idl">
+<xmp class="idl">
     partial dictionary CredentialCreationOptions {
         PublicKeyCredentialCreationOptions      publicKey;
     };
-</pre>
+</xmp>
 
 ### `CredentialRequestOptions` Dictionary Extension ### {#credentialrequestoptions-extension}
 
 To support obtaining assertions via {{CredentialsContainer/get()|navigator.credentials.get()}}, this document extends the
 {{CredentialRequestOptions}} dictionary as follows:
 
-<pre class="idl">
+<xmp class="idl">
     partial dictionary CredentialRequestOptions {
         PublicKeyCredentialRequestOptions      publicKey;
     };
-</pre>
+</xmp>
 
 
 ### Create a new credential - PublicKeyCredential's `[[Create]](origin, options, sameOriginWithAncestors)` method ### {#createCredential}
@@ -1484,11 +1484,11 @@ A timeout value on the order of 10 minutes is recommended;
 this is enough time for successful user interactions to be performed
 but short enough that the dangling promise will still be resolved in a reasonably timely fashion.
 
-<pre class="idl">
+<xmp class="idl">
     partial interface PublicKeyCredential {
-        static Promise < boolean > isUserVerifyingPlatformAuthenticatorAvailable();
+        static Promise<boolean> isUserVerifyingPlatformAuthenticatorAvailable();
     };
-</pre>
+</xmp>
 
 </div>
 
@@ -1497,12 +1497,12 @@ but short enough that the dangling promise will still be resolved in a reasonabl
 [=Authenticators=] respond to [=[RP]=] requests by returning an object derived from the
 {{AuthenticatorResponse}} interface:
 
-<pre class="idl">
+<xmp class="idl">
     [SecureContext, Exposed=Window]
     interface AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      clientDataJSON;
     };
-</pre>
+</xmp>
 <div dfn-type="attribute" dfn-for="AuthenticatorResponse">
     :   <dfn>clientDataJSON</dfn>
     ::  This attribute contains a [=JSON-serialized client data|JSON serialization=] of the [=client data=] passed to the
@@ -1516,12 +1516,12 @@ for the creation of a new [=public key credential=]. It contains information abo
 identify it for later use, and metadata that can be used by the [=[RP]=] to assess the characteristics of the credential
 during registration.
 
-<pre class="idl">
+<xmp class="idl">
     [SecureContext, Exposed=Window]
     interface AuthenticatorAttestationResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      attestationObject;
     };
-</pre>
+</xmp>
 <div dfn-type="attribute" dfn-for="AuthenticatorAttestationResponse">
     :   {{AuthenticatorResponse/clientDataJSON}}
     ::  This attribute, inherited from {{AuthenticatorResponse}}, contains the [=JSON-serialized client data=] (see
@@ -1547,14 +1547,14 @@ generation of a new [=authentication assertion=] given the [=[RP]=]'s challenge 
 aware of. This response contains a cryptographic signature proving possession of the [=credential private key=], and
 optionally evidence of [=user consent=] to a specific transaction.
 
-<pre class="idl">
+<xmp class="idl">
     [SecureContext, Exposed=Window]
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
         [SameObject] readonly attribute ArrayBuffer?     userHandle;
     };
-</pre>
+</xmp>
 <div dfn-type="attribute" dfn-for="AuthenticatorAssertionResponse">
     :   {{AuthenticatorResponse/clientDataJSON}}
     ::  This attribute, inherited from {{AuthenticatorResponse}}, contains the [=JSON-serialized client data=] (see
@@ -1575,12 +1575,12 @@ optionally evidence of [=user consent=] to a specific transaction.
 
 ## Parameters for Credential Generation (dictionary <dfn dictionary>PublicKeyCredentialParameters</dfn>) ## {#credential-params}
 
-<pre class="idl">
+<xmp class="idl">
     dictionary PublicKeyCredentialParameters {
         required PublicKeyCredentialType      type;
         required COSEAlgorithmIdentifier      alg;
     };
-</pre>
+</xmp>
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialParameters">
     This dictionary is used to supply additional parameters when creating a new credential.
@@ -1703,11 +1703,11 @@ associated.
 
 The {{PublicKeyCredentialRpEntity}} dictionary is used to supply additional [=[RP]=] attributes when creating a new credential.
 
-<pre class="idl">
+<xmp class="idl">
     dictionary PublicKeyCredentialRpEntity : PublicKeyCredentialEntity {
         DOMString      id;
     };
-</pre>
+</xmp>
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialRpEntity">
     :   <dfn>id</dfn>
@@ -1720,12 +1720,12 @@ The {{PublicKeyCredentialRpEntity}} dictionary is used to supply additional [=[R
 The {{PublicKeyCredentialUserEntity}} dictionary is used to supply additional user account attributes when creating a new
 credential.
 
-<pre class="idl">
+<xmp class="idl">
     dictionary PublicKeyCredentialUserEntity : PublicKeyCredentialEntity {
         required BufferSource   id;
         required DOMString      displayName;
     };
-</pre>
+</xmp>
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialUserEntity">
     :   <dfn>id</dfn>
@@ -1773,12 +1773,12 @@ attributes.
 
 ### Authenticator Attachment enumeration (enum <dfn enum>AuthenticatorAttachment</dfn>) ### {#attachment}
 
-<pre class="idl">
+<xmp class="idl">
     enum AuthenticatorAttachment {
         "platform",
         "cross-platform"
     };
-</pre>
+</xmp>
 
 <div dfn-type="enum-value" dfn-for="AuthenticatorAttachment">
     :   <dfn>platform</dfn>
@@ -1826,13 +1826,13 @@ credential|credentials=]. The [=client=] and user will then use whichever is ava
 [=[RPS]=] may use {{AttestationConveyancePreference}} to specify their preference regarding [=attestation conveyance=]
 during credential generation.
 
-<pre class="idl">
+<xmp class="idl">
     enum AttestationConveyancePreference {
         "none",
         "indirect",
         "direct"
     };
-</pre>
+</xmp>
 
 <div dfn-type="enum-value" dfn-for="AttestationConveyancePreference">
     :   <dfn>none</dfn>
@@ -1976,7 +1976,7 @@ following Web IDL.
 
 Note: The {{CollectedClientData}} may be extended in the future. Therefore it's critical when parsing to be tolerant of unknown keys and of any reordering of the keys.
 
-<pre class="idl">
+<xmp class="idl">
     dictionary CollectedClientData {
         required DOMString           type;
         required DOMString           challenge;
@@ -1990,7 +1990,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     };
 
     enum TokenBindingStatus { "present", "supported", "not-supported" };
-</pre>
+</xmp>
 
 <div dfn-type="dict-member" dfn-for="CollectedClientData">
     :   <dfn>type</dfn>
@@ -2044,11 +2044,11 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
 
 ### Credential Type enumeration (enum <dfn enum>PublicKeyCredentialType</dfn>) ### {#credentialType}
 
-<pre class="idl">
+<xmp class="idl">
     enum PublicKeyCredentialType {
         "public-key"
     };
-</pre>
+</xmp>
 
 <div dfn-type="enum-value" dfn-for="PublicKeyCredentialType">
     This enumeration defines the valid credential types. It is an extension point; values can be added to it in the future, as
@@ -2088,14 +2088,14 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
 ### Authenticator Transport enumeration (enum <dfn enum>AuthenticatorTransport</dfn>) ### {#transport}
 
-<pre class="idl">
+<xmp class="idl">
     enum AuthenticatorTransport {
         "usb",
         "nfc",
         "ble",
         "internal"
     };
-</pre>
+</xmp>
 
 <div dfn-type="enum-value" dfn-for="AuthenticatorTransport">
     [=Authenticators=] may implement various [[#transport|transports]] for communicating with [=clients=]. This enumeration
@@ -2121,9 +2121,9 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
 ### Cryptographic Algorithm Identifier (typedef {{COSEAlgorithmIdentifier}}) ### {#alg-identifier}
 
-<pre class="idl">
+<xmp class="idl">
     typedef long COSEAlgorithmIdentifier;
-</pre>
+</xmp>
 
 <div dfn-type="typedef" dfn-for="COSEAlgorithmIdentifier">
     A {{COSEAlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
@@ -2134,13 +2134,13 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
 ### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
 
-<pre class="idl">
+<xmp class="idl">
     enum UserVerificationRequirement {
         "required",
         "preferred",
         "discouraged"
     };
-</pre>
+</xmp>
 
 A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express its
 needs.
@@ -4320,12 +4320,12 @@ as candidates to be employed in a [=registration=] ceremony.
 : Client extension input
 :: Biometric performance bounds:
 
-    <pre class="idl">
+    <xmp class="idl">
     dictionary authenticatorBiometricPerfBounds{
         float FAR;
         float FRR;
         };
-    </pre>
+    </xmp>
 
     The FAR is the maximum false acceptance rate for a biometric authenticator allowed by the [=[RP]=].
 


### PR DESCRIPTION
This fixes #943.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/949.html" title="Last updated on Jun 13, 2018, 4:17 PM GMT (5300df3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/949/99c552c...5300df3.html" title="Last updated on Jun 13, 2018, 4:17 PM GMT (5300df3)">Diff</a>