### PR TITLE
fix #517: add rationale wrt only "valid domain" format is allowed for "effective domain"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -844,7 +844,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     Note: An [=effective domain=] may resolve to a [=host=], which can be represented in various manners,
         such as [=domain=], [=ipv4 address=], [=ipv6 address=], [=opaque host=], or [=empty host=].
-        Only the [=domain=] format of [=host=] is allowed here.
+        Only the [=domain=] format of [=host=] is allowed here. This is for simplification and also
+        is in recognition of various issues with using direct IP address identification in concert
+        with PKI-based security.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to compile w/o errors
 -->
@@ -1194,7 +1196,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     Note: An [=effective domain=] may resolve to a [=host=], which can be represented in various manners,
         such as [=domain=], [=ipv4 address=], [=ipv6 address=], [=opaque host=], or [=empty host=].
-        Only the [=domain=] format of [=host=] is allowed here.
+        Only the [=domain=] format of [=host=] is allowed here. This is for simplification and also is
+        in recognition of various issues with using direct IP address identification in concert with
+        PKI-based security.
 
         <li id='GetAssn-DetermineRpId'>
             If |options|.{{PublicKeyCredentialRequestOptions/rpId}} is [=present|not present=], then set |rpId| to


### PR DESCRIPTION
fixes #517


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/975.html" title="Last updated on Jun 28, 2018, 6:50 PM GMT (2ceeb78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/975/a583650...2ceeb78.html" title="Last updated on Jun 28, 2018, 6:50 PM GMT (2ceeb78)">Diff</a>