### PR TITLE
fix 864: Note regarding CTAP2 integer keys vs webauthn string keys

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -137,6 +137,7 @@ spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
 spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
+        text: §6.2. Responses; url: responses
 
 spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html
     type: dfn
@@ -2204,6 +2205,8 @@ describes that [=authenticator model=].
 Client platforms MAY implement and expose this abstract model in any way desired. However, the behavior of the client's Web
 Authentication API implementation, when operating on the authenticators supported by that platform, MUST be indistinguishable
 from the behavior specified in [[#api]].
+
+Note: [[FIDO-CTAP]] is an example of a concrete instantiation of this model, but it is one in which there are differences in the <a href="FIDO-CTAP#resources">data it returns</a> and those expected by the [[#api|WebAuthn API]]'s algorithms.  The client platform is expected to perform any needed transformations on such data. The [[FIDO-CTAP]] specification details the necessary transformations.
 
 For authenticators, this model defines the logical operations that they MUST support, and the data formats that they expose to
 the client and the [=[WRP]=]. However, it does not define the details of how authenticators communicate with the client platform,

--- a/index.bs
+++ b/index.bs
@@ -2206,7 +2206,7 @@ Client platforms MAY implement and expose this abstract model in any way desired
 Authentication API implementation, when operating on the authenticators supported by that platform, MUST be indistinguishable
 from the behavior specified in [[#api]].
 
-Note: [[FIDO-CTAP]] is an example of a concrete instantiation of this model, but it is one in which there are differences in the data it returns and those expected by the [[#api|WebAuthn API]]'s algorithms. The CTAP2 response messages are CBOR maps constructed using integer keys rather than the string keys defined in this specification for the same objects. The client platform is expected to perform any needed transformations on such data. The [[FIDO-CTAP]] specification details the mapping between CTAP2 integer keys and WebAuthn string keys, in section [=§6.2. Responses=].
+Note: [[FIDO-CTAP]] is an example of a concrete instantiation of this model, but it is one in which there are differences in the data it returns and those expected by the [[#api|WebAuthn API]]'s algorithms. The CTAP2 response messages are CBOR maps constructed using integer keys rather than the string keys defined in this specification for the same objects. The [=client=] is expected to perform any needed transformations on such data. The [[FIDO-CTAP]] specification details the mapping between CTAP2 integer keys and WebAuthn string keys, in section [=§6.2. Responses=].
 
 For authenticators, this model defines the logical operations that they MUST support, and the data formats that they expose to
 the client and the [=[WRP]=]. However, it does not define the details of how authenticators communicate with the client platform,

--- a/index.bs
+++ b/index.bs
@@ -2206,7 +2206,7 @@ Client platforms MAY implement and expose this abstract model in any way desired
 Authentication API implementation, when operating on the authenticators supported by that platform, MUST be indistinguishable
 from the behavior specified in [[#api]].
 
-Note: [[FIDO-CTAP]] is an example of a concrete instantiation of this model, but it is one in which there are differences in the <a href="FIDO-CTAP#resources">data it returns</a> and those expected by the [[#api|WebAuthn API]]'s algorithms.  The client platform is expected to perform any needed transformations on such data. The [[FIDO-CTAP]] specification details the necessary transformations.
+Note: [[FIDO-CTAP]] is an example of a concrete instantiation of this model, but it is one in which there are differences in the data it returns and those expected by the [[#api|WebAuthn API]]'s algorithms. The CTAP2 response messages are CBOR maps constructed using integer keys rather than the string keys defined in this specification for the same objects. The client platform is expected to perform any needed transformations on such data. The [[FIDO-CTAP]] specification details the mapping between CTAP2 integer keys and WebAuthn string keys, in section [=§6.2. Responses=].
 
 For authenticators, this model defines the logical operations that they MUST support, and the data formats that they expose to
 the client and the [=[WRP]=]. However, it does not define the details of how authenticators communicate with the client platform,


### PR DESCRIPTION
fixes #864


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/986.html" title="Last updated on Jul 10, 2018, 7:30 PM GMT (f749dc3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/986/a96110e...f749dc3.html" title="Last updated on Jul 10, 2018, 7:30 PM GMT (f749dc3)">Diff</a>