### PR TITLE
Improve clarity of |x5c| in packed and tpm attstmt verification procedures

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3264,8 +3264,11 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
     :: A byte string containing the attestation signature.
 
     : x5c
-    :: The elements of this array contain the attestation certificate and its certificate chain, each encoded in X.509 format.
-        The attestation certificate MUST be the first element in the array.
+    :: The elements of this array contain |attestnCert| and its certificate chain, each encoded in X.509 format. The attestation
+        certificate |attestnCert| MUST be the first element in the array.
+
+    : attestnCert
+    :: The attestation certificate, encoded in X.509 format.
 
     : ecdaaKeyId
     :: The <dfn>identifier of the ECDAA-Issuer public key</dfn>.  This is the
@@ -3302,10 +3305,10 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
 
         1. If |x5c| is present, this indicates that the attestation type is not [=ECDAA=]. In this case:
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using the
-                attestation public key in |x5c| with the algorithm specified in |alg|.
-            - Verify that |x5c| meets the requirements in [[#packed-attestation-cert-requirements]].
-            - If |x5c| contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (`id-fido-gen-ce-aaguid`) verify that the value of this
-                extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
+                attestation public key in |attestnCert| with the algorithm specified in |alg|.
+            - Verify that |attestnCert| meets the requirements in [[#packed-attestation-cert-requirements]].
+            - If |attestnCert| contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (`id-fido-gen-ce-aaguid`) verify that the
+                value of this extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
             - If successful, return attestation type [=Basic=] and [=attestation trust path=] |x5c|.
 
         1. If |ecdaaKeyId| is present, then the attestation type is [=ECDAA=]. In this case:

--- a/index.bs
+++ b/index.bs
@@ -3403,7 +3403,10 @@ engine.
     :: A {{COSEAlgorithmIdentifier}} containing the identifier of the algorithm used to generate the attestation signature.
 
     : x5c
-    :: The AIK certificate used for the attestation and its certificate chain, in X.509 encoding.
+    :: |aikCert| followed by its certificate chain, in X.509 encoding.
+
+    : aikCert
+    :: The AIK certificate used for the attestation, in X.509 encoding.
 
     : ecdaaKeyId
     :: The [=identifier of the ECDAA-Issuer public key=]. This is the
@@ -3457,10 +3460,10 @@ engine.
         These fields MAY be used as an input to risk engines.
 
     If |x5c| is present, this indicates that the attestation type is not [=ECDAA=]. In this case:
-    - Verify the |sig| is a valid signature over |certInfo| using the attestation public key in |x5c| with the
+    - Verify the |sig| is a valid signature over |certInfo| using the attestation public key in |aikCert| with the
         algorithm specified in |alg|.
-    - Verify that |x5c| meets the requirements in [[#tpm-cert-requirements]].
-    - If |x5c| contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify that the value of this
+    - Verify that |aikCert| meets the requirements in [[#tpm-cert-requirements]].
+    - If |aikCert| contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify that the value of this
         extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
     - If successful, return attestation type [=AttCA=] and [=attestation trust path=] |x5c|.
 


### PR DESCRIPTION
This fixes part of #950.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/952.html" title="Last updated on Jun 15, 2018, 5:00 PM GMT (b7f7fb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/952/4fd5dd5...b7f7fb4.html" title="Last updated on Jun 15, 2018, 5:00 PM GMT (b7f7fb4)">Diff</a>