### PR TITLE
fix 985 add abort path to createCredential alg

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -991,6 +991,10 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|.
 
+        :   If the user exercises a user agent user-interface option to cancel the process,
+        ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
+            and [=set/remove=] |authenticator| from |issuedRequests|. Return a {{DOMException}} whose name is "{{NotAllowedError}}".
+
         :   If the <code>|options|.{{CredentialCreationOptions/signal}}</code> is [=present=] and its
             [=AbortSignal/aborted flag=] is set to [TRUE],
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=]
@@ -1329,7 +1333,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on
             |authenticator| and [=set/remove=] |authenticator| from |issuedRequests|.
 
-        :   If the user exercises a user-interface option to cancel the process,
+        :   If the user exercises a user agent user-interface option to cancel the process,
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|. Return a {{DOMException}} whose name is "{{NotAllowedError}}".
 


### PR DESCRIPTION
this fixes issue #985 

Also clarified in both the added switch branch to [#createCredential](https://w3c.github.io/webauthn/#createCredential) and the existing one in [#getAssertion](https://w3c.github.io/webauthn/#discover-from-external-source), that this is due to the user exercising a _user agent_ user-interface option.  This is to more clearly disambiguate these switch branches from the ones entitled "If any authenticator returns a status indicating that the user cancelled the operation...".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1005.html" title="Last updated on Jul 24, 2018, 1:06 AM GMT (2b1680f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1005/741cef6...2b1680f.html" title="Last updated on Jul 24, 2018, 1:06 AM GMT (2b1680f)">Diff</a>