### PR TITLE
Make transaction authorization extensions authentication exts only

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4251,7 +4251,7 @@ This extension allows for a simple form of transaction authorization. A
 :: `txAuthSimple`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
+:: [=authentication extension|Authentication=]
 
 : Client extension input
 :: A single USVString prompt.
@@ -4301,7 +4301,7 @@ as well. This allows authenticators without a font rendering engine to be used a
 :: `txAuthGeneric`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
+:: [=authentication extension|Authentication=]
 
 : Client extension input
 :: A JavaScript object defined as follows:


### PR DESCRIPTION
This fixes #621.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1002.html" title="Last updated on Jul 18, 2018, 5:27 PM GMT (911864c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1002/8d6b9ac...911864c.html" title="Last updated on Jul 18, 2018, 5:27 PM GMT (911864c)">Diff</a>