### PR TITLE
Allow client to return NotAllowedError early if success is impossible

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1101,9 +1101,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Return |constructCredentialAlg| and terminate this algorithm.
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
-        ::  The client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user confirms [=user
-            consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}" and terminate this
-            algorithm.
+        ::  The client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user [=user
+            consent|consents=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}" and terminate
+            this algorithm.
 
             Note: For example, the [=client=] might reach this conclusion if
             <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
@@ -1457,8 +1457,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
         ::  The client MAY prompt the user for [=user consent|consent=] to [=authentication|authenticate=] to the [=[RP]=]. If
-            the user confirms [=user consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is
-            "{{NotAllowedError}}" and terminate this algorithm.
+            the user [=user consent|consents=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}"
+            and terminate this algorithm.
 
             Note: For example, the [=client=] might reach this conclusion if
             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=] and all its

--- a/index.bs
+++ b/index.bs
@@ -1101,9 +1101,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Return |constructCredentialAlg| and terminate this algorithm.
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
-        ::  The client MAY prompt the user for [=user consent|consent=] to [=authentication|authenticate=] to the [=[RP]=]. If
-            the user does [=user consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is
-            "{{NotAllowedError}}" and terminate this algorithm.
+        ::  The client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user does [=user
+            consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}" and terminate this
+            algorithm.
 
             Note: For example, the [=client=] might reach this conclusion if
             <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
@@ -1456,9 +1456,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1.  Return |constructAssertionAlg| and terminate this algorithm.
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
-        ::  The client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user does [=user
-            consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}" and terminate this
-            algorithm.
+        ::  The client MAY prompt the user for [=user consent|consent=] to [=authentication|authenticate=] to the [=[RP]=]. If
+            the user does [=user consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is
+            "{{NotAllowedError}}" and terminate this algorithm.
 
             Note: For example, the [=client=] might reach this conclusion if
             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=] and all its

--- a/index.bs
+++ b/index.bs
@@ -1101,7 +1101,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Return |constructCredentialAlg| and terminate this algorithm.
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
-        ::  the client MAY prompt the user for [=user consent|consent=] to [=authentication|authenticate=] to the [=[RP]=]. If
+        ::  The client MAY prompt the user for [=user consent|consent=] to [=authentication|authenticate=] to the [=[RP]=]. If
             the user does [=user consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is
             "{{NotAllowedError}}" and terminate this algorithm.
 
@@ -1457,7 +1457,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1.  Return |constructAssertionAlg| and terminate this algorithm.
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
-        ::  the client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user does [=user
+        ::  The client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user does [=user
             consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}" and terminate this
             algorithm.
 

--- a/index.bs
+++ b/index.bs
@@ -1100,6 +1100,16 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
             1. Return |constructCredentialAlg| and terminate this algorithm.
 
+        :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
+        ::  the client MAY prompt the user for [=user consent|consent=] to [=authentication|authenticate=] to the [=[RP]=]. If
+            the user does [=user consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is
+            "{{NotAllowedError}}" and terminate this algorithm.
+
+            Note: For example, the [=client=] might reach this conclusion if
+            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=] and all its
+            [=list/items=] have {{PublicKeyCredentialDescriptor/transports}} set to transports that the client platform does not
+            support.
+
     </dl>
 
 1. Return a {{DOMException}} whose name is "{{NotAllowedError}}". In order to prevent information leak that could identify the
@@ -1445,6 +1455,15 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 on |authenticator| and [=set/remove=] it from |issuedRequests|.
 
             1.  Return |constructAssertionAlg| and terminate this algorithm.
+
+        :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
+        ::  the client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user does [=user
+            consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}" and terminate this
+            algorithm.
+
+            Note: For example, the [=client=] might reach this conclusion if
+            <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
+            {{AuthenticatorAttachment/platform}} and the client platform does not include a [=platform authenticator=].
     </dl>
 
 1. Return a {{DOMException}} whose name is "{{NotAllowedError}}". In order to prevent information leak that could identify the

--- a/index.bs
+++ b/index.bs
@@ -1106,9 +1106,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
             "{{NotAllowedError}}" and terminate this algorithm.
 
             Note: For example, the [=client=] might reach this conclusion if
-            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=] and all its
-            [=list/items=] have {{PublicKeyCredentialDescriptor/transports}} set to transports that the client platform does not
-            support.
+            <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
+            {{AuthenticatorAttachment/platform}} and the client platform does not include a [=platform authenticator=].
 
     </dl>
 
@@ -1462,8 +1461,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
             algorithm.
 
             Note: For example, the [=client=] might reach this conclusion if
-            <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
-            {{AuthenticatorAttachment/platform}} and the client platform does not include a [=platform authenticator=].
+            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=] and all its
+            [=list/items=] have {{PublicKeyCredentialDescriptor/transports}} set to transports that the client platform does not
+            support.
     </dl>
 
 1. Return a {{DOMException}} whose name is "{{NotAllowedError}}". In order to prevent information leak that could identify the

--- a/index.bs
+++ b/index.bs
@@ -1101,7 +1101,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Return |constructCredentialAlg| and terminate this algorithm.
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
-        ::  The client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user does [=user
+        ::  The client MAY prompt the user for [=user consent|consent=] to create a new credential. If the user confirms [=user
             consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is "{{NotAllowedError}}" and terminate this
             algorithm.
 
@@ -1457,7 +1457,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
         :   If the [=client=] concludes that it is impossible for any eligible [=authenticator=] to appear,
         ::  The client MAY prompt the user for [=user consent|consent=] to [=authentication|authenticate=] to the [=[RP]=]. If
-            the user does [=user consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is
+            the user confirms [=user consent|consent=], the [=client=] MAY return a {{DOMException}} whose name is
             "{{NotAllowedError}}" and terminate this algorithm.
 
             Note: For example, the [=client=] might reach this conclusion if


### PR DESCRIPTION
This aims to fix #953.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/962.html" title="Last updated on Jun 26, 2018, 3:51 PM GMT (7791942)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/962/2d669de...7791942.html" title="Last updated on Jun 26, 2018, 3:51 PM GMT (7791942)">Diff</a>