### PR TITLE
Disambiguate appid extension output behaviour

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3958,6 +3958,7 @@ JavaScript APIs.
 ::  1. Let |facetId| be the result of passing the caller's [=origin=] to the
         FIDO algorithm for [=determining the FacetID of a calling application=].
     1. Let |appId| be the extension input.
+    1. Let |output| be the Boolean value [FALSE].
     1. Pass |facetId| and |appId| to the FIDO algorithm for [=determining if a
         caller's FacetID is authorized for an AppID=]. If that algorithm rejects
         |appId| then return a "{{SecurityError}}" {{DOMException}}.
@@ -3966,11 +3967,12 @@ JavaScript APIs.
         returning `SW_WRONG_DATA`) then the client MUST retry with the U2F application
         parameter set to the SHA-256 hash of |appId|. If this results in an applicable
         credential, the client MUST include the credential in
-        <var ignore>allowCredentialDescriptorList</var>. The value of |appId| then replaces the `rpId`
+        <var ignore>allowCredentialDescriptorList</var> and set |output| to [TRUE]. The value of |appId| then replaces the `rpId`
         parameter of [=authenticatorGetAssertion=].
 
 : Client extension output
-:: Returns the value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon.
+:: Returns the value of |output|.
+
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean appid;


### PR DESCRIPTION
As proposed in issue #982, this disambiguates the output behaviour by specifying that `true` should only be returned if the AppID was used instead of the RP ID.

This fixes #982.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/995.html" title="Last updated on Jul 11, 2018, 4:49 PM GMT (905de00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/995/a96110e...905de00.html" title="Last updated on Jul 11, 2018, 4:49 PM GMT (905de00)">Diff</a>