### PR TITLE
Precisize "platform" and "device" terminology

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -690,7 +690,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[WRP]=] interacts through the
-[=client platform=]. Scripts can (with the [=user consent|user's consent=]) request the
+[=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
 browser to create a new credential for future use by the [=[RP]=]. Scripts can also request the user’s permission to perform
 authentication operations with an existing credential. All such operations are performed in the authenticator and are mediated by
 the [=client platform=] on the user's behalf. At no point does the script get access to the credentials themselves; it only
@@ -959,8 +959,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Let |issuedRequests| be a new [=ordered set=].
 
-1. Let |authenticators| represent a value which at any given instant is a [=set=] of [=client device=]-specific handles, where each
-    [=set/item=] identifies an [=authenticator=] presently available on this [=client device=] at that instant.
+1. Let |authenticators| represent a value which at any given instant is a [=set=] of [=client platform=]-specific handles, where each
+    [=set/item=] identifies an [=authenticator=] presently available on this [=client platform=] at that instant.
 
     Note: What qualifies an [=authenticator=] as "available" is intentionally unspecified; this is meant to represent how
     [=authenticators=] can be <a href="https://en.wikipedia.org/w/index.php?title=Hot_plug">hot-plugged</a> into (e.g., via USB)
@@ -1295,8 +1295,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |savedCredentialIds| be a new [=map=].
 
-1. Let |authenticators| represent a value which at any given instant is a [=set=] of [=client device=]-specific handles, where each
-    [=set/item=] identifies an [=authenticator=] presently available on this [=client device=] at that instant.
+1. Let |authenticators| represent a value which at any given instant is a [=set=] of [=client platform=]-specific handles, where each
+    [=set/item=] identifies an [=authenticator=] presently available on this [=client platform=] at that instant.
 
     Note: What qualifies an [=authenticator=] as "available" is intentionally unspecified; this is meant to represent how
     [=authenticators=] can be <a href="https://en.wikipedia.org/w/index.php?title=Hot_plug">hot-plugged</a> into (e.g., via USB)
@@ -1358,7 +1358,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     :   [=list/is not empty=]
                     ::  1. Let |allowCredentialDescriptorList| be a new [=list=].
 
-                        1. Execute a [=client device=]-specific procedure to determine which, if any, [=public key credentials=] described by
+                        1. Execute a [=client platform=]-specific procedure to determine which, if any, [=public key credentials=] described by
                             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are bound to this
                             |authenticator|, by matching with |rpId|,
                             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
@@ -1550,7 +1550,7 @@ This [=internal method=] accepts no arguments.
 <div link-for-hint="WebAuthentication/isUserVerifyingPlatformAuthenticatorAvailable">
 
 [=[WRPS]=] use this method to determine whether they can create a new credential using a [=user-verifying platform authenticator=].
-Upon invocation, the [=client=] employs a [=client device=]-specific procedure to discover available [=user-verifying platform authenticators=].
+Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=].
 If any are discovered, the promise is resolved with the value of [TRUE].
 Otherwise, the promise is resolved with the value of [FALSE].
 Based on the result, the [=[RP]=] can take further actions to guide the user to create a credential.
@@ -2881,7 +2881,7 @@ statement=], a [=[RP]=] needs to understand these two aspects of [=attestation=]
 
 1. The <dfn>attestation statement format</dfn> is the manner in which the signature is represented and the various contextual
     bindings are incorporated into the attestation statement by the [=authenticator=]. In other words, this defines the
-    syntax of the statement. Various existing [=client devices=] (such as TPMs and the Android OS) have previously defined
+    syntax of the statement. Various existing components and OS platforms (such as TPMs and the Android OS) have previously defined
     [=attestation statement formats=]. This specification supports a variety of such formats in an extensible way, as defined in
     [[#attestation-formats]].
 

--- a/index.bs
+++ b/index.bs
@@ -472,9 +472,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [=Registration=] and [=Authentication=] are ceremonies, and an [=authorization gesture=] is often a component of
     those [=ceremonies=].
 
-: <dfn>Client</dfn>
-:: See [=[WAC]=], [=Conforming User Agent=].
-
 : <dfn>Client Platform</dfn>
 :: A [=client device=] and a [=client=] together make up a [=client platform=]. A single hardware device MAY be part of multiple
     distinct [=client platforms=] at different times by running different operating systems and/or [=clients=].
@@ -664,6 +661,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>UV</dfn>
 :: Upon successful completion of a [=user verification=] process, the user is said to be "[=user verified|verified=]".
 
+: <dfn>Client</dfn>
 : <dfn>[WAC]</dfn>
 :: Also referred to herein as simply a [=client=]. See also [=Conforming User Agent=]. A [=[WAC]=] is an intermediary entity typically implemented in the user agent (in whole, or in part). Conceptually, it underlies the [=Web Authentication API=] and embodies the implementation of the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=]. It is responsible for both marshalling the inputs for the underlying [=authenticator operations=], and for returning the results of the latter operations to the [=Web Authentication API=]'s callers.
 

--- a/index.bs
+++ b/index.bs
@@ -492,7 +492,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [=client device=], but the [=client device=] is not expected to offload the key storage to remote entities (e.g., [=[WRP]=] Server).
 
 : <dfn>Conforming User Agent</dfn>
-:: A user agent implementing, in co-operation with the underlying [=client device=], the [=Web Authentication API=] and algorithms
+:: A user agent implementing, in cooperation with the underlying [=client device=], the [=Web Authentication API=] and algorithms
     given in this specification, and handling communication between [=authenticators=] and [=[RPS]=].
 
 : <dfn>Credential ID</dfn>

--- a/index.bs
+++ b/index.bs
@@ -3146,8 +3146,8 @@ the [=authenticator=] MUST:
             |  17 6c 92 bb 8e 36 c0 41  98 a2 7b 90 9b 6e 8f 13
         ```
 
-        Note: As CTAP1/U2F devices are already producing signatures values in this format, CTAP2
-        devices will also produce signatures values in the same format, for consistency reasons.
+        Note: As CTAP1/U2F [=authenticators=] are already producing signatures values in this format, CTAP2
+        [=authenticators=] will also produce signatures values in the same format, for consistency reasons.
         It is recommended that any new attestation formats defined not use ASN.1 encodings,
         but instead represent signatures as equivalent fixed-length byte arrays without internal structure,
         using the same representations as used by COSE signatures as defined in [[!RFC8152]] and [[!RFC8230]].
@@ -4414,7 +4414,7 @@ This extension enables use of a user verification index.
 
     As an example, the UVI could be computed as SHA256(KeyID || SHA256(rawUVI)), where `||` represents concatenation, and the
     rawUVI reflects (a) the biometric reference data, (b) the related OS level user ID and (c) an identifier which changes
-    whenever a factory reset is performed for the device, e.g. rawUVI = biometricReferenceData || OSLevelUserID ||
+    whenever a factory reset is performed for the [=authenticator=], e.g. rawUVI = biometricReferenceData || OSLevelUserID ||
     FactoryResetCounter.
 
     Example of [=authenticator data=] containing one UVI extension
@@ -4683,8 +4683,8 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
 - Specification Document: Section [[#sctn-uvi-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: loc
-- Description: The location [=registration extension=] and [=authentication extension=] provides the client device's current
-    location to the [=[WRP]=], if supported by the client device and subject to [=user consent=].
+- Description: The location [=registration extension=] and [=authentication extension=] provides the [=client device=]'s current
+    location to the [=[WRP]=], if supported by the [=client platform=] and subject to [=user consent=].
 - Specification Document: Section [[#sctn-location-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: uvm
@@ -4989,7 +4989,7 @@ The following are possible situations in which decommissioning a credential migh
 handled on the server side and do not need support from the API specified here.
 
 - Possibility #1 -- user reports the credential as lost.
-    * User goes to server.example.net, authenticates and follows a link to report a lost/stolen device.
+    * User goes to server.example.net, authenticates and follows a link to report a lost/stolen [=authenticator=].
     * Server returns a page showing the list of registered credentials with friendly names as configured during registration.
     * User selects a credential and the server deletes it from its database.
     * In future, the [=[RP]=] script does not specify this credential in any list of acceptable credentials, and assertions
@@ -5000,8 +5000,8 @@ handled on the server side and do not need support from the API specified here.
     * In the future, the [=[RP]=] script does not specify this credential in any list of acceptable credentials, and assertions
         signed by this credential are rejected.
 
-- Possibility #3 -- user deletes the credential from the device.
-    * User employs a device-specific method (e.g., device settings UI) to delete a credential from their device.
+- Possibility #3 -- user deletes the credential from the [=authenticator=].
+    * User employs a [=authenticator=]-specific method (e.g., device settings UI) to delete a credential from their [=authenticator=].
     * From this point on, this credential will not appear in any selection prompts, and no assertions can be generated with it.
     * Sometime later, the server deregisters this credential due to inactivity.
 
@@ -5042,7 +5042,7 @@ therefore be at least 16 bytes long.
 
 A 3-tier hierarchy for attestation certificates is RECOMMENDED (i.e., Attestation Root, Attestation Issuing CA, Attestation
 Certificate). It is also RECOMMENDED that for each WebAuthn Authenticator device line (i.e., model), a separate issuing CA is
-used to help facilitate isolating problems with a specific version of a device.
+used to help facilitate isolating problems with a specific version of an authenticator model.
 
 If the attestation root certificate is not dedicated to a single WebAuthn Authenticator device line (i.e., AAGUID), the AAGUID
 SHOULD be specified in the attestation certificate itself, so that it can be verified against the [=authenticator data=].
@@ -5052,7 +5052,7 @@ SHOULD be specified in the attestation certificate itself, so that it can be ver
 
 When an intermediate CA or a root CA used for issuing attestation certificates is compromised, WebAuthn [=authenticator=]
 attestation keys are still safe although their certificates can no longer be trusted. A WebAuthn Authenticator manufacturer that
-has recorded the public attestation keys for their devices can issue new attestation certificates for these keys from a new
+has recorded the public attestation keys for their [=authenticator=] models can issue new attestation certificates for these keys from a new
 intermediate CA or from a new root CA. If the root CA changes, the [=[WRPS]=]  MUST update their trusted root certificates
 accordingly.
 
@@ -5227,11 +5227,11 @@ instead of revealing the biometric data itself to the [=[RP]=].
 Attestation keys can be used to track users or link various online identities of the same user together. This can be mitigated
 in several ways, including:
 
-- A WebAuthn [=authenticator=] manufacturer may choose to ship all of their devices with the same (or a fixed number of)
+- A WebAuthn [=authenticator=] manufacturer may choose to ship all of their [=authenticators=] with the same (or a fixed number of)
     attestation key(s) (called [=Basic Attestation=]). This will anonymize the user at the risk of not being able to revoke a
     particular attestation key if its private key is compromised.
 
-    [[UAFProtocol]] requires that at least 100,000 devices share the same attestation certificate in order to produce
+    [[UAFProtocol]] requires that at least 100,000 [=authenticator=] devices share the same attestation certificate in order to produce
     sufficiently large groups. This may serve as guidance about suitable batch sizes.
 
 - A WebAuthn [=authenticator=] may be capable of dynamically generating different attestation keys (and requesting related

--- a/index.bs
+++ b/index.bs
@@ -229,7 +229,7 @@ Broadly, compliant [=authenticators=] protect [=public key credentials=], and in
 [=Web Authentication API=]. Some authenticators MAY run on the same [=client device=] (e.g., smart phone, tablet, desktop PC) as
 the user agent is running on. For instance, such an authenticator might consist of a Trusted Execution Environment (TEE) applet,
 a Trusted Platform Module (TPM), or a Secure Element (SE) integrated into the [=client device=] in conjunction with some means
-for [=user verification=], along with appropriate platform software to mediate access to these components' functionality. Other
+for [=user verification=], along with appropriate driver software to mediate access to these components' functionality. Other
 authenticators MAY operate autonomously from the [=client device=] running the user agent, and be accessed over a transport such
 as Universal Serial Bus (USB), Bluetooth Low Energy (BLE) or Near Field Communications (NFC).
 
@@ -421,7 +421,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     In the WebAuthn context, [=attestation=] is employed to <em>attest</em> to the <em>provenance</em> of an [=authenticator=]
     and the data it emits; including, for example: [=credential IDs=], [=credential key pairs=], signature counters, etc. An
     [=attestation statement=] is conveyed in an [=attestation object=] during [=registration=]. See also [[#sctn-attestation]]
-    and [Figure 3](#fig-attStructs). Whether or how the client platform conveys the [=attestation statement=] and [=AAGUID=] 
+    and [Figure 3](#fig-attStructs). Whether or how the [=client=] conveys the [=attestation statement=] and [=AAGUID=]
     portions of the [=attestation object=] to the [=[RP]=] is described by [=attestation conveyance=].
 
 : <dfn>Attestation Certificate</dfn>
@@ -692,10 +692,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[WRP]=] interacts through the
-client (consisting of the browser and underlying OS platform). Scripts can (with the [=user consent|user's consent=]) request the
+[=client platform=]. Scripts can (with the [=user consent|user's consent=]) request the
 browser to create a new credential for future use by the [=[RP]=]. Scripts can also request the user’s permission to perform
 authentication operations with an existing credential. All such operations are performed in the authenticator and are mediated by
-the browser and/or platform on the user's behalf. At no point does the script get access to the credentials themselves; it only
+the [=client platform=] on the user's behalf. At no point does the script get access to the credentials themselves; it only
 gets information about the credentials in the form of objects.
 
 In addition to the above script interface, the authenticator MAY implement (or come with client software that implements) a user
@@ -770,12 +770,12 @@ that are returned to the caller when a new credential is created, or a new asser
         "{{Credential/[[discovery]]/remote}}".
 
     :   <dfn>\[[identifier]]</dfn>
-    ::  This [=internal slot=] contains the [=credential ID=], chosen by the platform with help from the authenticator.
+    ::  This [=internal slot=] contains the [=credential ID=], chosen by the authenticator.
         The [=credential ID=] is used to look up credentials for use, and is therefore expected to be globally unique
         with high probability across all credentials of the same type, across all authenticators.
 
         Note: This API does not constrain
-        the format or length of this identifier, except that it MUST be sufficient for the platform to uniquely select a key.
+        the format or length of this identifier, except that it MUST be sufficient for the [=authenticator=] to uniquely select a key.
         For example, an authenticator without on-board storage may create identifiers containing a [=credential private key=]
         wrapped with a symmetric key that is burned into the authenticator.
 
@@ -866,9 +866,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
 1. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present=], check if its value lies within a
-    reasonable range as defined by the platform and if not, correct it to the closest value lying within that range. Set a timer
+    reasonable range as defined by the [=client=] and if not, correct it to the closest value lying within that range. Set a timer
     |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present|not
-    present=], then set |lifetimeTimer| to a platform-specific default.
+    present=], then set |lifetimeTimer| to a [=client=]-specific default.
 
         Note: A suggested reasonable range for the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is
         15 seconds to 120 seconds.
@@ -930,7 +930,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. If the {{PublicKeyCredentialCreationOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
     |extensionId| → |clientExtensionInput| of <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>:
-    1. If |extensionId| is not supported by this client platform or is not a [=registration extension=], then [=continue=].
+    1. If |extensionId| is not supported by this [=client platform=] or is not a [=registration extension=], then [=continue=].
 
     1. [=map/Set=] |clientExtensions|[|extensionId|] to |clientExtensionInput|.
 
@@ -961,8 +961,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Let |issuedRequests| be a new [=ordered set=].
 
-1. Let |authenticators| represent a value which at any given instant is a [=set=] of platform-specific handles, where each
-    [=set/item=] identifies an [=authenticator=] presently available on this platform at that instant.
+1. Let |authenticators| represent a value which at any given instant is a [=set=] of [=client device=]-specific handles, where each
+    [=set/item=] identifies an [=authenticator=] presently available on this [=client device=] at that instant.
 
     Note: What qualifies an [=authenticator=] as "available" is intentionally unspecified; this is meant to represent how
     [=authenticators=] can be <a href="https://en.wikipedia.org/w/index.php?title=Hot_plug">hot-plugged</a> into (e.g., via USB)
@@ -983,7 +983,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             operation on |authenticator| and [=set/remove=] |authenticator| from |issuedRequests|. Then return a {{DOMException}}
             whose name is "{{AbortError}}" and terminate this algorithm.
 
-        :   If an |authenticator| becomes available on this platform,
+        :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
 
             1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}</code> is [=present=]:
@@ -1044,7 +1044,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
             1. [=set/Append=] |authenticator| to |issuedRequests|.
 
-        :   If an |authenticator| ceases to be available on this platform,
+        :   If an |authenticator| ceases to be available on this [=client device=],
         ::  [=set/Remove=] |authenticator| from |issuedRequests|.
 
         :   If any |authenticator| returns a status indicating that the user cancelled the operation,
@@ -1162,7 +1162,7 @@ authorizing an authenticator.
 
 [=[WRPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
 discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[RP]=] script optionally specifies some criteria
-to indicate what [=credential sources=] are acceptable to it. The user agent and/or platform locates [=credential sources=]
+to indicate what [=credential sources=] are acceptable to it. The [=client platform=] locates [=credential sources=]
 matching the specified criteria, and guides the user to pick one that the script will be allowed to use. The user may choose to
 decline the entire interaction even if a [=credential source=] is present, for example to maintain privacy. If the user picks a
 [=credential source=], the user agent then uses
@@ -1223,9 +1223,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 1. Let |options| be the value of <code>|options|.{{CredentialRequestOptions/publicKey}}</code>.
 
 1. If the {{PublicKeyCredentialRequestOptions/timeout}} member of |options| is [=present=], check if its value lies
-    within a reasonable range as defined by the platform and if not, correct it to the closest value lying within that range.
+    within a reasonable range as defined by the [=client=] and if not, correct it to the closest value lying within that range.
     Set a timer |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialRequestOptions/timeout}} member of
-    |options| is [=present|not present=], then set |lifetimeTimer| to a platform-specific default.
+    |options| is [=present|not present=], then set |lifetimeTimer| to a [=client=]-specific default.
 
         Note: A suggested reasonable range for the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is
         15 seconds to 120 seconds.
@@ -1264,7 +1264,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. If the {{PublicKeyCredentialRequestOptions/extensions}} member of |options| is [=present=], then [=map/for each=]
     |extensionId| → |clientExtensionInput| of <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>:
-    1. If |extensionId| is not supported by this client platform or is not an [=authentication extension=], then [=continue=].
+    1. If |extensionId| is not supported by this [=client platform=] or is not an [=authentication extension=], then [=continue=].
 
     1. [=map/Set=] |clientExtensions|[|extensionId|] to |clientExtensionInput|.
 
@@ -1297,8 +1297,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |savedCredentialIds| be a new [=map=].
 
-1. Let |authenticators| represent a value which at any given instant is a [=set=] of platform-specific handles, where each
-    [=set/item=] identifies an [=authenticator=] presently available on this platform at that instant.
+1. Let |authenticators| represent a value which at any given instant is a [=set=] of [=client device=]-specific handles, where each
+    [=set/item=] identifies an [=authenticator=] presently available on this [=client device=] at that instant.
 
     Note: What qualifies an [=authenticator=] as "available" is intentionally unspecified; this is meant to represent how
     [=authenticators=] can be <a href="https://en.wikipedia.org/w/index.php?title=Hot_plug">hot-plugged</a> into (e.g., via USB)
@@ -1321,7 +1321,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             and [=set/remove=] |authenticator| from |issuedRequests|. Then
             return a {{DOMException}} whose name is "{{AbortError}}" and terminate this algorithm.
 
-        :   If an |authenticator| becomes available on this platform,
+        :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
 
             1. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code> is set to
@@ -1360,7 +1360,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     :   [=list/is not empty=]
                     ::  1. Let |allowCredentialDescriptorList| be a new [=list=].
 
-                        1. Execute a platform-specific procedure to determine which, if any, [=public key credentials=] described by
+                        1. Execute a [=client device=]-specific procedure to determine which, if any, [=public key credentials=] described by
                             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are bound to this
                             |authenticator|, by matching with |rpId|,
                             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
@@ -1412,7 +1412,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
             1. [=set/Append=] |authenticator| to |issuedRequests|.
 
-        :   If an |authenticator| ceases to be available on this platform,
+        :   If an |authenticator| ceases to be available on this [=client device=],
         ::  [=set/Remove=] |authenticator| from |issuedRequests|.
 
         :   If any |authenticator| returns a status indicating that the user cancelled the operation,
@@ -1552,7 +1552,7 @@ This [=internal method=] accepts no arguments.
 <div link-for-hint="WebAuthentication/isUserVerifyingPlatformAuthenticatorAvailable">
 
 [=[WRPS]=] use this method to determine whether they can create a new credential using a [=user-verifying platform authenticator=].
-Upon invocation, the [=client=] employs a platform-specific procedure to discover available [=user-verifying platform authenticators=].
+Upon invocation, the [=client=] employs a [=client device=]-specific procedure to discover available [=user-verifying platform authenticators=].
 If any are discovered, the promise is resolved with the value of [TRUE].
 Otherwise, the promise is resolved with the value of [FALSE].
 Based on the result, the [=[RP]=] can take further actions to guide the user to create a credential.
@@ -1710,16 +1710,16 @@ optionally evidence of [=user consent=] to a specific transaction.
 
     :   <dfn>pubKeyCredParams</dfn>
     ::  This member contains information about the desired properties of the credential to be created. The sequence is ordered
-        from most preferred to least preferred. The platform makes a best-effort to create the most preferred credential that it
+        from most preferred to least preferred. The [=client=] makes a best-effort to create the most preferred credential that it
         can.
 
     :   <dfn>timeout</dfn>
     ::  This member specifies a time, in milliseconds, that the caller is willing to wait for the call to complete. This is
-        treated as a hint, and MAY be overridden by the platform.
+        treated as a hint, and MAY be overridden by the [=client=].
 
     :   <dfn>excludeCredentials</dfn>
     ::  This member is intended for use by [=[RPS]=] that wish to limit the creation of multiple credentials for the same
-        account on a single authenticator. The platform is requested to return an error if the new credential would be created
+        account on a single authenticator. The [=client=] is requested to return an error if the new credential would be created
         on an authenticator that also contains one of the credentials enumerated in this parameter.
 
     :   <dfn>authenticatorSelection</dfn>
@@ -1947,7 +1947,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
 
     :   <dfn>timeout</dfn>
     ::  This OPTIONAL member specifies a time, in milliseconds, that the caller is willing to wait for the call to complete.
-        The value is treated as a hint, and MAY be overridden by the platform.
+        The value is treated as a hint, and MAY be overridden by the [=client=].
 
     :   <dfn>rpId</dfn>
     ::  This OPTIONAL member specifies the [=relying party identifier=] claimed by the caller. If omitted, its value will
@@ -2036,7 +2036,7 @@ follows.
 
 ### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
 
-The <dfn>client data</dfn> represents the contextual bindings of both the [=[WRP]=] and the client platform. It is a key-value
+The <dfn>client data</dfn> represents the contextual bindings of both the [=[WRP]=] and the [=client=]. It is a key-value
 mapping whose keys are strings. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
 following Web IDL.
 
@@ -2177,8 +2177,8 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     ::  Indicates the respective [=authenticator=] can be contacted over Bluetooth Smart (Bluetooth Low Energy / BLE).
 
     :   <dfn>internal</dfn>
-    ::  Indicates the respective [=authenticator=] is contacted using a platform-specific transport. These authenticators are not
-        removable from the platform.
+    ::  Indicates the respective [=authenticator=] is contacted using a [=client device=]-specific transport. These authenticators are not
+        removable from the [=client device=].
 </div>
 
 
@@ -2228,14 +2228,14 @@ needs.
 [[#api|The Web Authentication API]] implies a specific abstract functional model for an [=authenticator=]. This section
 describes that [=authenticator model=].
 
-Client platforms MAY implement and expose this abstract model in any way desired. However, the behavior of the client's Web
-Authentication API implementation, when operating on the authenticators supported by that platform, MUST be indistinguishable
+[=Client platforms=] MAY implement and expose this abstract model in any way desired. However, the behavior of the client's Web
+Authentication API implementation, when operating on the authenticators supported by that [=client platform=], MUST be indistinguishable
 from the behavior specified in [[#api]].
 
 Note: [[FIDO-CTAP]] is an example of a concrete instantiation of this model, but it is one in which there are differences in the data it returns and those expected by the [[#api|WebAuthn API]]'s algorithms. The CTAP2 response messages are CBOR maps constructed using integer keys rather than the string keys defined in this specification for the same objects. The [=client=] is expected to perform any needed transformations on such data. The [[FIDO-CTAP]] specification details the mapping between CTAP2 integer keys and WebAuthn string keys, in section [=§6.2. Responses=].
 
 For authenticators, this model defines the logical operations that they MUST support, and the data formats that they expose to
-the client and the [=[WRP]=]. However, it does not define the details of how authenticators communicate with the client platform,
+the client and the [=[WRP]=]. However, it does not define the details of how authenticators communicate with the [=client device=],
 unless they are necessary for interoperability with [=[RPS]=]. For instance, this abstract model does not define protocols for
 connecting authenticators to clients over transports such as USB or NFC. Similarly, this abstract model does not define specific
 error codes or methods of returning them; however, it does define error behavior in terms of the needs of the client. Therefore,
@@ -2274,13 +2274,13 @@ sends only the result to the authenticator. The authenticator signs over the com
 
 The goals of this design can be summarized as follows.
 
-- The scheme for generating signatures should accommodate cases where the link between the client platform and authenticator
+- The scheme for generating signatures should accommodate cases where the link between the [=client device=] and authenticator
     is very limited, in bandwidth and/or latency. Examples include Bluetooth Low Energy and Near-Field Communication.
 
 - The data processed by the authenticator should be small and easy to interpret in low-level code. In particular, authenticators
     should not have to parse high-level encodings such as JSON.
 
-- Both the client platform and the authenticator should have the flexibility to add contextual bindings as needed.
+- Both the [=client=] and the authenticator should have the flexibility to add contextual bindings as needed.
 
 - The design aims to reuse as much as possible of existing encoding formats in order to aid adoption and implementation.
 
@@ -2312,7 +2312,7 @@ software, connected to the client over a secure channel. In both cases, the [=[R
 format, and uses its knowledge of the authenticator to make trust decisions.
 
 The [=authenticator data=] has a compact but extensible encoding. This is desired since authenticators can be devices with
-limited capabilities and low power requirements, with much simpler software stacks than the client platform components.
+limited capabilities and low power requirements, with much simpler software stacks than the [=client platform=].
 
 The [=authenticator data=] structure is a byte array of 37 bytes or more, as follows.
 
@@ -2509,13 +2509,13 @@ supports. The following sections define the terms [=authenticator attachment mod
 ### <dfn>Authenticator Attachment Modality</dfn> ### {#sctn-authenticator-attachment-modality}
 
 [=Clients=] can communicate with [=authenticators=] using a variety of mechanisms. For example, a [=client=] MAY use a
-platform-specific API to communicate with an [=authenticator=] which is physically bound to a [=client device=]. On the other hand, a
+[=client device=]-specific API to communicate with an [=authenticator=] which is physically bound to a [=client device=]. On the other hand, a
 [=client=] can use a variety of standardized cross-platform transport protocols such as Bluetooth (see [[#transport]]) to discover
 and communicate with [=cross-platform attachment|cross-platform attached=] [=authenticators=]. We refer to [=authenticators=] that
 are part of the [=client device=] as <dfn>platform authenticators</dfn>, while those that are reachable via cross-platform
 transport protocols are referred to as <dfn>roaming authenticators</dfn>.
 
-- A [=platform authenticator=] is attached using a platform-specific transport, called <dfn>platform attachment</dfn>, and is usually not removable from the [=client
+- A [=platform authenticator=] is attached using a [=client device=]-specific transport, called <dfn>platform attachment</dfn>, and is usually not removable from the [=client
     device=]. A [=public key credential=] bound to a [=platform authenticator=] is called a <dfn>platform credential</dfn>.
 
 - A [=roaming authenticator=] is attached using cross-platform transports, called <dfn>cross-platform attachment</dfn>. Authenticators of this class are removable from, and
@@ -2630,7 +2630,7 @@ It takes the following input parameters:
 :: The [=effective user verification requirement for credential creation=], a Boolean value provided by the client.
 : |credTypesAndPubKeyAlgs|
 :: A sequence of pairs of {{PublicKeyCredentialType}} and public key algorithms ({{COSEAlgorithmIdentifier}}) requested by the
-    [=[RP]=]. This sequence is ordered from most preferred to least preferred. The platform makes a best-effort to create the most
+    [=[RP]=]. This sequence is ordered from most preferred to least preferred. The [=authenticator=] makes a best-effort to create the most
     preferred credential that it can.
 : |excludeCredentialDescriptorList|
 :: An OPTIONAL list of {{PublicKeyCredentialDescriptor}} objects provided by the [=[RP]=] with the intention that, if any of
@@ -2883,7 +2883,7 @@ statement=], a [=[RP]=] needs to understand these two aspects of [=attestation=]
 
 1. The <dfn>attestation statement format</dfn> is the manner in which the signature is represented and the various contextual
     bindings are incorporated into the attestation statement by the [=authenticator=]. In other words, this defines the
-    syntax of the statement. Various existing devices and platforms (such as TPMs and the Android OS) have previously defined
+    syntax of the statement. Various existing [=client devices=] (such as TPMs and the Android OS) have previously defined
     [=attestation statement formats=]. This specification supports a variety of such formats in an extensible way, as defined in
     [[#attestation-formats]].
 
@@ -3838,7 +3838,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     : sig
     :: The [=attestation signature=].  
         The signature was calculated over the (raw) U2F registration response message [[!FIDO-U2F-Message-Formats]]
-        received by the platform from the authenticator.
+        received by the [=client=] from the authenticator.
 
 : Signing procedure
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
@@ -3925,8 +3925,8 @@ client.
 When creating a [=public key credential=] or requesting an [=authentication assertion=], a [=[WRP]=] can request the use of a set
 of extensions. These extensions will be invoked during the requested operation if they are supported by the client and/or the
 authenticator. The [=[RP]=] sends the [=client extension input=] for each extension in the {{CredentialsContainer/get()}} call
-(for [=authentication extensions=]) or {{CredentialsContainer/create()}} call (for [=registration extensions=]) to the client
-platform. The client platform performs [=client extension processing=] for each extension that it supports, and augments the
+(for [=authentication extensions=]) or {{CredentialsContainer/create()}} call (for [=registration extensions=]) to the [=client=].
+The [=client=] performs [=client extension processing=] for each extension that the [=client platform=] supports, and augments the
 [=client data=] as specified by each extension, by including the [=extension identifier=] and [=client extension output=]
 values.
 
@@ -4073,7 +4073,7 @@ Note: Extensions should aim to define authenticator arguments that are as small 
 
 ## <dfn>Client extension processing</dfn> ## {#sctn-client-extension-processing}
 
-Extensions MAY define additional processing requirements on the client platform during the creation of credentials or the
+Extensions MAY define additional processing requirements on the [=client=] during the creation of credentials or the
 generation of an assertion. The [=client extension input=] for the extension is used as an input to this client processing.
 For each supported [=client extension=], the client adds an entry to the |clientExtensions|  [=map=] with the
 [=extension identifier=] as the key, and the extension's [=client extension input=] as the value.
@@ -4723,11 +4723,11 @@ sample code for using this API. Note that this is an example flow and does not l
 
 As was the case in earlier sections, this flow focuses on a use case involving a [=first-factor roaming authenticator=]
 with its own display. One example of such an authenticator would be a smart phone. Other authenticator types are also supported
-by this API, subject to implementation by the platform. For instance, this flow also works without modification for the case of
-an authenticator that is embedded in the client platform. The flow also works for the case of an authenticator without
-its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the client platform
-needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the client
-platform to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.
+by this API, subject to implementation by the [=client platform=]. For instance, this flow also works without modification for the case of
+an authenticator that is embedded in the [=client device=]. The flow also works for the case of an authenticator without
+its own display (similar to a smart card) subject to specific implementation considerations. Specifically, the [=client platform=]
+needs to display any prompts that would otherwise be shown by the authenticator, and the authenticator needs to allow the [=client
+platform=] to enumerate all the authenticator's credentials so that the client can have information to show appropriate prompts.
 
 
 ## Registration ## {#sample-registration}
@@ -4741,14 +4741,14 @@ In this flow, the [=[WRP]=] does not have a preference for [=platform authentica
 
 1. The [=[RP]=] script runs the code snippet below.
 
-1. The client platform searches for and locates the authenticator.
+1. The [=client platform=] searches for and locates the authenticator.
 
-1. The client platform connects to the authenticator, performing any pairing actions if necessary.
+1. The [=client=] connects to the authenticator, performing any pairing actions if necessary.
 
 1. The authenticator shows appropriate UI for the user to select the authenticator on which the new credential will be
     created, and obtains a biometric or other authorization gesture from the user.
 
-1. The authenticator returns a response to the client platform, which in turn returns a response to the [=[RP]=] script. If
+1. The authenticator returns a response to the [=client=], which in turn returns a response to the [=[RP]=] script. If
     the user declined to select an authenticator or provide authorization, an appropriate error is returned.
 
 1. If a new credential was created,
@@ -4762,7 +4762,7 @@ In this flow, the [=[WRP]=] does not have a preference for [=platform authentica
 The sample code for generating and registering a new key follows:
 
 <pre class="example" highlight="js">
-    if (!window.PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Client not capable. Handle error. */ }
 
     var publicKey = {
       // The challenge is produced by the server; see the Security Considerations
@@ -4828,7 +4828,7 @@ a [=user-verifying platform authenticator=].
     Upon successful credential creation, the [=[RP]=] script conveys the new credential to the server.
 
 <pre class="example" highlight="js">
-    if (!window.PublicKeyCredential) { /* Platform not capable of the API. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Client not capable of the API. Handle error. */ }
 
     PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
         .then(function (userIntent) {
@@ -4860,15 +4860,15 @@ credential.
 
 1. The user visits example.com, which serves up a script.
 
-1. The script asks the client platform for an Authentication Assertion, providing as much information as possible to narrow
+1. The script asks the [=client=] for an Authentication Assertion, providing as much information as possible to narrow
     the choice of acceptable credentials for the user. This can be obtained from the data that was stored locally after
     registration, or by other means such as prompting the user for a username.
 
 1. The [=[RP]=] script runs one of the code snippets below.
 
-1. The client platform searches for and locates the authenticator.
+1. The [=client platform=] searches for and locates the authenticator.
 
-1. The client platform connects to the authenticator, performing any pairing actions if necessary.
+1. The [=client=] connects to the authenticator, performing any pairing actions if necessary.
 
 1. The authenticator presents the user with a notification that their attention is needed. On opening the
     notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided
@@ -4876,7 +4876,7 @@ credential.
 
 1. The authenticator obtains a biometric or other authorization gesture from the user.
 
-1. The authenticator returns a response to the client platform, which in turn returns a response to the [=[RP]=] script.
+1. The authenticator returns a response to the [=client=], which in turn returns a response to the [=[RP]=] script.
     If the user declined to select a credential or provide an authorization, an appropriate error is returned.
 
 1. If an assertion was successfully generated and returned,
@@ -4894,7 +4894,7 @@ If the [=[RP]=] script does not have any hints available (e.g., from locally sto
 credentials, then the sample code for performing such an authentication might look like this:
 
 <pre class="example" highlight="js">
-    if (!window.PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Client not capable. Handle error. */ }
 
     // credentialId is generated by the authenticator and is an opaque random byte array
     var credentialId = new Uint8Array([183, 148, 245 /* more random bytes previously generated by the authenticator */]);
@@ -4918,7 +4918,7 @@ performing such an authentication might look like the following. Note that this 
 extension for transaction authorization.
 
 <pre class="example" highlight="js">
-    if (!window.PublicKeyCredential) { /* Platform not capable. Handle error. */ }
+    if (!window.PublicKeyCredential) { /* Client not capable. Handle error. */ }
 
     var encoder = new TextEncoder();
     var acceptableCredential1 = {

--- a/index.bs
+++ b/index.bs
@@ -475,8 +475,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Client</dfn>
 :: See [=[WAC]=], [=Conforming User Agent=].
 
+: <dfn>Client Platform</dfn>
+:: A [=client device=] and a [=client=] together make up a [=client platform=]. A single hardware device MAY be part of multiple
+    distinct [=client platforms=] at different times by running different operating systems and/or [=clients=].
+
 : <dfn>Client-Side</dfn>
-:: This refers in general to the combination of the user's [=client device=], user agent, [=authenticators=], and everything gluing
+:: This refers in general to the combination of the user's [=client platform=], [=authenticators=], and everything gluing
     it all together.
 
 : <dfn>Resident Credential</dfn>
@@ -491,7 +495,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [=client device=], but the [=client device=] is not expected to offload the key storage to remote entities (e.g., [=[WRP]=] Server).
 
 : <dfn>Conforming User Agent</dfn>
-:: A user agent implementing, in conjunction with the underlying platform, the [=Web Authentication API=] and algorithms
+:: A user agent implementing, in co-operation with the underlying [=client device=], the [=Web Authentication API=] and algorithms
     given in this specification, and handling communication between [=authenticators=] and [=[RPS]=].
 
 : <dfn>Credential ID</dfn>
@@ -667,12 +671,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Client Device</dfn>
 : <dfn>[WAC] Device</dfn>
-:: The hardware device on which the [=[WAC]=] runs, for example a smartphone, a laptop computer or a desktop computer. Also
-    referred to herein as the "platform" or "client platform".
+:: The hardware device on which the [=[WAC]=] runs, for example a smartphone, a laptop computer or a desktop computer, and the
+    operating system running on that hardware.
 
-    The distinction between this and the [=client=] is that multiple [=clients=], i.e., browser implementations, may run on the
-    same [=client device=] and have access to the same [=authenticators=] available on that [=client device=]; and that [=platform
-    authenticators=] are bound to a [=[WAC] Device=] rather than a [=[WAC]=].
+    The distinction between this and the [=client=] is that one [=client device=] MAY support running multiple [=clients=], i.e., browser
+    implementations, which all have access to the same [=authenticators=] available on that [=client device=]; and that [=platform
+    authenticators=] are bound to a [=[WAC] Device=] rather than a [=[WAC]=]. A [=client device=] and a [=client=] together make
+    up a [=client platform=].
 
 : <dfn>[WRP]</dfn>
 :: The entity whose web application utilizes the [=Web Authentication API=] to register and authenticate users. See


### PR DESCRIPTION
This mitigates #358 and #462.

- Add "client platform" definition
- Rewrite/remove most unqualified uses of "platform"; main exception is "platform-provided" in the context of the Android attestation statement formats
- Rewrite/qualify most uses of "device"

This should eliminate from #358:

- Platform
  - a platform
  - underlying platform
  - underlying OS platform
  - [this|the] client platform
  - client's platform
  - [this|the] platform
  - user agent and/or platform

and from #462:

- CLIENT:
  - client
  - client device
  - client platform
  - (not "client-side", but #997 takes care of most of what remains of that)
- Device
  - computing device
  - user's computing device
  - see also 'client device'
- PLATFORM:
  - All sub-items except:
    - Android "N" or later platform
    - Android platforms


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/998.html" title="Last updated on Jul 18, 2018, 5:21 PM GMT (7683687)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/998/bf4dbab...7683687.html" title="Last updated on Jul 18, 2018, 5:21 PM GMT (7683687)">Diff</a>