### PR TITLE
fix #493: be explicit about "same user" is verified at get() time as was verified at create() time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2601,8 +2601,10 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     by the [=authenticator=] if it has its own output capability, or by the user agent otherwise.
 
     If |requireUserVerification| is [TRUE], the method of obtaining [=user consent=] MUST include [=user verification=].
-    If successful, the verified user MUST be the same user as was verified when this [=authenticator=] created this
-    [=public key credential=] in <a href='#op-makecred-step-user-consent'>Step 6</a> of [[#op-make-cred]].
+
+        Note: For the overal WebAuthn security properties to hold, the verified user must be the same user that was verified
+        when this [=authenticator=] created this [=public key credential=] in <a href='#op-makecred-step-user-consent'>Step
+        6</a> of [[#op-make-cred]].
 
     If |requireUserPresence| is [TRUE], the method of obtaining [=user consent=] MUST include a
         [=test of user presence=].

--- a/index.bs
+++ b/index.bs
@@ -846,7 +846,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
         such as [=domain=], [=ipv4 address=], [=ipv6 address=], [=opaque host=], or [=empty host=].
         Only the [=domain=] format of [=host=] is allowed here.
 
-<!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to compile w/o errors
+<!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
+a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
 -->
     <li id='CreateCred-DetermineRpId'>
 
@@ -2488,18 +2489,24 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
     Private Key=], return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is [TRUE] and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
-1. Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
-    authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display
-    <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>, <code>|rpEntity|.{{PublicKeyCredentialEntity/name}}</code>,
-    <code>|userEntity|.{{PublicKeyCredentialEntity/name}}</code> and
-    <code>|userEntity|.{{PublicKeyCredentialUserEntity/displayName}}</code>, if possible.
 
-    If |requireUserVerification| is [TRUE], the method of obtaining [=user consent=] MUST include [=user verification=].
+<!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
+a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
+-->
+    <li id='op-makecred-step-user-consent'>
+        Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
+        authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display
+        <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>, <code>|rpEntity|.{{PublicKeyCredentialEntity/name}}</code>,
+        <code>|userEntity|.{{PublicKeyCredentialEntity/name}}</code> and
+        <code>|userEntity|.{{PublicKeyCredentialUserEntity/displayName}}</code>, if possible.
 
-    If |requireUserPresence| is [TRUE], the method of obtaining [=user consent=] MUST include a [=test of user presence=].
+        If |requireUserVerification| is [TRUE], the method of obtaining [=user consent=] MUST include [=user verification=].
 
-    If the user does not [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
-    "{{NotAllowedError}}" and terminate the operation.
+        If |requireUserPresence| is [TRUE], the method of obtaining [=user consent=] MUST include a [=test of user presence=].
+
+        If the user does not [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
+        "{{NotAllowedError}}" and terminate the operation.
+    </li>
 
 1. Once [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|, |privateKey|) be a new pair of cryptographic keys using the combination of {{PublicKeyCredentialType}}

--- a/index.bs
+++ b/index.bs
@@ -2632,7 +2632,8 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
 1. If any error occurred while generating the [=assertion signature=], return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
 
-<!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to compile w/o errors and to render properly.
+<!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
+a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
 -->
     <li id='authenticatorGetAssertion-return-values'>
         Return to the user agent:

--- a/index.bs
+++ b/index.bs
@@ -2601,6 +2601,8 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     by the [=authenticator=] if it has its own output capability, or by the user agent otherwise.
 
     If |requireUserVerification| is [TRUE], the method of obtaining [=user consent=] MUST include [=user verification=].
+    If successful, the verified user MUST be the same user as was verified when this [=authenticator=] created this
+    [=public key credential=] in <a href='#op-makecred-step-user-consent'>Step 6</a> of [[#op-make-cred]].
 
     If |requireUserPresence| is [TRUE], the method of obtaining [=user consent=] MUST include a
         [=test of user presence=].

--- a/index.bs
+++ b/index.bs
@@ -2602,9 +2602,9 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
 
     If |requireUserVerification| is [TRUE], the method of obtaining [=user consent=] MUST include [=user verification=].
 
-        Note: For the overal WebAuthn security properties to hold, the verified user must be the same user that was verified
-        when this [=authenticator=] created this [=public key credential=] in <a href='#op-makecred-step-user-consent'>Step
-        6</a> of [[#op-make-cred]].
+        Note: For the overall WebAuthn security properties to hold, the user verified here must be the same user that was
+        verified when this [=authenticator=] created this [=public key credential=] in
+        <a href='#op-makecred-step-user-consent'>Step 6</a> of [[#op-make-cred]].
 
     If |requireUserPresence| is [TRUE], the method of obtaining [=user consent=] MUST include a
         [=test of user presence=].


### PR DESCRIPTION
fixes #493


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/976.html" title="Last updated on Jul 6, 2018, 10:19 PM GMT (9bd0894)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/976/a96110e...9bd0894.html" title="Last updated on Jul 6, 2018, 10:19 PM GMT (9bd0894)">Diff</a>