### PR TITLE
Replace local/remote storage terms with client/server side

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -483,7 +483,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Client-side-resident Public Key Credential Source</dfn>
 :: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short, is a [=public key credential
     source=] whose [=credential private key=] is stored in the [=authenticator=], [=client=] or [=client device=]. Such
-    [=client-side=] storage requires a [=local storage capable=] [=authenticator=] and has the property that the [=authenticator=]
+    [=client-side=] storage requires a [=resident credential capable=] [=authenticator=] and has the property that the [=authenticator=]
     is able to select the [=credential private key=] given
     only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] associated with the [=RP ID=]).
     By definition, the [=credential private key=] is always exclusively controlled by the [=authenticator=]. In the case of a
@@ -2460,37 +2460,37 @@ The following defines names for some [=authenticator types=]:
         <tr>
             <th> <dfn>Second-factor platform authenticator</dfn> </th>
             <td> [=platform attachment|platform=] </td>
-            <td> [=remote credential storage modality|Remote=] </td>
+            <td> [=server-side credential storage modality|Server-side storage=] </td>
             <td> [=single-factor capable|Single-factor=] </td>
         </tr>
         <tr>
             <th> <dfn>User-verifying platform authenticator</dfn> </th>
             <td> [=platform attachment|platform=] </td>
-            <td> [=remote credential storage modality|Remote=] </td>
+            <td> [=server-side credential storage modality|Server-side storage=] </td>
             <td> [=multi-factor capable|Multi-factor=] </td>
         </tr>
         <tr>
             <th> <dfn>First-factor platform authenticator</dfn> </th>
             <td> [=platform attachment|platform=] </td>
-            <td> [=local credential storage modality|Local=] </td>
+            <td> [=client-side credential storage modality|Client-side storage=] </td>
             <td> [=multi-factor capable|Multi-factor=] </td>
         </tr>
         <tr>
             <th> <dfn>Second-factor roaming authenticator</dfn> </th>
             <td> [=cross-platform attachment|cross-platform=] </td>
-            <td> [=remote credential storage modality|Remote=] </td>
+            <td> [=server-side credential storage modality|Server-side storage=] </td>
             <td> [=single-factor capable|Single-factor=] </td>
         </tr>
         <tr>
             <th> <dfn>User-verifying roaming authenticator</dfn> </th>
             <td> [=cross-platform attachment|cross-platform=] </td>
-            <td> [=remote credential storage modality|Remote=] </td>
+            <td> [=server-side credential storage modality|Server-side storage=] </td>
             <td> [=multi-factor capable|Multi-factor=] </td>
         </tr>
         <tr>
             <th> <dfn>First-factor roaming authenticator</dfn> </th>
             <td> [=cross-platform attachment|cross-platform=] </td>
-            <td> [=local credential storage modality|Local=] </td>
+            <td> [=client-side credential storage modality|Client-side storage=] </td>
             <td> [=multi-factor capable|Multi-factor=] </td>
         </tr>
     </tbody>
@@ -2552,13 +2552,14 @@ An [=authenticator=] can store a [=public key credential source=] in one of two 
 Which of these storage strategies an [=authenticator=] supports defines the [=authenticator=]'s <dfn>credential storage
 modality</dfn> as follows:
 
-- An [=authenticator=] has the <dfn>local credential storage modality</dfn> if it supports [=resident credentials=]. An
-    [=authenticator=] with [=local credential storage modality=] is also called <dfn>local storage capable</dfn>.
+- An [=authenticator=] has the <dfn>client-side credential storage modality</dfn> if it supports [=client-side-resident public key
+    credential sources=]. An [=authenticator=] with [=client-side credential storage modality=] is also called <dfn>resident
+    credential capable</dfn>.
 
-- An [=authenticator=] has the <dfn>remote credential storage modality</dfn> if it does not have the [=local credential storage
+- An [=authenticator=] has the <dfn>server-side credential storage modality</dfn> if it does not have the [=client-side credential storage
     modality=], i.e., it only supports storing [=credential private keys=] as a ciphertext in the [=credential ID=].
 
-Note that a [=local storage capable=] [=authenticator=] MAY support both storage strategies. In this case, the [=authenticator=] MAY
+Note that a [=resident credential capable=] [=authenticator=] MAY support both storage strategies. In this case, the [=authenticator=] MAY
 at its discretion use different storage strategies for different [=public key credential|credentials=], though subject to the
 {{AuthenticatorSelectionCriteria/requireResidentKey}} option of {{CredentialsContainer/create()}}.
 


### PR DESCRIPTION
This mitigates #358, specifically https://github.com/w3c/webauthn/issues/358#issuecomment-403977896.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/997.html" title="Last updated on Jul 18, 2018, 5:18 PM GMT (6f4fbe6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/997/a0d84c1...6f4fbe6.html" title="Last updated on Jul 18, 2018, 5:18 PM GMT (6f4fbe6)">Diff</a>