### PR TITLE
fix 933: authnr does not enforce RP ID being eTLD+1 of RP's origin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2408,12 +2408,11 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, as fol
   actual representation of the [=authenticator data=].
 
 
-The [=RP ID=] is originally received from the client when the credential is created, and again when an assertion is generated.
+The [=RP ID=] is originally received from the [=client=] when the credential is created, and again when an assertion is generated.
 However, it differs from other [=client data=] in some important ways. First, unlike the client data, the [=RP ID=] of a
 credential does not change between operations but instead remains the same for the lifetime of that credential. Secondly, it is
 validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] associated
-with the requested credential exactly matches the [=RP ID=] supplied by the client, and that the [=RP ID=] [=is a registrable
-domain suffix of or is equal to=] the [=effective domain=] of the RP's [=origin=]'s [=effective domain=].
+with the requested credential exactly matches the [=RP ID=] supplied by the [=client=].
 
 [=Authenticators=] <dfn for="authenticator data">perform the following steps to generate an [=authenticator data=] structure</dfn>:
 

--- a/index.bs
+++ b/index.bs
@@ -2408,7 +2408,7 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, as fol
   actual representation of the [=authenticator data=].
 
 
-The [=RP ID=] is originally received from the [=client=] when the credential is created, and again when an assertion is generated.
+The [=RP ID=] is originally received from the [=client=] when the credential is created, and again when an [=assertion=] is generated.
 However, it differs from other [=client data=] in some important ways. First, unlike the client data, the [=RP ID=] of a
 credential does not change between operations but instead remains the same for the lifetime of that credential. Secondly, it is
 validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] associated


### PR DESCRIPTION
fixes #933 
```
* c067d6a 2018-07-13 | link assertion term (HEAD -> jeffh-fix-933-authnr-not-enforce-tld+1) [JeffH]
* 8f2767f 2018-07-13 | remove inapprop phrase and link some terms [JeffH]
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/999.html" title="Last updated on Jul 13, 2018, 7:51 PM GMT (c067d6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/999/f864d09...c067d6a.html" title="Last updated on Jul 13, 2018, 7:51 PM GMT (c067d6a)">Diff</a>