### PR TITLE
fix #939 add intro abort language to #getAssertion

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1193,6 +1193,10 @@ Since this specification requires an [=authorization gesture=] to create any [=c
 for="PublicKeyCredential" method>\[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)</dfn></code> [=internal method=] inherits the default behavior of
 {{Credential/[[CollectFromCredentialStore]]()|Credential.[[CollectFromCredentialStore]]()}}, of returning an empty set.
 
+This
+{{CredentialsContainer/get()|navigator.credentials.get()}} operation can be aborted by leveraging the {{AbortController}};
+see [[dom#abortcontroller-api-integration]] for detailed instructions.
+
 <h5 id="discover-from-external-source" algorithm>PublicKeyCredential's <code><dfn for="PublicKeyCredential" method>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn></code> method</h5>
 
 <div link-for-hint="PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)">


### PR DESCRIPTION
see issue #939


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1006.html" title="Last updated on Jul 24, 2018, 1:24 AM GMT (3979124)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1006/741cef6...3979124.html" title="Last updated on Jul 24, 2018, 1:24 AM GMT (3979124)">Diff</a>