### PR TITLE
fix #180: do not totally lose the term "WebAuthn Relying Party"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -52,6 +52,7 @@ Text Macro: RPS Relying Parties
 Text Macro: INFORMATIVE <em>This section is not normative.</em>
 Text Macro: TRUE <code>true</code>
 Text Macro: WAC WebAuthn Client
+Text Macro: WRP WebAuthn Relying Party
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more [=public key
@@ -473,10 +474,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: A [=Client-side-resident Credential Private Key=] is stored either on the client platform, or in some cases on the
     authenticator itself, e.g., in the case of a discrete first-factor [=roaming authenticator=]. Such <dfn>client-side credential
     private key storage</dfn> has the property that the authenticator is able to select the [=credential private key=] given
-    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of credentials associated with the RP
+    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of credentials associated with the [=[RP]=]
     ID). By definition, the private key is always exclusively controlled by the [=authenticator=]. In the case of a
     [=Client-side-resident Credential Private Key=], the [=authenticator=] might offload storage of wrapped key material to the
-    client platform, but the client platform is not expected to offload the key storage to remote entities (e.g. RP Server).
+    client platform, but the client platform is not expected to offload the key storage to remote entities (e.g. [=[RP]=] Server).
 
 : <dfn>Conforming User Agent</dfn>
 :: A user agent implementing, in conjunction with the underlying platform, the [=Web Authentication API=] and algorithms
@@ -581,11 +582,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     Note that this includes employing a [=test of user presence=] or [=user verification=].
 
 : <dfn>[RP]</dfn>
-:: The entity whose web application utilizes the [=Web Authentication API=] to register and authenticate users. See
-    [=Registration=] and [=Authentication=], respectively.
-
-        Note: While the term [=[RP]=] is used in other contexts (e.g., X.509 and OAuth), an entity acting as a [=[RP]=] in one
-        context is not necessarily a [=[RP]=] in other contexts.
+:: See [=[WRP]=].
 
 : <dfn>Relying Party Identifier</dfn>
 : <dfn>RP ID</dfn>
@@ -651,6 +648,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>[WAC]</dfn>
 :: Also referred to herein as simply a [=client=]. See also [=Conforming User Agent=]. A [=[WAC]=] is an intermediary entity typically implemented in the user agent (in whole, or in part). Conceptually, it underlies the [=Web Authentication API=] and embodies the implementation of the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=]. It is responsible for both marshalling the inputs for the underlying [=authenticator operations=], and for returning the results of the latter operations to the [=Web Authentication API=]'s callers.
+
+: <dfn>[WRP]</dfn>
+:: The entity whose web application utilizes the [=Web Authentication API=] to register and authenticate users. See
+    [=Registration=] and [=Authentication=], respectively.
+
+        Note: While the term [=[RP]=] is used in other contexts (e.g., X.509 and OAuth), an entity acting as a [=[RP]=] in one
+        context is not necessarily a [=[RP]=] in other contexts. In this specification, the term [=[WRP]=] is often shortened 
+        to be just [=[RP]=].
 
 
 # <dfn>Web Authentication API</dfn> # {#api}
@@ -1728,7 +1733,7 @@ associated.
 </div>
 
 
-### RP Parameters for Credential Generation (dictionary <dfn dictionary>PublicKeyCredentialRpEntity</dfn>) ### {#sctn-rp-credential-params}
+### Relying Party Parameters for Credential Generation (dictionary <dfn dictionary>PublicKeyCredentialRpEntity</dfn>) ### {#sctn-rp-credential-params}
 
 The {{PublicKeyCredentialRpEntity}} dictionary is used to supply additional [=[RP]=] attributes when creating a new credential.
 
@@ -2221,13 +2226,13 @@ Each authenticator stores a <dfn for=authenticator>credentials map</dfn>, a [=ma
 Additionally, each authenticator has an AAGUID, which is a 128-bit identifier indicating the type (e.g. make and model) of the
 authenticator. The AAGUID MUST be chosen by the manufacturer to be identical across all substantially identical authenticators
 made by that manufacturer, and different (with high probability) from the AAGUIDs of all other types of authenticators.
-The AAGUID for a given type of authenticator SHOULD be randomly generated to ensure this. The RP MAY use the AAGUID to infer certain
+The AAGUID for a given type of authenticator SHOULD be randomly generated to ensure this. The [=[RP]=] MAY use the AAGUID to infer certain
 properties of the authenticator, such as certification level and strength of key protection, using information from other sources.
 
 The primary function of the authenticator is to provide WebAuthn signatures, which are bound to various contextual data. These
 data are observed and added at different levels of the stack as a signature request passes from the server to the
 authenticator. In verifying a signature, the server checks these bindings against expected values. These contextual bindings
-are divided in two: Those added by the RP or the client, referred to as [=client data=]; and those added by the authenticator,
+are divided in two: Those added by the [=[RP]=] or the client, referred to as [=client data=]; and those added by the authenticator,
 referred to as the [=authenticator data=]. The authenticator signs over the [=client data=], but is otherwise not interested in
 its contents. To save bandwidth and processing requirements on the authenticator, the client hashes the [=client data=] and
 sends only the result to the authenticator. The authenticator signs over the combination of the
@@ -3960,7 +3965,7 @@ JavaScript APIs.
         parameter of [=authenticatorGetAssertion=].
 
 : Client extension output
-:: Returns the value [TRUE] to indicate to the RP that the extension was acted upon.
+:: Returns the value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean appid;
@@ -4114,7 +4119,7 @@ creation.
     MUST select an authenticator from among the available authenticators to generate the credential.
 
 : Client extension output
-:: Returns the value [TRUE] to indicate to the RP that the extension was acted upon.
+:: Returns the value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean authnSel;
@@ -4403,7 +4408,7 @@ as candidates to be employed in a [=registration=] ceremony.
     sources such as the FIDO Metadata Service [[FIDOMetadataService]] (see Sec. 3.2 of [[FIDOUAFAuthenticatorMetadataStatements]]).
 
 : Client extension output
-:: Returns the JSON value [TRUE] to indicate to the RP that the extension was acted upon
+:: Returns the JSON value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon
 
 : Authenticator extension input
 :: None.
@@ -4630,7 +4635,7 @@ a [=user verification|user-verifying=] [=platform authenticator=].
 1. If the user is not willing, terminate this flow.
 
 1. The user is shown appropriate UI and guided in creating a credential using one of the available platform authenticators.
-    Upon successful credential creation, the RP script conveys the new credential to the server.
+    Upon successful credential creation, the [=[RP]=] script conveys the new credential to the server.
 
 <pre class="example" highlight="js">
     if (!window.PublicKeyCredential) { /* Platform not capable of the API. Handle error. */ }
@@ -4638,7 +4643,7 @@ a [=user verification|user-verifying=] [=platform authenticator=].
     PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
         .then(function (userIntent) {
 
-            // If the user has affirmed willingness to register with RP using an available platform authenticator
+            // If the user has affirmed willingness to register with [=[RP]=] using an available platform authenticator
             if (userIntent) {
                 var publicKeyOptions = { /* Public key credential creation options. */};
 

--- a/index.bs
+++ b/index.bs
@@ -57,10 +57,10 @@ Text Macro: WRPS WebAuthn Relying Parties
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more [=public key
- credentials=], each [=scoped=] to a given [=Relying Party=], are created and stored on an [=authenticator=] by the user agent in
+ credentials=], each [=scoped=] to a given [=WebAuthn Relying Parties=], are created and stored on an [=authenticator=] by the user agent in
  conjunction with the web application. The user agent mediates access to [=public key credentials=] in order to preserve user
  privacy. [=Authenticators=] are responsible for ensuring that no operation is performed without [=user consent=].
- [=Authenticators=] provide cryptographic proof of their properties to [=relying parties=] via [=attestation=]. This
+ [=Authenticators=] provide cryptographic proof of their properties to [=Relying Parties=] via [=attestation=]. This
  specification also describes the functional model for WebAuthn conformant [=authenticators=], including their signature and
  [=attestation=] functionality.
 Boilerplate: omit conformance, omit feedback-header, omit abstract-header
@@ -3927,7 +3927,7 @@ These are RECOMMENDED for implementation by user agents targeting broad interope
 
 This extension allows [=[WRPS]=] that have previously registered a
 credential using the legacy FIDO JavaScript APIs to request an [=assertion=]. The
-FIDO APIs use an alternative identifier for [=relying parties=] called an |AppID|
+FIDO APIs use an alternative identifier for [=[RPS]=] called an |AppID|
 [[FIDO-APPID]], and any credentials created using those APIs will be bound to
 that identifier. Without this extension, they would need to be re-registered in
 order to be bound to an [=RP ID=].
@@ -4476,7 +4476,7 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
     <br/><br/>
 - WebAuthn Extension Identifier: authnSel
 - Description: This [=registration extension=] allows a WebAuthn Relying Party to guide the selection of the authenticator that
-    will be leveraged when creating the credential. It is intended primarily for WebAuthn Relying Parties that wish to tightly
+    will be leveraged when creating the credential. It is intended primarily for [=[WRPS]=] that wish to tightly
     control the experience around credential creation.
 - Specification Document: Section [[#sctn-authenticator-selection-extension]] of this specification
     <br/><br/>
@@ -4495,12 +4495,12 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
     <br/><br/>
 - WebAuthn Extension Identifier: loc
 - Description: The location [=registration extension=] and [=authentication extension=] provides the client device's current
-    location to the WebAuthn relying party, if supported by the client device and subject to [=user consent=].
+    location to the [=[WRP]=], if supported by the client device and subject to [=user consent=].
 - Specification Document: Section [[#sctn-location-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: uvm
 - Description: This [=registration extension=] and [=authentication extension=] enables use of a user verification method.
-    The user verification method extension returns to the Webauthn relying party which user verification methods (factors) were
+    The user verification method extension returns to the [=[WRP]=] which user verification methods (factors) were
     used for the WebAuthn operation.
 - Specification Document: Section [[#sctn-uvm-extension]] of this specification
 

--- a/index.bs
+++ b/index.bs
@@ -4644,7 +4644,8 @@ a [=user verification|user-verifying=] [=platform authenticator=].
     PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
         .then(function (userIntent) {
 
-            // If the user has affirmed willingness to register with [=[RP]=] using an available platform authenticator
+            // If the user has affirmed willingness to register with the 
+            // relying party using an available platform authenticator
             if (userIntent) {
                 var publicKeyOptions = { /* Public key credential creation options. */};
 
@@ -4873,7 +4874,7 @@ manufactured WebAuthn Authenticators, if the exposure was due to a firmware flaw
 scope for this specification.) If the WebAuthn Authenticator manufacturer does not have this capability, then it may not be
 possible for [=[RPS]=] to trust any further attestation statements from the affected WebAuthn Authenticators.
 
-If attestation certificate validation fails due to a revoked intermediate attestation CA certificate, and the [=[WRP]=]'s policy
+If attestation certificate validation fails due to a revoked intermediate attestation CA certificate, and the [=[RP]=]'s policy
 requires rejecting the registration/authentication request in these situations, then it is RECOMMENDED that the [=[RP]=] also
 un-registers (or marks with a trust level equivalent to "[=self attestation=]") [=public key credentials=] that were registered
 after the CA compromise date using an attestation certificate chaining up to the same intermediate CA. It is thus RECOMMENDED

--- a/index.bs
+++ b/index.bs
@@ -57,7 +57,7 @@ Text Macro: WRPS WebAuthn Relying Parties
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more [=public key
- credentials=], each [=scoped=] to a given [=WebAuthn Relying Parties=], are created and stored on an [=authenticator=] by the user agent in
+ credentials=], each [=scoped=] to a given [=WebAuthn Relying Party=], are created and stored on an [=authenticator=] by the user agent in
  conjunction with the web application. The user agent mediates access to [=public key credentials=] in order to preserve user
  privacy. [=Authenticators=] are responsible for ensuring that no operation is performed without [=user consent=].
  [=Authenticators=] provide cryptographic proof of their properties to [=Relying Parties=] via [=attestation=]. This
@@ -1125,12 +1125,12 @@ authorizing an authenticator.
 ### Use an existing credential to make an assertion - PublicKeyCredential's `[[Get]](options)` method ### {#getAssertion}
 
 [=[WRPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
-discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[WRP]=] script optionally specifies some criteria
+discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[RP]=] script optionally specifies some criteria
 to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential sources=]
 matching the specified criteria, and guides the user to pick one that the script will be allowed to use. The user may choose to
 decline the entire interaction even if a [=credential source=] is present, for example to maintain privacy. If the user picks a
 [=credential source=], the user agent then uses
-[[#op-get-assertion]] to sign a [RP]-provided challenge and other collected data into an assertion, which is used as a
+[[#op-get-assertion]] to sign a [=[RP]=]-provided challenge and other collected data into an assertion, which is used as a
 [=credential=].
 
 The {{CredentialsContainer/get()}} implementation [[CREDENTIAL-MANAGEMENT-1]] calls

--- a/index.bs
+++ b/index.bs
@@ -53,6 +53,7 @@ Text Macro: INFORMATIVE <em>This section is not normative.</em>
 Text Macro: TRUE <code>true</code>
 Text Macro: WAC WebAuthn Client
 Text Macro: WRP WebAuthn Relying Party
+Text Macro: WRPS WebAuthn Relying Parties
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more [=public key
@@ -201,7 +202,7 @@ spec:webidl; type:interface; text:Promise
 
 This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
 credentials by web applications, for the purpose of strongly authenticating users. A [=public key credential=] is
-created and stored by an <em>[=authenticator=]</em> at the behest of a <em>[=[RP]=]</em>, subject to <em>[=user
+created and stored by an <em>[=authenticator=]</em> at the behest of a <em>[=[WRP]=]</em>, subject to <em>[=user
 consent=]</em>. Subsequently, the [=public key credential=] can only be accessed by [=origins=] belonging to that [=[RP]=].
 This scoping is enforced jointly by <em>[=conforming User Agents=]</em> and <em>[=authenticators=]</em>.
 Additionally, privacy across [=[RPS]=] is maintained; [=[RPS]=] are not able to detect any properties, or even
@@ -341,9 +342,9 @@ external hardware, or a combination of both.
 [=Authenticators=] that only support the [[#fido-u2f-attestation]] have no mechanism to store a
 [=user handle=], so the returned {{AuthenticatorAssertionResponse/userHandle}} will always be null.
 
-## [RPS] ## {#conforming-relying-parties}
+## [WRPS] ## {#conforming-relying-parties}
 
-A [=[RP]=] MUST behave as described in [[#rp-operations]] to obtain all the security benefits offered by this specification. See
+A [=[WRP]=] MUST behave as described in [[#rp-operations]] to obtain all the security benefits offered by this specification. See
 [[#sctn-rp-benefits]] for further discussion of this.
 
 
@@ -442,7 +443,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: A cryptographic entity used by a [=[WAC]=] to (i) generate a [=public key credential=] and register it with a [=[RP]=],
     and (ii) [=authentication|authenticate=] by potentially [=user verification|verifying the user=], and then 
     cryptographically signing and returning, in the form of an [=Authentication Assertion=], 
-    a challenge and other data presented by a [=[RP]=] (in concert with the [=[WAC]=]).
+    a challenge and other data presented by a [=[WRP]=] (in concert with the [=[WAC]=]).
 
 : <dfn>Authorization Gesture</dfn>
 :: An [=authorization gesture=] is a physical interaction performed by a user with an authenticator as part of a [=ceremony=],
@@ -474,10 +475,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: A [=Client-side-resident Credential Private Key=] is stored either on the client platform, or in some cases on the
     authenticator itself, e.g., in the case of a discrete first-factor [=roaming authenticator=]. Such <dfn>client-side credential
     private key storage</dfn> has the property that the authenticator is able to select the [=credential private key=] given
-    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of credentials associated with the [=[RP]=]
-    ID). By definition, the private key is always exclusively controlled by the [=authenticator=]. In the case of a
+    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of credentials associated with the [=[RP ID]=]).
+    By definition, the private key is always exclusively controlled by the [=authenticator=]. In the case of a
     [=Client-side-resident Credential Private Key=], the [=authenticator=] might offload storage of wrapped key material to the
-    client platform, but the client platform is not expected to offload the key storage to remote entities (e.g. [=[RP]=] Server).
+    client platform, but the client platform is not expected to offload the key storage to remote entities (e.g. [=[WRP]=] Server).
 
 : <dfn>Conforming User Agent</dfn>
 :: A user agent implementing, in conjunction with the underlying platform, the [=Web Authentication API=] and algorithms
@@ -586,7 +587,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Relying Party Identifier</dfn>
 : <dfn>RP ID</dfn>
-:: A [=valid domain string=] that identifies the [=[RP]=] on whose behalf a given [=registration=] or
+:: A [=valid domain string=] that identifies the [=[WRP]=] on whose behalf a given [=registration=] or
     [=authentication|authentication ceremony=] is being performed. A [=public key credential=] can only be used for
     [=authentication=] with the same entity (as identified by [=RP ID=]) it was registered with.
 
@@ -661,7 +662,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 # <dfn>Web Authentication API</dfn> # {#api}
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
-idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[RP]=] interacts through the
+idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[WRP]=] interacts through the
 client (consisting of the browser and underlying OS platform). Scripts can (with the [=user consent|user's consent=]) request the
 browser to create a new credential for future use by the [=[RP]=]. Scripts can also request the user’s permission to perform
 authentication operations with an existing credential. All such operations are performed in the authenticator and are mediated by
@@ -789,7 +790,7 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 <div link-for-hint="PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)">
 {{PublicKeyCredential}}'s [=interface object=]'s implementation of the <dfn for="PublicKeyCredential" method>\[[Create]](origin,
 options, sameOriginWithAncestors)</dfn> [=internal method=] [[CREDENTIAL-MANAGEMENT-1]] allows
-[=[RP]=] scripts to call {{CredentialsContainer/create()|navigator.credentials.create()}} to request the creation of a new
+[=[WRP]=] scripts to call {{CredentialsContainer/create()|navigator.credentials.create()}} to request the creation of a new
 [=public key credential source=], bound to an [=authenticator=]. This
 {{CredentialsContainer/create()|navigator.credentials.create()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
@@ -1123,8 +1124,8 @@ authorizing an authenticator.
 
 ### Use an existing credential to make an assertion - PublicKeyCredential's `[[Get]](options)` method ### {#getAssertion}
 
-[=[RPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
-discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[RP]=] script optionally specifies some criteria
+[=[WRPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
+discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[WRP]=] script optionally specifies some criteria
 to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential sources=]
 matching the specified criteria, and guides the user to pick one that the script will be allowed to use. The user may choose to
 decline the entire interaction even if a [=credential source=] is present, for example to maintain privacy. If the user picks a
@@ -1509,7 +1510,7 @@ This [=internal method=] accepts no arguments.
 
 <div link-for-hint="WebAuthentication/isUserVerifyingPlatformAuthenticatorAvailable">
 
-[=[RPS]=] use this method to determine whether they can create a new credential using a [=user verification|user-verifying=] [=platform authenticator=].
+[=[WRPS]=] use this method to determine whether they can create a new credential using a [=user verification|user-verifying=] [=platform authenticator=].
 Upon invocation, the [=client=] employs a platform-specific procedure to discover available [=user verification|user-verifying=] [=platform authenticators=].
 If any are discovered, the promise is resolved with the value of [TRUE].
 Otherwise, the promise is resolved with the value of [FALSE].
@@ -1546,7 +1547,7 @@ This method has no arguments and returns a Boolean value.
 
 The {{AuthenticatorAttestationResponse}} interface represents the [=authenticator=]'s response to a client's request
 for the creation of a new [=public key credential=]. It contains information about the new credential that can be used to
-identify it for later use, and metadata that can be used by the [=[RP]=] to assess the characteristics of the credential
+identify it for later use, and metadata that can be used by the [=[WRP]=] to assess the characteristics of the credential
 during registration.
 
 <xmp class="idl">
@@ -1576,7 +1577,7 @@ during registration.
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}
 
 The {{AuthenticatorAssertionResponse}} interface represents an [=authenticator=]'s response to a client's request for
-generation of a new [=authentication assertion=] given the [=[RP]=]'s challenge and OPTIONAL list of credentials it is
+generation of a new [=authentication assertion=] given the [=[WRP]=]'s challenge and OPTIONAL list of credentials it is
 aware of. This response contains a cryptographic signature proving possession of the [=credential private key=], and
 optionally evidence of [=user consent=] to a specific transaction.
 
@@ -1698,7 +1699,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 
 ### Public Key Entity Description (dictionary <dfn dictionary>PublicKeyCredentialEntity</dfn>) ### {#dictionary-pkcredentialentity}
 
-The {{PublicKeyCredentialEntity}} dictionary describes a user account, or a [=[RP]=], with which a [=public key credential=] is
+The {{PublicKeyCredentialEntity}} dictionary describes a user account, or a [=[WRP]=], with which a [=public key credential=] is
 associated.
 
 <xmp class="idl">
@@ -1777,7 +1778,7 @@ credential.
 
 ### Authenticator Selection Criteria (dictionary <dfn dictionary>AuthenticatorSelectionCriteria</dfn>) ### {#authenticatorSelection}
 
-[=[RPS]=] may use the {{AuthenticatorSelectionCriteria}} dictionary to specify their requirements regarding authenticator
+[=[WRPS]=] may use the {{AuthenticatorSelectionCriteria}} dictionary to specify their requirements regarding authenticator
 attributes.
 
 <xmp class="idl">
@@ -1840,7 +1841,7 @@ them as <dfn>roaming authenticators</dfn>.
     this class are removable from, and can "roam" among, client platforms. A [=public key credential=] bound to a [=roaming
     authenticator=] is called a <dfn>roaming credential</dfn>.
 
-This distinction is important because there are use-cases where only [=platform authenticators=] are acceptable to a [=[RP]=], and
+This distinction is important because there are use-cases where only [=platform authenticators=] are acceptable to a [=[WRP]=], and
 conversely ones where only [=roaming authenticators=] are employed. As a concrete example of the former, a [=platform credential=]
 may be used by [=[RPS]=] to quickly and conveniently reauthenticate the user with a minimum of friction, e.g., the user will not
 have to dig around in their pocket for their key fob or phone. As a concrete example of the latter, when the user is accessing the
@@ -1857,7 +1858,7 @@ credential|credentials=]. The [=client=] and user will then use whichever is ava
 
 ### <dfn>Attestation Conveyance</dfn> Preference enumeration (enum <dfn enum>AttestationConveyancePreference</dfn>) ### {#attestation-convey}
 
-[=[RPS]=] may use {{AttestationConveyancePreference}} to specify their preference regarding [=attestation conveyance=]
+[=[WRPS]=] may use {{AttestationConveyancePreference}} to specify their preference regarding [=attestation conveyance=]
 during credential generation.
 
 <xmp class="idl">
@@ -2004,7 +2005,7 @@ follows.
 
 ### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
 
-The <dfn>client data</dfn> represents the contextual bindings of both the [=[RP]=] and the client platform. It is a key-value
+The <dfn>client data</dfn> represents the contextual bindings of both the [=[WRP]=] and the client platform. It is a key-value
 mapping whose keys are strings. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
 following Web IDL.
 
@@ -2131,7 +2132,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 <div dfn-type="enum-value" dfn-for="AuthenticatorTransport">
     [=Authenticators=] may implement various [[#transport|transports]] for communicating with [=clients=]. This enumeration
     defines hints as to how clients might communicate with a particular authenticator in order to obtain an assertion for a
-    specific credential. Note that these hints represent the [=[RP]=]'s best belief as to how an authenticator may be reached. A
+    specific credential. Note that these hints represent the [=[WRP]=]'s best belief as to how an authenticator may be reached. A
     [=[RP]=] may obtain a list of transports hints from some [=attestation statement formats=] or via some out-of-band mechanism;
     it is outside the scope of this specification to define that mechanism.
 
@@ -2173,7 +2174,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     };
 </xmp>
 
-A [=[RP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express its
+A [=[WRP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express its
 needs.
 
 <div dfn-type="enum-value" dfn-for="UserVerificationRequirement">
@@ -2201,7 +2202,7 @@ Authentication API implementation, when operating on the authenticators supporte
 from the behavior specified in [[#api]].
 
 For authenticators, this model defines the logical operations that they MUST support, and the data formats that they expose to
-the client and the [=[RP]=]. However, it does not define the details of how authenticators communicate with the client platform,
+the client and the [=[WRP]=]. However, it does not define the details of how authenticators communicate with the client platform,
 unless they are necessary for interoperability with [=[RPS]=]. For instance, this abstract model does not define protocols for
 connecting authenticators to clients over transports such as USB or NFC. Similarly, this abstract model does not define specific
 error codes or methods of returning them; however, it does define error behavior in terms of the needs of the client. Therefore,
@@ -2271,7 +2272,7 @@ The formats of these signatures, as well as the procedures for generating them, 
 ## Authenticator data ## {#sec-authenticator-data}
 
 The <dfn>authenticator data</dfn> structure encodes contextual bindings made by the [=authenticator=]. These bindings are
-controlled by the authenticator itself, and derive their trust from the [=[RP]=]'s assessment of the security properties of the
+controlled by the authenticator itself, and derive their trust from the [=[WRP]=]'s assessment of the security properties of the
 authenticator. In one extreme case, the authenticator may be embedded in the client, and its bindings may be no more trustworthy
 than the [=client data=]. At the other extreme, the authenticator may be a discrete entity with high-security hardware and
 software, connected to the client over a secure channel. In both cases, the [=[RP]=] receives the [=authenticator data=] in the same
@@ -2377,7 +2378,7 @@ follows.
 ### <dfn>Signature Counter</dfn> Considerations ### {#sign-counter}
 
 Authenticators SHOULD implement a [=signature counter=] feature. The [=signature counter=] is incremented for each successful
-[=authenticatorGetAssertion=] operation by some positive value, and its value is returned to the [=[RP]=] within the
+[=authenticatorGetAssertion=] operation by some positive value, and its value is returned to the [=[WRP]=] within the
 [=authenticator data=]. The [=signature counter=]'s purpose is to aid [=[RPS]=] in detecting cloned authenticators. Clone
 detection is more important for authenticators with limited protection measures.
 
@@ -2668,7 +2669,7 @@ or [=authenticatorGetAssertion=] operation currently in progress.
 ## Attestation ## {#sctn-attestation}
 
 [=Authenticators=] MUST also provide some form of [=attestation=]. The basic requirement is that the [=authenticator=] can
-produce, for each [=credential public key=], an [=attestation statement=] verifiable by the [=[RP]=]. Typically, this
+produce, for each [=credential public key=], an [=attestation statement=] verifiable by the [=[WRP]=]. Typically, this
 [=attestation statement=] contains a signature by an [=attestation private key=] over the attested [=credential public key=] and
 a challenge, as well as a certificate or similar data providing provenance information for the [=attestation public key=],
 enabling the [=[RP]=] to make a trust decision. However, if an [=attestation key pair=] is not available, then the authenticator
@@ -2972,9 +2973,9 @@ the [=authenticator=] MUST:
         RSASSA-PSS signature scheme defined in section 8.1.1 in [[RFC8017]] with SHA-256 as the hash function.
         The signature is not ASN.1 wrapped.
 
-# [=[RP]=] Operations # {#rp-operations}
+# [=[WRP]=] Operations # {#rp-operations}
 
-Upon successful execution of {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}, the [=[RP]=]'s script receives
+Upon successful execution of {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}, the [=[WRP]=]'s script receives
 a {{PublicKeyCredential}} containing an {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}} structure,
 respectively, from the client. It must then deliver the contents of this structure to the [=[RP]=] server, using methods outside
 the scope of this specification. This section describes the operations that the [=[RP]=] must perform upon receipt of these
@@ -3491,7 +3492,7 @@ When the [=authenticator=] in question is a platform-provided Authenticator on t
 attestation statement is based on the [Android key
 attestation](https://developer.android.com/preview/api-overview.html#key_attestation). In these cases, the attestation statement
 is produced by a component running in a secure operating environment, but the [=authenticator data for the attestation=] is
-produced outside this environment. The [=[RP]=] is expected to check that the [=authenticator data claimed to have been used for
+produced outside this environment. The [=[WRP]=] is expected to check that the [=authenticator data claimed to have been used for
 the attestation=] is consistent with the fields of the attestation certificate's extension data.
 
 
@@ -3692,7 +3693,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
 
 ## None Attestation Statement Format ## {#none-attestation}
 
-The none attestation statement format is used to replace any [=authenticator=]-provided [=attestation statement=] when a [=[RP]=] indicates it does not wish to receive attestation information, see  [[#attestation-convey]].
+The none attestation statement format is used to replace any [=authenticator=]-provided [=attestation statement=] when a [=[WRP]=] indicates it does not wish to receive attestation information, see  [[#attestation-convey]].
 
 : Attestation statement format identifier
 :: none
@@ -3734,7 +3735,7 @@ client.
 
 - [=Client extension processing=] for [=registration extensions=] and [=authentication extensions=].
 
-When creating a [=public key credential=] or requesting an [=authentication assertion=], a [=[RP]=] can request the use of a set
+When creating a [=public key credential=] or requesting an [=authentication assertion=], a [=[WRP]=] can request the use of a set
 of extensions. These extensions will be invoked during the requested operation if they are supported by the client and/or the
 authenticator. The [=[RP]=] sends the [=client extension input=] for each extension in the {{CredentialsContainer/get()}} call
 (for [=authentication extensions=]) or {{CredentialsContainer/create()}} call (for [=registration extensions=]) to the client
@@ -3836,7 +3837,7 @@ it MUST also specify the [=CBOR=] [=authenticator extension input=] argument
 sent via the [=authenticatorGetAssertion=] or [=authenticatorMakeCredential=] call,
 the [=authenticator extension processing=] rules, and the [=CBOR=] [=authenticator extension output=] value.
 
-Any [=client extension=] that is processed by the client MUST return a [=client extension output=] value so that the [=[RP]=]
+Any [=client extension=] that is processed by the client MUST return a [=client extension output=] value so that the [=[WRP]=]
 knows that the extension was honored by the client. Similarly, any extension that requires authenticator processing MUST return
 an [=authenticator extension output=] to let the [=[RP]=] know that the extension was honored by the authenticator. If an
 extension does not otherwise require any result values, it SHOULD be defined as returning a JSON Boolean [=client extension
@@ -3848,7 +3849,7 @@ extension=] that does not otherwise require any result values MUST return a valu
 ## Extending request parameters ## {#sctn-extension-request-parameters}
 
 An extension defines one or two request arguments. The <dfn>client extension input</dfn>,
-which is a value that can be encoded in JSON, is passed from the [=[RP]=] to the client
+which is a value that can be encoded in JSON, is passed from the [=[WRP]=] to the client
 in the {{CredentialsContainer/get()}} or {{CredentialsContainer/create()}} call,
 while the [=CBOR=] <dfn>authenticator extension input</dfn> is
 passed from the client to the authenticator for [=authenticator extensions=] during the processing of these calls.
@@ -3924,7 +3925,7 @@ These are RECOMMENDED for implementation by user agents targeting broad interope
 
 ## FIDO <dfn>AppID</dfn> Extension (appid) ## {#sctn-appid-extension}
 
-This extension allows [=[RPS]=] that have previously registered a
+This extension allows [=[WRPS]=] that have previously registered a
 credential using the legacy FIDO JavaScript APIs to request an [=assertion=]. The
 FIDO APIs use an alternative identifier for [=relying parties=] called an |AppID|
 [[FIDO-APPID]], and any credentials created using those APIs will be bound to
@@ -4082,7 +4083,7 @@ as well. This allows authenticators without a font rendering engine to be used a
 
 ## Authenticator Selection Extension (authnSel) ## {#sctn-authenticator-selection-extension}
 
-This extension allows a [=[RP]=] to guide the selection of the authenticator that will be leveraged when
+This extension allows a [=[WRP]=] to guide the selection of the authenticator that will be leveraged when
 creating the credential. It is intended primarily for [=[RPS]=] that wish to tightly control the experience around credential
 creation.
 
@@ -4137,7 +4138,7 @@ creation.
 
 ## Supported Extensions Extension (exts) ## {#sctn-supported-extensions-extension}
 
-This extension enables the [=[RP]=] to determine which extensions the authenticator supports.
+This extension enables the [=[WRP]=] to determine which extensions the authenticator supports.
 
 : Extension identifier
 :: `exts`
@@ -4245,7 +4246,7 @@ This extension enables use of a user verification index.
 
 ## Location Extension (loc) ## {#sctn-location-extension}
 
-This extension provides the [=authenticator=]'s current location to the WebAuthn [=[RP]=].
+This extension provides the [=authenticator=]'s current location to the WebAuthn [=[WRP]=].
 
 : Extension identifier
 :: `loc`
@@ -4379,7 +4380,7 @@ This extension enables use of a user verification method.
 
 ## Biometric Authenticator Performance Bounds Extension (biometricPerfBounds) ## {#sctn-authenticator-biometric-criteria-extension}
 
-This extension allows [=[RPS]=] to specify the desired performance bounds for selecting [=biometric authenticators=]
+This extension allows [=[WRPS]=] to specify the desired performance bounds for selecting [=biometric authenticators=]
 as candidates to be employed in a [=registration=] ceremony. 
 
 : Extension identifier
@@ -4457,7 +4458,7 @@ This section registers the [=extension identifier=] values defined in Section [[
 IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]].
 
 - WebAuthn Extension Identifier: appid
-- Description: This [=authentication extension=] allows [=[RPS]=] that have previously registered a credential using the legacy
+- Description: This [=authentication extension=] allows [=[WRPS]=] that have previously registered a credential using the legacy
     FIDO JavaScript APIs to request an assertion.
 - Specification Document: Section [[#sctn-appid-extension]] of this specification
     <br/><br/>
@@ -4480,7 +4481,7 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
 - Specification Document: Section [[#sctn-authenticator-selection-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: exts
-- Description: This [=registration extension=] enables the [=[RP]=] to determine which extensions the authenticator supports. The
+- Description: This [=registration extension=] enables the [=[WRP]=] to determine which extensions the authenticator supports. The
     extension data is a list (CBOR array) of extension identifiers encoded as UTF-8 Strings. This extension is added
     automatically by the authenticator. This extension can be added to attestation statements.
 - Specification Document: Section [[#sctn-supported-extensions-extension]] of this specification
@@ -4543,7 +4544,7 @@ platform to enumerate all the authenticator's credentials so that the client can
 ## Registration ## {#sample-registration}
 
 This is the first-time flow, in which a new credential is created and registered with the server.
-In this flow, the [=[RP]=] does not have a preference for [=platform authenticator=] or [=roaming authenticators=].
+In this flow, the [=[WRP]=] does not have a preference for [=platform authenticator=] or [=roaming authenticators=].
 
 1. The user visits example.com, which serves up a script. At this point, the user may already be logged in using a legacy
     username and password, or additional authenticator, or other means acceptable to the [=[RP]=].
@@ -4621,7 +4622,7 @@ The sample code for generating and registering a new key follows:
 
 ## Registration Specifically with User Verifying Platform Authenticator ## {#sample-registration-with-platform-authenticator}
 
-This is flow for when the [=[RP]=] is specifically interested in creating a public key credential with
+This is flow for when the [=[WRP]=] is specifically interested in creating a public key credential with
 a [=user verification|user-verifying=] [=platform authenticator=].
 
 1. The user visits example.com and clicks on the login button, which redirects the user to login.example.com.
@@ -4820,7 +4821,7 @@ handled on the server side and do not need support from the API specified here.
 This specification defines a Web API and a cryptographic peer-entity authentication protocol.
 The [=Web Authentication API=] allows Web developers (i.e., "authors") to utilize the Web Authentication protocol in their
 [=registration=] and [=authentication=] [=ceremonies=].
-The entities comprising the Web Authentication protocol endpoints are user-controlled [=authenticators=] and a [=[RP]=]'s
+The entities comprising the Web Authentication protocol endpoints are user-controlled [=authenticators=] and a [=[WRP]=]'s
 computing environment hosting the [=[RP]=]'s web application.
 In this model, the user agent, together with the [=[WAC]=], comprise an intermediary between [=authenticators=] and [=[RPS]=].
 Additionally, [=authenticators=] can [=attestation|attest=] to [=[RPS]=] as to their provenance.
@@ -4836,7 +4837,7 @@ The below subsections comprise the current Web Authentication-specific security 
 As a cryptographic protocol, Web Authentication is dependent upon randomized challenges
 to avoid replay attacks. Therefore, both {{PublicKeyCredentialCreationOptions/challenge}}'s
 and {{PublicKeyCredentialRequestOptions/challenge}}'s value MUST be randomly generated
-by [=[RPS]=] in an environment they trust (e.g., on the server-side), and the
+by [=[WRPS]=] in an environment they trust (e.g., on the server-side), and the
 returned challenge value in the client's
 response MUST match what was generated. This SHOULD be done in a fashion that does not rely
 upon a client's behavior, e.g., the Relying Party SHOULD store the challenge temporarily
@@ -4863,7 +4864,7 @@ SHOULD be specified in the attestation certificate itself, so that it can be ver
 When an intermediate CA or a root CA used for issuing attestation certificates is compromised, WebAuthn [=authenticator=]
 attestation keys are still safe although their certificates can no longer be trusted. A WebAuthn Authenticator manufacturer that
 has recorded the public attestation keys for their devices can issue new attestation certificates for these keys from a new
-intermediate CA or from a new root CA. If the root CA changes, the [=[RPS]=]  MUST update their trusted root certificates
+intermediate CA or from a new root CA. If the root CA changes, the [=[WRPS]=]  MUST update their trusted root certificates
 accordingly.
 
 A WebAuthn Authenticator attestation certificate MUST be revoked by the issuing CA if its key has been compromised. A WebAuthn
@@ -4872,7 +4873,7 @@ manufactured WebAuthn Authenticators, if the exposure was due to a firmware flaw
 scope for this specification.) If the WebAuthn Authenticator manufacturer does not have this capability, then it may not be
 possible for [=[RPS]=] to trust any further attestation statements from the affected WebAuthn Authenticators.
 
-If attestation certificate validation fails due to a revoked intermediate attestation CA certificate, and the [=[RP]=]'s policy
+If attestation certificate validation fails due to a revoked intermediate attestation CA certificate, and the [=[WRP]=]'s policy
 requires rejecting the registration/authentication request in these situations, then it is RECOMMENDED that the [=[RP]=] also
 un-registers (or marks with a trust level equivalent to "[=self attestation=]") [=public key credentials=] that were registered
 after the CA compromise date using an attestation certificate chaining up to the same intermediate CA. It is thus RECOMMENDED
@@ -4885,9 +4886,9 @@ RogueList when performing ECDAA-Verify (see section 3.6 in [[!FIDOEcdaaAlgorithm
 [[FIDOMetadataService]] provides one way to access such information.
 
 
-## Security Benefits for [RPS] ## {#sctn-rp-benefits}
+## Security Benefits for [WRPS] ## {#sctn-rp-benefits}
 
-The main benefits offered to [=[RPS]=] by this specification include:
+The main benefits offered to [=[WRPS]=] by this specification include:
 
 1. Users and accounts can be secured using widely compatible, easy-to-use multi-factor authentication.
 1. The [=[RP]=] does not need to provision [=authenticator=] hardware to its users. Instead, each user can independently obtain
@@ -4907,7 +4908,7 @@ next section.
 
 ### Considerations for Self and None Attestation Types and Ignoring Attestation ### {#sctn-no-attestation-security-attestation}
 
-When [[#registering-a-new-credential|registering a new credential]], the [=[RP]=] MAY choose to accept an [=attestation
+When [[#registering-a-new-credential|registering a new credential]], the [=[WRP]=] MAY choose to accept an [=attestation
 statement=] of [[#sctn-attestation-types|type]] [=self attestation|Self=] or [=None=], or to not verify
 the [=attestation statement=]. In all of these cases the [=[RP]=] loses much of benefit (3) listed above, but retains the other
 benefits.
@@ -4932,7 +4933,7 @@ concern in most [=[RPS]=]' threat models. For example, the [=man-in-the-middle a
 
 The [=credential ID=] is not signed.
 This is not a problem because all that would happen if an [=authenticator=] returns
-the wrong [=credential ID=], or if an attacker intercepts and manipulates the [=credential ID=], is that the [=[RP]=] would not look up the correct
+the wrong [=credential ID=], or if an attacker intercepts and manipulates the [=credential ID=], is that the [=[WRP]=] would not look up the correct
 [=credential public key=] with which to verify the returned signed [=authenticator data=]
 (a.k.a., [=assertion=]), and thus the interaction would end in an error.
 
@@ -4960,7 +4961,7 @@ form of global identity, the following kinds of potentially correlatable identif
 
 - The user's [=credential IDs=] and [=credential public keys=].
 
-    These are registered by the [=[RP]=] and subsequently used by the user to prove possession of the corresponding [=credential
+    These are registered by the [=[WRP]=] and subsequently used by the user to prove possession of the corresponding [=credential
     private key=]. They are also visible to the [=client=] in the communication with the [=authenticator=].
 
 - The user's identities specific to each [=[RP]=], e.g., usernames and [=user handles=].
@@ -4991,7 +4992,7 @@ prevent malicious [=[RPS]=] from using it to discover a user's personal identity
 
 [INFORMATIVE]
 
-Although [=Credential IDs=] and [=credential public keys=] are necessarily shared with the [=[RP]=] to enable strong
+Although [=Credential IDs=] and [=credential public keys=] are necessarily shared with the [=[WRP]=] to enable strong
 authentication, they are designed to be minimally identifying and not shared between [=[RPS]=].
 
 - [=Credential IDs=] and [=credential public keys=] are meaningless in isolation, as they only identify [=credential key pairs=]
@@ -5022,7 +5023,7 @@ without a traditional username, further improving non-correlatability between [=
 
 [=Biometric authenticators=] perform the [=biometric recognition=] internally in the [=authenticator=] - though for [=platform
 authenticators=] the biometric data might also be visible to the [=client=], depending on the implementation. Biometric data is
-not revealed to the [=[RP]=]; it is used only locally to perform [=user verification=] authorizing the creation and
+not revealed to the [=[WRP]=]; it is used only locally to perform [=user verification=] authorizing the creation and
 [=registration=] of, or [=authentication=] using, a [=public key credential=]. A malicious [=[RP]=] therefore cannot discover the
 user's personal identity via biometric data, and a security breach at a [=[RP]=] cannot expose biometric data for an attacker to
 use for forging logins at other [=[RPS]=].
@@ -5055,7 +5056,7 @@ in several ways, including:
         confusion in the specific context of this specification.
 
 - A WebAuthn Authenticator can implement [=Elliptic Curve based direct anonymous attestation=] (see [[FIDOEcdaaAlgorithm]]).
-    Using this scheme, the authenticator generates a blinded attestation signature. This allows the [=[RP]=] to verify the
+    Using this scheme, the authenticator generates a blinded attestation signature. This allows the [=[WRP]=] to verify the
     signature using the [=ECDAA-Issuer public key=], but the attestation signature does not serve as a global correlation handle.
 
 
@@ -5063,7 +5064,7 @@ in several ways, including:
 
 In order to protect users from being identified without [=user consent|consent=], implementations of the
 {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method need to take care to not leak information that
-could enable a malicious [=[RP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
+could enable a malicious [=[WRP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
 credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is bound to the
 [=authenticator=]:
 
@@ -5086,7 +5087,7 @@ leaked.
 
 In order to protect users from being identified without [=user consent|consent=], implementations of the
 {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method need to take care to not
-leak information that could enable a malicious [=[RP]=] to distinguish between these cases, where "named" means that the [=public
+leak information that could enable a malicious [=[WRP]=] to distinguish between these cases, where "named" means that the [=public
 key credential|credential=] is listed by the [=[RP]=] in {{PublicKeyCredentialRequestOptions/allowCredentials}}:
 
 - A named [=public key credential|credential=] is not available.


### PR DESCRIPTION
fixes #180


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/974.html" title="Last updated on Jun 28, 2018, 1:22 AM GMT (c0aefc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/974/a583650...c0aefc4.html" title="Last updated on Jun 28, 2018, 1:22 AM GMT (c0aefc4)">Diff</a>