### PR TITLE
Fix #593: employ PRECIS RFC8264 et al for 'name'-ish domstring values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1793,8 +1793,8 @@ credential.
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialUserEntity">
     :   <dfn>id</dfn>
     ::  The [=user handle=] of the user account entity. To ensure secure operation, authentication and authorization
-        decisions MUST be made on the basis of this {{PublicKeyCredentialEntity/id}} member,  not the
-        {{PublicKeyCredentialEntity/displayName}} nor {{PublicKeyCredentialEntity/name}} members. See [[!RFC8266]]
+        decisions MUST be made on the basis of this {{PublicKeyCredentialUserEntity/id}} member,  not the
+        {{PublicKeyCredentialUserEntity/displayName}} nor {{PublicKeyCredentialEntity/name}} members. See [[!RFC8266]]
         Section 6.1.
 
     :   <dfn>displayName</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1724,12 +1724,12 @@ associated.
           - When inherited by {{PublicKeyCredentialRpEntity}} it is a [=human palatability|human-palatable=] identifier for the [=[RP]=], intended only
             for display. For example, "ACME Corporation", "Wonderful Widgets, Inc." or "ОАО Примертех".
 
-              - [=[RPS]=] SHOULD perform enforcement, as prescribed in [[!RFC8266]]
-                Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+              - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
+                [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
                 when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value to the user.
 
-              - [=Clients=] MUST perform enforcement, as prescribed in [[!RFC8266]]
-                Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+              - [=Clients=] MUST perform enforcement, as prescribed in Section 2.3 of
+                [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
@@ -1739,12 +1739,12 @@ associated.
             or "+14255551234".
 
               - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,
-                as prescribed in [[!RFC8265]] Section 3.4.3 for the UsernameCasePreserved Profile of the PRECIS
+                as prescribed in Section 3.4.3 of [[!RFC8265]] for the UsernameCasePreserved Profile of the PRECIS
                 IdentifierClass [[!RFC8264]], when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value
                 to the user.
 
-              - [=Clients=] MUST perform enforcement, as prescribed in [[!RFC8265]]
-                Section 3.4.3 for the UsernameCasePreserved Profile of the PRECIS IdentifierClass [[!RFC8264]],
+              - [=Clients=] MUST perform enforcement, as prescribed in Section 3.4.3 of [[!RFC8265]]
+                for the UsernameCasePreserved Profile of the PRECIS IdentifierClass [[!RFC8264]],
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
@@ -1794,19 +1794,18 @@ credential.
     :   <dfn>id</dfn>
     ::  The [=user handle=] of the user account entity. To ensure secure operation, authentication and authorization
         decisions MUST be made on the basis of this {{PublicKeyCredentialUserEntity/id}} member,  not the
-        {{PublicKeyCredentialUserEntity/displayName}} nor {{PublicKeyCredentialEntity/name}} members. See [[!RFC8266]]
-        Section 6.1.
+        {{PublicKeyCredentialUserEntity/displayName}} nor {{PublicKeyCredentialEntity/name}} members. See Section 6.1 of [[!RFC8266]].
 
     :   <dfn>displayName</dfn>
     ::  A [=human palatability|human-palatable=] name for the user account, intended only for display. For example, "Alex P. Müller" or "田中 倫". The
         [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
 
-        - [=[RPS]=] SHOULD perform enforcement, as prescribed in [[!RFC8266]]
-            Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+        - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
+            [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
             when setting {{PublicKeyCredentialUserEntity/displayName}}'s value, or displaying the value to the user.
 
-        - [=Clients=] MUST perform enforcement, as prescribed in [[!RFC8266]]
-            Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+        - [=Clients=] MUST perform enforcement, as prescribed in Section 2.3 of
+            [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
             on {{PublicKeyCredentialUserEntity/displayName}}'s value prior to displaying the value to the user or
             including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 

--- a/index.bs
+++ b/index.bs
@@ -1728,7 +1728,7 @@ associated.
                 [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
                 when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value to the user.
 
-              - [=Clients=] MUST perform enforcement, as prescribed in Section 2.3 of
+              - [=Clients=] SHOULD perform enforcement, as prescribed in Section 2.3 of
                 [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
@@ -1743,7 +1743,7 @@ associated.
                 IdentifierClass [[!RFC8264]], when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value
                 to the user.
 
-              - [=Clients=] MUST perform enforcement, as prescribed in Section 3.4.3 of [[!RFC8265]]
+              - [=Clients=] SHOULD perform enforcement, as prescribed in Section 3.4.3 of [[!RFC8265]]
                 for the UsernameCasePreserved Profile of the PRECIS IdentifierClass [[!RFC8264]],
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
@@ -1804,7 +1804,7 @@ credential.
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
             when setting {{PublicKeyCredentialUserEntity/displayName}}'s value, or displaying the value to the user.
 
-        - [=Clients=] MUST perform enforcement, as prescribed in Section 2.3 of
+        - [=Clients=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
             on {{PublicKeyCredentialUserEntity/displayName}}'s value prior to displaying the value to the user or
             including the value as a parameter of the [=authenticatorMakeCredential=] operation.

--- a/index.bs
+++ b/index.bs
@@ -1724,12 +1724,12 @@ associated.
           - When inherited by {{PublicKeyCredentialRpEntity}} it is a [=human palatability|human-palatable=] identifier for the [=[RP]=], intended only
             for display. For example, "ACME Corporation", "Wonderful Widgets, Inc." or "ОАО Примертех".
 
-              - [=[RPS]=] SHOULD perform preparation and enforcement, as prescribed in [[!RFC8266]]
-                Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+              - [=[RPS]=] SHOULD perform enforcement, as prescribed in [[!RFC8266]]
+                Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
                 when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value to the user.
 
-              - [=Clients=] MUST perform preparation and enforcement, as prescribed in [[!RFC8266]]
-                Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+              - [=Clients=] MUST perform enforcement, as prescribed in [[!RFC8266]]
+                Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
@@ -1738,13 +1738,13 @@ associated.
             accounts with similar {{PublicKeyCredentialUserEntity/displayName}}s. For example, "alexm", "alex.p.mueller@example.com"
             or "+14255551234".
 
-              - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform preparation and enforcement,
-                as prescribed in [[!RFC8265]] Sections 3.4.2 and 3.4.3 for the UsernameCasePreserved Profile of the PRECIS
+              - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,
+                as prescribed in [[!RFC8265]] Section 3.4.3 for the UsernameCasePreserved Profile of the PRECIS
                 IdentifierClass [[!RFC8264]], when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value
                 to the user.
 
-              - [=Clients=] MUST perform preparation and enforcement, as prescribed in [[!RFC8265]]
-                Sections 3.4.2 and 3.4.3 for the UsernameCasePreserved Profile of the PRECIS IdentifierClass [[!RFC8264]],
+              - [=Clients=] MUST perform enforcement, as prescribed in [[!RFC8265]]
+                Section 3.4.3 for the UsernameCasePreserved Profile of the PRECIS IdentifierClass [[!RFC8264]],
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
@@ -1801,12 +1801,12 @@ credential.
     ::  A [=human palatability|human-palatable=] name for the user account, intended only for display. For example, "Alex P. Müller" or "田中 倫". The
         [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
 
-        - [=[RPS]=] SHOULD perform preparation and enforcement, as prescribed in [[!RFC8266]]
-            Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+        - [=[RPS]=] SHOULD perform enforcement, as prescribed in [[!RFC8266]]
+            Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
             when setting {{PublicKeyCredentialUserEntity/displayName}}'s value, or displaying the value to the user.
 
-        - [=Clients=] MUST perform preparation and enforcement, as prescribed in [[!RFC8266]]
-            Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+        - [=Clients=] MUST perform enforcement, as prescribed in [[!RFC8266]]
+            Section 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
             on {{PublicKeyCredentialUserEntity/displayName}}'s value prior to displaying the value to the user or
             including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 

--- a/index.bs
+++ b/index.bs
@@ -1657,17 +1657,20 @@ optionally evidence of [=user consent=] to a specific transaction.
     :   <dfn>rp</dfn>
     ::  This member contains data about the [=[RP]=] responsible for the request.
 
-        Its value's {{PublicKeyCredentialEntity/name}} member is required.
+        Its value's {{PublicKeyCredentialEntity/name}} member is required. See [[#dictionary-pkcredentialentity]] for further
+        details.
 
-        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=relying party identifier=] with which the credential
+        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=RP ID=] with which the credential
         should be associated. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
-        settings object=]'s [=environment settings object/origin=]'s [=effective domain=].
+        settings object=]'s [=environment settings object/origin=]'s [=effective domain=]. See [[#sctn-rp-credential-params]]
+        for further details.
 
     :   <dfn>user</dfn>
     ::  This member contains data about the user account for which the [=[RP]=] is requesting attestation.
 
         Its value's {{PublicKeyCredentialEntity/name}}, {{PublicKeyCredentialUserEntity/displayName}} and
-        {{PublicKeyCredentialUserEntity/id}} members are required.
+        {{PublicKeyCredentialUserEntity/id}} members are required. See [[#dictionary-pkcredentialentity]] and
+        [[#sctn-user-credential-params]] for further details.
 
     :   <dfn>challenge</dfn>
     ::  This member contains a challenge intended to be used for generating the newly created credential's [=attestation
@@ -1716,16 +1719,35 @@ associated.
 </xmp>
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialEntity">
     :   <dfn>name</dfn>
-    ::  A human-readable name for the entity. Its function depends on what the {{PublicKeyCredentialEntity}} represents:
+    ::  A [=human palatability|human-palatable=] name for the entity. Its function depends on what the {{PublicKeyCredentialEntity}} represents:
 
-          - When inherited by {{PublicKeyCredentialRpEntity}} it is a human-friendly identifier for the [=[RP]=], intended only
+          - When inherited by {{PublicKeyCredentialRpEntity}} it is a [=human palatability|human-palatable=] identifier for the [=[RP]=], intended only
             for display. For example, "ACME Corporation", "Wonderful Widgets, Inc." or "ОАО Примертех".
+
+              - [=[RPS]=] SHOULD perform preparation and enforcement, as prescribed in [[!RFC8266]]
+                Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+                when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value to the user.
+
+              - [=Clients=] MUST perform preparation and enforcement, as prescribed in [[!RFC8266]]
+                Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+                on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
+                including the value as a parameter of the [=authenticatorMakeCredential=] operation.
+
           - When inherited by {{PublicKeyCredentialUserEntity}}, it is a [=human palatability|human-palatable=] identifier for a
-            user account. It is intended only for display, and SHOULD allow the user to easily tell the difference between user
+            user account. It is intended only for display, i.e., aiding the user in determining the difference between user
             accounts with similar {{PublicKeyCredentialUserEntity/displayName}}s. For example, "alexm", "alex.p.mueller@example.com"
-            or "+14255551234". The [=[RP]=] MAY let the user choose this, and MAY restrict the choice as needed or appropriate.
-            For example, a [=[RP]=] might choose to map [=human palatability|human-palatable=] [=username=] account identifiers to
-            the {{PublicKeyCredentialEntity/name}} member of {{PublicKeyCredentialUserEntity}}.
+            or "+14255551234".
+
+              - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform preparation and enforcement,
+                as prescribed in [[!RFC8265]] Sections 3.4.2 and 3.4.3 for the UsernameCasePreserved Profile of the PRECIS
+                IdentifierClass [[!RFC8264]], when setting {{PublicKeyCredentialEntity/name}}'s value, or displaying the value
+                to the user.
+
+              - [=Clients=] MUST perform preparation and enforcement, as prescribed in [[!RFC8265]]
+                Sections 3.4.2 and 3.4.3 for the UsernameCasePreserved Profile of the PRECIS IdentifierClass [[!RFC8264]],
+                on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
+                including the value as a parameter of the [=authenticatorMakeCredential=] operation.
+
 
         [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialEntity/name}} member's
         value. Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value to a length equal to or greater
@@ -1740,7 +1762,7 @@ associated.
 </div>
 
 
-### RP Parameters for Credential Generation (dictionary <dfn dictionary>PublicKeyCredentialRpEntity</dfn>) ### {#sctn-rp-credential-params}
+### Relying Party Parameters for Credential Generation (dictionary <dfn dictionary>PublicKeyCredentialRpEntity</dfn>) ### {#sctn-rp-credential-params}
 
 The {{PublicKeyCredentialRpEntity}} dictionary is used to supply additional [=[RP]=] attributes when creating a new credential.
 
@@ -1770,11 +1792,24 @@ credential.
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialUserEntity">
     :   <dfn>id</dfn>
-    ::  The [=user handle=] of the user account entity.
+    ::  The [=user handle=] of the user account entity. To ensure secure operation, authentication and authorization
+        decisions MUST be made on the basis of this {{PublicKeyCredentialEntity/id}} member,  not the
+        {{PublicKeyCredentialEntity/displayName}} nor {{PublicKeyCredentialEntity/name}} members. See [[!RFC8266]]
+        Section 6.1.
 
     :   <dfn>displayName</dfn>
-    ::  A human-friendly name for the user account, intended only for display. For example, "Alex P. Müller" or "田中 倫". The
+    ::  A [=human palatability|human-palatable=] name for the user account, intended only for display. For example, "Alex P. Müller" or "田中 倫". The
         [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
+
+        - [=[RPS]=] SHOULD perform preparation and enforcement, as prescribed in [[!RFC8266]]
+            Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+            when setting {{PublicKeyCredentialUserEntity/displayName}}'s value, or displaying the value to the user.
+
+        - [=Clients=] MUST perform preparation and enforcement, as prescribed in [[!RFC8266]]
+            Sections 2.2 and 2.3 for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
+            on {{PublicKeyCredentialUserEntity/displayName}}'s value prior to displaying the value to the user or
+            including the value as a parameter of the [=authenticatorMakeCredential=] operation.
+
 
         [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialUserEntity/displayName}}
         member's value. Authenticators MAY truncate a {{PublicKeyCredentialUserEntity/displayName}} member's value to a length

--- a/index.bs
+++ b/index.bs
@@ -1777,6 +1777,8 @@ associated.
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
 
+        When [=clients=], client platforms, or [=authenticators=] display a {{PublicKeyCredentialEntity/name}}'s value, they should always use UI elements to provide a clear boundary around the displayed value, and not allow overflow into other elements [[css-overflow-3]].
+
         [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialEntity/name}} member's
         value. Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value to a length equal to or greater
         than 64 bytes.
@@ -1837,6 +1839,7 @@ credential.
             on {{PublicKeyCredentialUserEntity/displayName}}'s value prior to displaying the value to the user or
             including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
+        When [=clients=], client platforms, or [=authenticators=] display a {{PublicKeyCredentialUserEntity/displayName}}'s value, they should always use UI elements to provide a clear boundary around the displayed value, and not allow overflow into other elements [[css-overflow-3]].
 
         [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialUserEntity/displayName}}
         member's value. Authenticators MAY truncate a {{PublicKeyCredentialUserEntity/displayName}} member's value to a length


### PR DESCRIPTION
I suggest this PR as an alternative to PR #878.  In my review of the latter, and of PRECIS RFCs 8264, 8265, 8266, it seems that we ought to provide more fine-grained guidance regarding employing PRECIS to "corral" RP- and user-supplied "name"-ish strings.  See discussion in both issue #593 and pr #878.

cc @stpeter

fixes #593

This does not (as yet) address #593 because the latter issue touches on two aspects to the overall issue:
1. corralling the unicode content of the "name"-ish domstrings
2. providing implementer guidance regarding how to display/present these string values in order to mitigate effects of possibly malicious string content.

Originally, this PR addressed only item 1, above. 
Now (11-Jul-2018) it also addresses item 2, see commit 4ddc3c0 and https://github.com/w3c/webauthn/pull/951#issuecomment-404334287.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/951.html" title="Last updated on Jul 11, 2018, 10:51 PM GMT (4ddc3c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/951/ca80875...4ddc3c0.html" title="Last updated on Jul 11, 2018, 10:51 PM GMT (4ddc3c0)">Diff</a>