### PR TITLE
Add recommendation of scoping platform credentials to OS accounts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5105,7 +5105,7 @@ one of the [=public key credential|credentials=] listed in the {{PublicKeyCreden
 available to the user.
 
 
-## Privacy between OS accounts ## {#sctn-os-account-privacy}
+## Privacy between operating system accounts ## {#sctn-os-account-privacy}
 
 If a [=platform authenticator=] is included in a [=client device=] with a multi-user operating system, the [=platform
 authenticator=] and [=client device=] SHOULD work together to ensure that the existence of any [=platform credential=] is revealed

--- a/index.bs
+++ b/index.bs
@@ -5105,6 +5105,13 @@ one of the [=public key credential|credentials=] listed in the {{PublicKeyCreden
 available to the user.
 
 
+## Privacy between OS accounts ## {#sctn-os-account-privacy}
+
+If a [=platform authenticator=] is included in a [=client device=] with a multi-user operating system, the [=platform
+authenticator=] and [=client device=] SHOULD work together to ensure that the existence of any [=platform credential=] is revealed
+only to the operating system user that created that [=platform credential=].
+
+
 # Acknowledgements # {#acknowledgements}
 We thank the following people for their reviews of, and contributions to, this specification:
 Yuriy Ackermann,


### PR DESCRIPTION
Note: [=client device=] is currently undefined; it will be added by commit 2ef1db88 in PR #956.

Note: This adds a normative SHOULD clause.

This fixes #96.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/989.html" title="Last updated on Jul 9, 2018, 2:52 PM GMT (ada317e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/989/a96110e...ada317e.html" title="Last updated on Jul 9, 2018, 2:52 PM GMT (ada317e)">Diff</a>