### PR TITLE
fix #24: add reg & authn flow diagrams

### DIFF
--- a/images/webauthn-authentication-flow-01.svg
+++ b/images/webauthn-authentication-flow-01.svg
@@ -1,0 +1,858 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="34 36 1068 495"
+   width="1068"
+   height="495"
+   id="svg4100"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="webauthn-authentication-flow-01.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1925"
+     inkscape:window-height="1024"
+     id="namedview4310"
+     showgrid="false"
+     inkscape:zoom="1.1610487"
+     inkscape:cx="492.98587"
+     inkscape:cy="247.5"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Graphic_27" />
+  <defs
+     id="defs4102">
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5285"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(1.1) translate(1,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Lend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path5288"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(1.1) rotate(180) translate(1,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker"
+       stroke-linejoin="miter"
+       stroke-miterlimit="10"
+       viewBox="-1 -4 10 8"
+       markerWidth="10"
+       markerHeight="8"
+       color="#c1c1c1">
+      <g
+         id="g4105">
+        <path
+           d="M 7.2 0 L 0 -2.7 L 0 2.7 Z"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1"
+           id="path4107" />
+      </g>
+    </marker>
+    <font-face
+       font-family="Open Sans"
+       font-size="21"
+       panose-1="2 11 8 6 3 5 4 2 2 4"
+       units-per-em="1000"
+       underline-position="-75.19531"
+       underline-thickness="49.80469"
+       slope="0"
+       x-height="545.89844"
+       cap-height="713.8672"
+       ascent="1068.8477"
+       descent="-292.96875"
+       font-weight="700"
+       id="font-face4109">
+      <font-face-src>
+        <font-face-name
+           name="OpenSans-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_2"
+       stroke-linejoin="miter"
+       stroke-miterlimit="10"
+       viewBox="-1 -4 10 8"
+       markerWidth="10"
+       markerHeight="8"
+       color="black">
+      <g
+         id="g4112">
+        <path
+           d="M 7.2 0 L 0 -2.7 L 0 2.7 Z"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1"
+           id="path4114" />
+      </g>
+    </marker>
+    <font-face
+       font-family="Open Sans"
+       font-size="16"
+       panose-1="2 11 6 6 3 5 4 2 2 4"
+       units-per-em="1000"
+       underline-position="-75.19531"
+       underline-thickness="49.80469"
+       slope="0"
+       x-height="535.15625"
+       cap-height="713.8672"
+       ascent="1068.8477"
+       descent="-292.96875"
+       font-weight="400"
+       id="font-face4116">
+      <font-face-src>
+        <font-face-name
+           name="OpenSans" />
+      </font-face-src>
+    </font-face>
+    <font-face
+       font-family="Open Sans"
+       font-size="16"
+       panose-1="2 11 8 6 3 5 4 2 2 4"
+       units-per-em="1000"
+       underline-position="-75.19531"
+       underline-thickness="49.80469"
+       slope="0"
+       x-height="545.89844"
+       cap-height="713.8672"
+       ascent="1068.8477"
+       descent="-292.96875"
+       font-weight="700"
+       id="font-face4118">
+      <font-face-src>
+        <font-face-name
+           name="OpenSans-Bold" />
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata
+     id="metadata4120"> Produced by OmniGraffle 7.7.1 
+    <dc:date>2018-06-26 16:26:03 +0000</dc:date>
+<rdf:RDF>
+  <cc:Work
+     rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+    <dc:title></dc:title>
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+  <g
+     id="Authentication_WebAuthn"
+     fill-opacity="1"
+     stroke-dasharray="none"
+     stroke="none"
+     stroke-opacity="1"
+     fill="none">
+    <title
+       id="title4123">Authentication WebAuthn</title>
+    <g
+       id="Authentication_WebAuthn: Layer 1">
+      <title
+         id="title4126">Layer 1</title>
+      <g
+         id="Graphic_34">
+        <rect
+           x="333.5"
+           y="105"
+           width="19"
+           height="68"
+           id="path" />
+        <clipPath
+           id="clip_path">
+          <use
+             xlink:href="#path"
+             id="use4131" />
+        </clipPath>
+        <g
+           clip-path="url(#clip_path)"
+           id="g4133">
+          <image
+             sodipodi:absref="/Users/jehodges/_work-stds-w3c-webauthn/images/image7.tiff"
+             xlink:href="image7.tiff"
+             id="image4135"
+             transform="translate(352.5 173) rotate(180)"
+             height="68"
+             width="19" />
+        </g>
+      </g>
+      <g
+         id="Graphic_33">
+        <rect
+           x="808"
+           y="104.5"
+           width="19"
+           height="68"
+           id="path_2" />
+        <clipPath
+           id="clip_path_2">
+          <use
+             xlink:href="#path_2"
+             id="use4140" />
+        </clipPath>
+        <g
+           clip-path="url(#clip_path_2)"
+           id="g4142">
+          <image
+             sodipodi:absref="/Users/jehodges/_work-stds-w3c-webauthn/images/image7.tiff"
+             xlink:href="image7.tiff"
+             id="image4144"
+             transform="translate(808 104.5)"
+             height="68"
+             width="19" />
+        </g>
+      </g>
+      <g
+         id="Line_28">
+        <line
+           x1="509.5"
+           y1="196"
+           x2="509.5"
+           y2="98.7"
+           marker-end="url(#FilledArrow_Marker)"
+           stroke="#c1c1c1"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="2"
+           id="line4147" />
+      </g>
+      <g
+         id="Graphic_27">
+        <rect
+           x="357.5"
+           y="37"
+           width="375.5"
+           height="44"
+           id="rect4150"
+           fill="white" />
+        <path
+           d="M 357.5 37 L 733 37 L 733 81 L 357.5 81 Z"
+           id="path4152"
+           stroke-dasharray="4.0,4.0"
+           stroke-linejoin="round"
+           stroke-linecap="round"
+           stroke-width="1"
+           stroke="black" />
+        <text
+           id="text4154"
+           style="fill:#000000"
+           x="300.48709"
+           y="41.55484">
+          <tspan
+             font-size="21"
+             font-weight="700"
+             x="449.53763"
+             y="63.55484"
+             id="tspan4156"
+             style="font-weight:700;font-size:21px;font-family:'Open Sans';fill:#000000">Relying Party Server</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_26">
+        <rect
+           x="357.5"
+           y="409"
+           width="375.5"
+           height="44"
+           fill="white"
+           id="rect4159" />
+        <path
+           d="M 357.5 409 L 733 409 L 733 453 L 357.5 453 Z"
+           stroke="black"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-dasharray="4.0,4.0"
+           stroke-width="1"
+           id="path4161" />
+        <text
+           transform="translate(362.5 417)"
+           fill="black"
+           id="text4163">
+          <tspan
+             font-family="Open Sans"
+             font-size="21"
+             font-weight="700"
+             fill="black"
+             x="108.71167"
+             y="22"
+             id="tspan4165">Authenticator</tspan>
+        </text>
+      </g>
+      <g
+         id="Line_25">
+        <line
+           x1="482.66667"
+           y1="81"
+           x2="482.66667"
+           y2="178.3"
+           marker-end="url(#FilledArrow_Marker_2)"
+           stroke="black"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="2"
+           id="line4168" />
+      </g>
+      <g
+         id="Line_24">
+        <line
+           x1="482.66667"
+           y1="328"
+           x2="482.66667"
+           y2="391.3"
+           marker-end="url(#FilledArrow_Marker_2)"
+           stroke="black"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="2"
+           id="line4171" />
+      </g>
+      <g
+         id="Line_23">
+        <line
+           x1="607.8333"
+           y1="409"
+           x2="607.8333"
+           y2="345.7"
+           marker-end="url(#FilledArrow_Marker_2)"
+           stroke="black"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="2"
+           id="line4174" />
+      </g>
+      <g
+         id="Line_22">
+        <line
+           x1="607.8333"
+           y1="196"
+           x2="607.8333"
+           y2="98.7"
+           marker-end="url(#FilledArrow_Marker_2)"
+           stroke="black"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="2"
+           id="line4177" />
+      </g>
+      <g
+         id="Graphic_21">
+        <text
+           transform="translate(357.5 127.5)"
+           fill="#2073a5"
+           id="text4180">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x=".015625"
+             y="17"
+             id="tspan4182">challenge</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_20">
+        <text
+           transform="translate(314 350)"
+           fill="#2073a5"
+           id="text4185">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x=".01953125"
+             y="17"
+             id="tspan4187">relying party id,</tspan>
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x=".7890625"
+             y="39"
+             id="tspan4189">clientDataHash</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_19">
+        <text
+           transform="translate(671.5 350)"
+           fill="#2073a5"
+           id="text4192">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x=".42578125"
+             y="17"
+             id="tspan4194">authenticatorData</tspan>
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x="33.589844"
+             y="39"
+             id="tspan4196">signature</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_18">
+        <text
+           transform="translate(662 105.5)"
+           fill="#2073a5"
+           id="text4199">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x="12.117188"
+             y="17"
+             id="tspan4201">clientDataJSON,</tspan>
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x=".46484375"
+             y="39"
+             id="tspan4203">authenticatorData,</tspan>
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x="35.589844"
+             y="61"
+             id="tspan4205">signature</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_17">
+        <circle
+           cx="456.5"
+           cy="138.5"
+           r="15.0000239685284"
+           fill="white"
+           id="circle4208" />
+        <circle
+           cx="456.5"
+           cy="138.5"
+           r="15.0000239685284"
+           stroke="#2073a5"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="3"
+           id="circle4210" />
+        <text
+           transform="translate(449.5 127.5)"
+           fill="#2073a5"
+           id="text4212">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x="2.4335938"
+             y="17"
+             id="tspan4214">1</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_16">
+        <circle
+           cx="456.5"
+           cy="372"
+           r="15.0000239685284"
+           fill="white"
+           id="circle4217" />
+        <circle
+           cx="456.5"
+           cy="372"
+           r="15.0000239685284"
+           stroke="#2073a5"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="3"
+           id="circle4219" />
+        <text
+           transform="translate(449.5 361)"
+           fill="#2073a5"
+           id="text4221">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x="2.4335938"
+             y="17"
+             id="tspan4223">2</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_15">
+        <circle
+           cx="635"
+           cy="138.5"
+           r="15.0000239685284"
+           fill="white"
+           id="circle4226" />
+        <circle
+           cx="635"
+           cy="138.5"
+           r="15.0000239685284"
+           stroke="#2073a5"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="3"
+           id="circle4228" />
+        <text
+           transform="translate(628 127.5)"
+           fill="#2073a5"
+           id="text4230">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x="2.4335938"
+             y="17"
+             id="tspan4232">5</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_14">
+        <circle
+           cx="635"
+           cy="372"
+           r="15.0000239685284"
+           fill="white"
+           id="circle4235" />
+        <circle
+           cx="635"
+           cy="372"
+           r="15.0000239685284"
+           stroke="#2073a5"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="3"
+           id="circle4237" />
+        <text
+           transform="translate(628 361)"
+           fill="#2073a5"
+           id="text4239">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x="2.4335938"
+             y="17"
+             id="tspan4241">4</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_13">
+        <circle
+           cx="545.25"
+           cy="462"
+           r="15.0000239685284"
+           fill="white"
+           id="circle4244" />
+        <circle
+           cx="545.25"
+           cy="462"
+           r="15.0000239685284"
+           stroke="#2073a5"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="3"
+           id="circle4246" />
+        <text
+           transform="translate(538.25 451)"
+           fill="#2073a5"
+           id="text4248">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x="2.4335938"
+             y="17"
+             id="tspan4250">3</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_12">
+        <text
+           transform="translate(483.25 482)"
+           fill="#2073a5"
+           id="text4253">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x=".11328125"
+             y="17"
+             id="tspan4255">user verification,</tspan>
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x="2.3320312"
+             y="39"
+             id="tspan4257">create assertion</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_11">
+        <rect
+           x="357.5"
+           y="262"
+           width="375.5"
+           height="66"
+           fill="#1972a7"
+           id="rect4260" />
+        <rect
+           x="357.5"
+           y="262"
+           width="375.5"
+           height="66"
+           stroke="black"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="4"
+           id="rect4262" />
+        <text
+           transform="translate(362.5 281)"
+           fill="white"
+           id="text4264">
+          <tspan
+             font-family="Open Sans"
+             font-size="21"
+             font-weight="700"
+             fill="white"
+             x="139.66821"
+             y="22"
+             id="tspan4266">Browser</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_10">
+        <rect
+           x="357.5"
+           y="196"
+           width="375.5"
+           height="66"
+           fill="#1972a7"
+           id="rect4269" />
+        <rect
+           x="357.5"
+           y="196"
+           width="375.5"
+           height="66"
+           stroke="black"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="4"
+           id="rect4271" />
+        <text
+           id="text4273"
+           style="fill:#ffffff"
+           x="353.88708"
+           y="215">
+          <tspan
+             font-size="21"
+             font-weight="700"
+             x="421.57288"
+             y="237"
+             id="tspan4275"
+             style="font-weight:700;font-size:21px;font-family:'Open Sans';fill:#ffffff">RP JavaScript Application</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_9">
+        <circle
+           cx="740"
+           cy="59"
+           r="15.0000239685285"
+           fill="white"
+           id="circle4278" />
+        <circle
+           cx="740"
+           cy="59"
+           r="15.0000239685285"
+           stroke="#2073a5"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="3"
+           id="circle4280" />
+        <text
+           transform="translate(733 48)"
+           fill="#2073a5"
+           id="text4282">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x="2.4335938"
+             y="17"
+             id="tspan4284">6</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_8">
+        <circle
+           cx="534"
+           cy="138.5"
+           r="15.0000239685284"
+           fill="white"
+           id="circle4287" />
+        <circle
+           cx="534"
+           cy="138.5"
+           r="15.0000239685284"
+           stroke="#c1c1c1"
+           stroke-linecap="round"
+           stroke-linejoin="round"
+           stroke-width="3"
+           id="circle4289" />
+        <text
+           transform="translate(527 127.5)"
+           fill="#c1c1c1"
+           id="text4291">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#c1c1c1"
+             x="2.4335938"
+             y="17"
+             id="tspan4293">0</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_7">
+        <text
+           transform="translate(767 48)"
+           fill="#2073a5"
+           id="text4296">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="400"
+             fill="#2073a5"
+             x=".14453125"
+             y="17"
+             id="tspan4298">server validation</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_5">
+        <text
+           transform="translate(832 127.5)"
+           fill="#2073a5"
+           id="text4301">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x=".171875"
+             y="17"
+             id="tspan4303">AuthenticatorAssertionResponse</tspan>
+        </text>
+      </g>
+      <g
+         id="Graphic_3">
+        <text
+           transform="translate(39.5 127.5)"
+           fill="#2073a5"
+           id="text4306">
+          <tspan
+             font-family="Open Sans"
+             font-size="16"
+             font-weight="700"
+             fill="#2073a5"
+             x=".1640625"
+             y="17"
+             id="tspan4308">PublicKeyCredentialRequestOptions</tspan>
+        </text>
+      </g>
+      <g
+         id="g4435"
+         transform="translate(-29.283871,123.16452)">
+        <text
+           id="text4437"
+           style="fill:#2073a5"
+           x="206.59032"
+           y="128.3613">
+          <tspan
+             id="tspan4439"
+             y="145.3613"
+             x="206.75438"
+             font-weight="700"
+             font-size="16"
+             style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#2073a5">WebAuthnAPI</tspan>
+        </text>
+        <path
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lstart)"
+           d="m 334.59032,140.83548 c 44.7871,0 43.92581,0 43.92581,0"
+           id="path4443"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         style="fill:#ef0000;stroke:#fc0000;stroke-width:5.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:22,22;stroke-dashoffset:0;fill-opacity:1"
+         d="m 356.12258,260.55484 c 376.38387,0 376.38387,-0.86129 376.38387,-0.86129"
+         id="path5617"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/images/webauthn-registration-flow-01.svg
+++ b/images/webauthn-registration-flow-01.svg
@@ -1,0 +1,877 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="60 136 1118 547"
+   width="1118"
+   height="547"
+   id="svg3612"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="webauthn-registration-flow-01.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1690"
+     inkscape:window-height="1158"
+     id="namedview3848"
+     showgrid="false"
+     inkscape:zoom="1.0056349"
+     inkscape:cx="559"
+     inkscape:cy="273.5"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Graphic_10" />
+  <defs
+     id="defs3614">
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker"
+       stroke-linejoin="miter"
+       stroke-miterlimit="10"
+       viewBox="-1 -4 10 8"
+       markerWidth="10"
+       markerHeight="8"
+       color="#c1c1c1">
+      <g
+         id="g3617">
+        <path
+           d="M 7.2 0 L 0 -2.7 L 0 2.7 Z"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1"
+           id="path3619" />
+      </g>
+    </marker>
+    <font-face
+       font-family="Open Sans"
+       font-size="21"
+       panose-1="2 11 8 6 3 5 4 2 2 4"
+       units-per-em="1000"
+       underline-position="-75.19531"
+       underline-thickness="49.80469"
+       slope="0"
+       x-height="545.89844"
+       cap-height="713.8672"
+       ascent="1068.8477"
+       descent="-292.96875"
+       font-weight="700"
+       id="font-face3621">
+      <font-face-src>
+        <font-face-name
+           name="OpenSans-Bold" />
+      </font-face-src>
+    </font-face>
+    <marker
+       orient="auto"
+       overflow="visible"
+       markerUnits="strokeWidth"
+       id="FilledArrow_Marker_2"
+       stroke-linejoin="miter"
+       stroke-miterlimit="10"
+       viewBox="-1 -4 10 8"
+       markerWidth="10"
+       markerHeight="8"
+       color="black">
+      <g
+         id="g3624">
+        <path
+           d="M 7.2 0 L 0 -2.7 L 0 2.7 Z"
+           fill="currentColor"
+           stroke="currentColor"
+           stroke-width="1"
+           id="path3626" />
+      </g>
+    </marker>
+    <font-face
+       font-family="Open Sans"
+       font-size="16"
+       panose-1="2 11 6 6 3 5 4 2 2 4"
+       units-per-em="1000"
+       underline-position="-75.19531"
+       underline-thickness="49.80469"
+       slope="0"
+       x-height="535.15625"
+       cap-height="713.8672"
+       ascent="1068.8477"
+       descent="-292.96875"
+       font-weight="400"
+       id="font-face3628">
+      <font-face-src>
+        <font-face-name
+           name="OpenSans" />
+      </font-face-src>
+    </font-face>
+    <font-face
+       font-family="Open Sans"
+       font-size="16"
+       panose-1="2 11 8 6 3 5 4 2 2 4"
+       units-per-em="1000"
+       underline-position="-75.19531"
+       underline-thickness="49.80469"
+       slope="0"
+       x-height="545.89844"
+       cap-height="713.8672"
+       ascent="1068.8477"
+       descent="-292.96875"
+       font-weight="700"
+       id="font-face3630">
+      <font-face-src>
+        <font-face-name
+           name="OpenSans-Bold" />
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata
+     id="metadata3632"> Produced by OmniGraffle 7.7.1 
+    <dc:date>2018-06-26 16:26:03 +0000</dc:date>
+<rdf:RDF>
+  <cc:Work
+     rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+    <dc:title></dc:title>
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+  <g
+     style="fill:none;fill-opacity:1;stroke:none;stroke-dasharray:none;stroke-opacity:1"
+     id="Registration_WebAuthn: Layer 1">
+    <title
+       id="title3638">Layer 1</title>
+    <g
+       id="Graphic_39">
+      <rect
+         id="path"
+         height="68"
+         width="19"
+         y="205"
+         x="347" />
+      <clipPath
+         id="clip_path">
+        <use
+           height="100%"
+           width="100%"
+           y="0"
+           x="0"
+           id="use3643"
+           xlink:href="#path" />
+      </clipPath>
+      <g
+         id="g3645"
+         clip-path="url(#clip_path)">
+        <image
+           sodipodi:absref="/Users/jehodges/_work-stds-w3c-webauthn/images/image7.tiff"
+           xlink:href="image7.tiff"
+           width="19"
+           height="68"
+           transform="matrix(-1,0,0,-1,366,273)"
+           id="image3647" />
+      </g>
+    </g>
+    <g
+       id="Graphic_38">
+      <rect
+         id="path_2"
+         height="68"
+         width="19"
+         y="449"
+         x="846" />
+      <clipPath
+         id="clip_path_2">
+        <use
+           height="100%"
+           width="100%"
+           y="0"
+           x="0"
+           id="use3652"
+           xlink:href="#path_2" />
+      </clipPath>
+      <g
+         id="g3654"
+         clip-path="url(#clip_path_2)">
+        <image
+           sodipodi:absref="/Users/jehodges/_work-stds-w3c-webauthn/images/image7.tiff"
+           xlink:href="image7.tiff"
+           width="19"
+           height="68"
+           transform="translate(846,449)"
+           id="image3656" />
+      </g>
+    </g>
+    <g
+       id="Graphic_40">
+      <rect
+         id="path_3"
+         height="68"
+         width="19"
+         y="205"
+         x="867" />
+      <clipPath
+         id="clip_path_3">
+        <use
+           height="100%"
+           width="100%"
+           y="0"
+           x="0"
+           id="use3661"
+           xlink:href="#path_3" />
+      </clipPath>
+      <g
+         id="g3663"
+         clip-path="url(#clip_path_3)">
+        <image
+           sodipodi:absref="/Users/jehodges/_work-stds-w3c-webauthn/images/image7.tiff"
+           xlink:href="image7.tiff"
+           width="19"
+           height="68"
+           transform="translate(867,205)"
+           id="image3665" />
+      </g>
+    </g>
+    <g
+       id="Line_30">
+      <line
+         style="stroke:#c1c1c1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker-end:url(#FilledArrow_Marker)"
+         id="line3668"
+         y2="198.7"
+         x2="575.5"
+         y1="296"
+         x1="575.5" />
+    </g>
+    <g
+       id="Graphic_29">
+      <rect
+         style="fill:#ffffff"
+         id="rect3671"
+         height="44"
+         width="375.5"
+         y="137"
+         x="423.5" />
+      <path
+         style="stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:4, 4"
+         inkscape:connector-curvature="0"
+         id="path3673"
+         d="m 423.5,137 375.5,0 0,44 -375.5,0 z" />
+      <text
+         style="fill:#000000"
+         id="text3675"
+         x="358.89221"
+         y="143.0112">
+        <tspan
+           style="font-weight:700;font-size:21px;font-family:'Open Sans';fill:#000000"
+           id="tspan3677"
+           y="165.0112"
+           x="507.94275"
+           font-weight="700"
+           font-size="21">Relying Party Server</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_28">
+      <rect
+         style="fill:#ffffff"
+         id="rect3680"
+         height="44"
+         width="375.5"
+         y="539"
+         x="423.5" />
+      <path
+         style="stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:4, 4"
+         inkscape:connector-curvature="0"
+         id="path3682"
+         d="m 423.5,539 375.5,0 0,44 -375.5,0 z" />
+      <text
+         style="fill:#000000"
+         id="text3684"
+         transform="translate(428.5,547)">
+        <tspan
+           style="font-weight:700;font-size:21px;font-family:'Open Sans';fill:#000000"
+           id="tspan3686"
+           y="22"
+           x="108.71167"
+           font-weight="700"
+           font-size="21">Authenticator</tspan>
+      </text>
+    </g>
+    <g
+       id="Line_27">
+      <line
+         style="stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker-end:url(#FilledArrow_Marker_2)"
+         id="line3689"
+         y2="278.29999"
+         x2="548.66669"
+         y1="181"
+         x1="548.66669" />
+    </g>
+    <g
+       id="Line_26">
+      <line
+         style="stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker-end:url(#FilledArrow_Marker_2)"
+         id="line3692"
+         y2="521.29999"
+         x2="548.66669"
+         y1="428"
+         x1="548.66669" />
+    </g>
+    <g
+       id="Line_25">
+      <line
+         style="stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker-end:url(#FilledArrow_Marker_2)"
+         id="line3695"
+         y2="445.70001"
+         x2="673.83331"
+         y1="539"
+         x1="673.83331" />
+    </g>
+    <g
+       id="Line_24">
+      <line
+         style="stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker-end:url(#FilledArrow_Marker_2)"
+         id="line3698"
+         y2="198.7"
+         x2="673.83331"
+         y1="296"
+         x1="673.83331" />
+    </g>
+    <g
+       id="Graphic_23">
+      <text
+         style="fill:#0f71a9"
+         id="text3701"
+         transform="translate(371,205.5)">
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3703"
+           y="17"
+           x="26.054688"
+           font-weight="400"
+           font-size="16">challenge,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3705"
+           y="39"
+           x="28.503906"
+           font-weight="400"
+           font-size="16">user info,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3707"
+           y="61"
+           x="0.4296875"
+           font-weight="400"
+           font-size="16">relying party info</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_22">
+      <text
+         style="fill:#2073a5"
+         id="text3710"
+         transform="translate(371.5,439.5)">
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#2073a5"
+           id="tspan3712"
+           y="17"
+           x="8.0195312"
+           font-weight="400"
+           font-size="16">relying party id</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3714"
+           y="17"
+           font-weight="400"
+           font-size="16">,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3716"
+           y="39"
+           x="30.503906"
+           font-weight="400"
+           font-size="16">user info,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3718"
+           y="61"
+           x="0.46875"
+           font-weight="400"
+           font-size="16">relying party info,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3720"
+           y="83"
+           x="8.7890615"
+           font-weight="400"
+           font-size="16">clientDataHash</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_21">
+      <text
+         style="fill:#0f71a9"
+         id="text3723"
+         transform="translate(728,450.5)">
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3725"
+           y="17"
+           x="0.2734375"
+           font-weight="400"
+           font-size="16">new public key,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3727"
+           y="39"
+           x="8.5117188"
+           font-weight="400"
+           font-size="16">credential id,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3729"
+           y="61"
+           x="16.234375"
+           font-weight="400"
+           font-size="16">attestation</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_20">
+      <text
+         style="fill:#0f71a9"
+         id="text3732"
+         transform="translate(730,216.5)">
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3734"
+           y="17"
+           x="25.40625"
+           font-weight="400"
+           font-size="16">clientData,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3736"
+           y="39"
+           x="0.45703125"
+           font-weight="400"
+           font-size="16">attestationObject</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_19">
+      <circle
+         style="fill:#ffffff"
+         id="circle3739"
+         r="15.000024"
+         cy="238.5"
+         cx="522.5" />
+      <circle
+         style="stroke:#0f71a9;stroke-width:3;stroke-linecap:round;stroke-linejoin:round"
+         id="circle3741"
+         r="15.000024"
+         cy="238.5"
+         cx="522.5" />
+      <text
+         style="fill:#0f71a9"
+         id="text3743"
+         transform="translate(515.5,227.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3745"
+           y="17"
+           x="2.4335938"
+           font-weight="700"
+           font-size="16">1</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_18">
+      <circle
+         style="fill:#ffffff"
+         id="circle3748"
+         r="15.000024"
+         cy="483.5"
+         cx="522.5" />
+      <circle
+         style="stroke:#0f71a9;stroke-width:3;stroke-linecap:round;stroke-linejoin:round"
+         id="circle3750"
+         r="15.000024"
+         cy="483.5"
+         cx="522.5" />
+      <text
+         style="fill:#0f71a9"
+         id="text3752"
+         transform="translate(515.5,472.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3754"
+           y="17"
+           x="2.4335938"
+           font-weight="700"
+           font-size="16">2</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_17">
+      <circle
+         style="fill:#ffffff"
+         id="circle3757"
+         r="15.000024"
+         cy="238.5"
+         cx="701" />
+      <circle
+         style="stroke:#0f71a9;stroke-width:3;stroke-linecap:round;stroke-linejoin:round"
+         id="circle3759"
+         r="15.000024"
+         cy="238.5"
+         cx="701" />
+      <text
+         style="fill:#0f71a9"
+         id="text3761"
+         transform="translate(694,227.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3763"
+           y="17"
+           x="2.4335938"
+           font-weight="700"
+           font-size="16">5</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_16">
+      <circle
+         style="fill:#ffffff"
+         id="circle3766"
+         r="15.000024"
+         cy="483.5"
+         cx="701" />
+      <circle
+         style="stroke:#0f71a9;stroke-width:3;stroke-linecap:round;stroke-linejoin:round"
+         id="circle3768"
+         r="15.000024"
+         cy="483.5"
+         cx="701" />
+      <text
+         style="fill:#0f71a9"
+         id="text3770"
+         transform="translate(694,472.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3772"
+           y="17"
+           x="2.4335938"
+           font-weight="700"
+           font-size="16">4</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_15">
+      <circle
+         style="fill:#ffffff"
+         id="circle3775"
+         r="15.000024"
+         cy="592"
+         cx="611.25" />
+      <circle
+         style="stroke:#0f71a9;stroke-width:3;stroke-linecap:round;stroke-linejoin:round"
+         id="circle3777"
+         r="15.000024"
+         cy="592"
+         cx="611.25" />
+      <text
+         style="fill:#0f71a9"
+         id="text3779"
+         transform="translate(604.25,581)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3781"
+           y="17"
+           x="2.4335938"
+           font-weight="700"
+           font-size="16">3</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_14">
+      <text
+         style="fill:#0f71a9"
+         id="text3784"
+         transform="translate(549.25,612)">
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3786"
+           y="17"
+           x="0.11328125"
+           font-weight="400"
+           font-size="16">user verification,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3788"
+           y="39"
+           x="15.460938"
+           font-weight="400"
+           font-size="16">new keypair,</tspan>
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3790"
+           y="61"
+           x="21.734375"
+           font-weight="400"
+           font-size="16">attestation</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_12">
+      <text
+         style="fill:#0f71a9"
+         id="text3793"
+         transform="translate(872,472.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3795"
+           y="17"
+           x="0.40625"
+           font-weight="700"
+           font-size="16">attestationObject</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_11">
+      <rect
+         style="fill:#0f71a9"
+         id="rect3798"
+         height="66"
+         width="375.5"
+         y="362"
+         x="423.5" />
+      <rect
+         style="stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round"
+         id="rect3800"
+         height="66"
+         width="375.5"
+         y="362"
+         x="423.5" />
+      <text
+         style="fill:#ffffff"
+         id="text3802"
+         transform="translate(428.5,381)">
+        <tspan
+           style="font-weight:700;font-size:21px;font-family:'Open Sans';fill:#ffffff"
+           id="tspan3804"
+           y="22"
+           x="139.66821"
+           font-weight="700"
+           font-size="21">Browser</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_10">
+      <rect
+         style="fill:#0f71a9"
+         id="rect3807"
+         height="66"
+         width="375.5"
+         y="296"
+         x="423.5" />
+      <rect
+         style="stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round"
+         id="rect3809"
+         height="66"
+         width="375.5"
+         y="296"
+         x="423.5" />
+      <text
+         style="font-size:12.33704281px;fill:#ffffff"
+         id="text3811"
+         transform="scale(1.0280869,0.97268042)"
+         x="393.59189"
+         y="324.86972">
+        <tspan
+           style="font-weight:700;font-size:21.58982468px;font-family:'Open Sans';fill:#ffffff"
+           id="tspan3813"
+           y="347.48764"
+           x="463.17877"
+           font-weight="700"
+           font-size="21">RP JavaScript Application</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_9">
+      <circle
+         style="fill:#ffffff"
+         id="circle3816"
+         r="15.000024"
+         cy="159"
+         cx="795" />
+      <circle
+         style="stroke:#0f71a9;stroke-width:3;stroke-linecap:round;stroke-linejoin:round"
+         id="circle3818"
+         r="15.000024"
+         cy="159"
+         cx="795" />
+      <text
+         style="fill:#0f71a9"
+         id="text3820"
+         transform="translate(788,148)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3822"
+           y="17"
+           x="2.4335938"
+           font-weight="700"
+           font-size="16">6</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_8">
+      <circle
+         style="fill:#ffffff"
+         id="circle3825"
+         r="15.000024"
+         cy="238.5"
+         cx="600" />
+      <circle
+         style="stroke:#c1c1c1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round"
+         id="circle3827"
+         r="15.000024"
+         cy="238.5"
+         cx="600" />
+      <text
+         style="fill:#c1c1c1"
+         id="text3829"
+         transform="translate(593,227.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#c1c1c1"
+           id="tspan3831"
+           y="17"
+           x="2.4335938"
+           font-weight="700"
+           font-size="16">0</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_7">
+      <text
+         style="fill:#0f71a9"
+         id="text3834"
+         transform="translate(821,148)">
+        <tspan
+           style="font-weight:400;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3836"
+           y="17"
+           x="0.14453125"
+           font-weight="400"
+           font-size="16">server validation</tspan>
+      </text>
+    </g>
+    <g
+       id="Graphic_5">
+      <text
+         style="fill:#0f71a9"
+         id="text3839"
+         transform="translate(893,227.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3841"
+           y="17"
+           x="0.03125"
+           font-weight="700"
+           font-size="16">AuthenticatorAttestationResponse</tspan>
+      </text>
+      <image
+         y="362.14862"
+         x="243.89603"
+         id="image5641"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAi0AAAANCAYAAABl2l5tAAAABHNCSVQICAgIfAhkiAAAC2JJREFU
+eJztnGtUFOcZx3+zuyyw3JEFES+gUgUMRNAmxZg0YCSYmsbGpqk1J2lMahsjiQbPSXrRcxJ7mqP2
+mKPmYhv6QT2a5tgSNceAUUmssZrIRdD1QgisKBcBl+WysMuy2w/rLsv9NiOazu/Tzswzz/xfmJn3
+med93lfY+99S++/3fw3AukUJvJQSh5NffXCMU9/WAvCXn/+Qp++b7jr26F8Pc7m6EaVC4NxbS/Hx
+9GAoRGXuBSBI40nBm08O6RwnT24/QoG+3rX9+bqfMD3Mf1g++mJnno62jk4AXl14jyhah8NQ2+XU
+445KqWB8gDfzosfzcuosJgb7dLOVWruMjIyMzP85lZXY6+rAbh/YrrFxYBurFZqbXb+FxYvB19fd
+Yp8qKVLr2sovr3P97rTZKbra0HWsot4VtDS3d1BaYwRgxvjAIQcso0Hf0NKtYwfIzi9n3aKEUfve
+mXcRg8kMdA9abgejbZe108a1m63880wZOcWV/DtjIVO1ow/k7jbsb7+NvbxcdL+K9eshIkJ0v/Y3
+38R+/brofu9ovSYTmM3ddim2bIHJk0fntw9smZlw9arofmW9DmwvvAB6veh+FR9+CFOmiO7X9tRT
+8N13jg2zGbvJJIpfZU4OREeL4ssdW3Iy9kuXBjc0GIblV6nTQUzMCFX1T2daGly8KLpfZVlZz6AF
+VXRYAAHeaoxtFvIr6rHbQRBAV2XAZLG6DM+6BTQFFfXYbkVLSZEhogvti0/ye3dIBworyExPQBBu
+iwRJGEm73LMntU1t/PlgAYeK9BjbLGzNLWH78nlSShYVg8FAUFDQqP3Y9+7FXlIigqIefl9+GUGK
+IGD/flkvYP/Tn5Dk8T1yRNaLhHpPn8Z+4YLobu0tLdLo1emk0WuxSKO3qWnYAcmQGCwTMlKk6oSt
+1l67VIIAiZEh5F2swthm4dsbRqLDAsivcAQpD84I56vSGirqm7nZYibY15OzFV0BTFJUV6amrrmd
+bZ+XkHexitqmNvy8PJgXPZ7XHo0nMsSv18WLKxtYn32Wi1UGpozz44+PJ/LgjPA+tX9SUAGAl4eS
+R+ImcqhIz3VDK19/d4P7poW67PobFhlsf3/bTq7UGNl4sICz5XUE+XiyJCmSNWnxKBVCr3ODNJ7s
+Wvkwb39aRH5FHcE+Xn3aD6dd/RHm782GJ5I4VOT46inskbW501mzZg25ubk8++yzrFq1ikmTJo21
+JJnbiH2EL2d7H1mbblgso1DVPzadThrfbW3i+wQ6T5+G2tphn2cf5H+iaGoaqaQB6fj4474zhT4+
+CGr1iP0qnEMOImPNyQGdbngnqdWD3kNS6e3IyYG+gjeFAiEgYNDzhf4+MKV63hobUfTYpwJIitSS
+d7EKgPyKultBi6Pze2hmOPXN7eiqDOTr63gkbqIroAGYc2t4qcZoYsm2I9QYu9JuhlYznxbp+c/l
+arIz0ojSdgUuJouV5TuP09zeAUBprZEX/vEln722iGmh3Yc3CvX1VNQ7/okPzZjAk3Omujrp7ILy
+IXXuo6HV0sHSHUdcWtsarbx77AIhfl4898CMXvYt5g6e2nGUtg5HlFjV2NqnvVjtcg+e77as06ZN
+mzh69CibNm1i165dhIeHs3LlSpYtW4Zvj7TgWNBXpyoEBICi56PUA6sV+0Avns5OEdT1xnbtGoKP
+j/iOJXopjTRoGSuEiRMRpk4V3a9drUaKb2BFbCxCbKzofu2+vpLo9Vi6FOEe8YfobW+9JYle1cKF
+d5feBQsQ4uNF92vTaCTRK3j0Lj1RQVfgAfBNeR1P3zfdNRw0J1KLvr4FXZWBs+V1pMREUKR31LqM
+D9AQEeR4QW7NLaHGaELr50XWih8zMzyQb8rreGbncYxtFrbknOPdZx5wXcds7eS5+TNYlRrHB8d1
+vHf8Ah2dNnYcO8/WXyZ3E+nMRgCkJ0xiXnQY/t5qmtosfFZcyZtL5qJWDdKJ9EP5lmUkrv+Xq6al
+fMsy1zFn5sRitbEofjIbnpjDZ8VXcRYuHyzU9xm0dHTaeCxhcHsx2uUcHnKSOOX2DNeJRWhoKNOm
+TeP69etUV1dTXV1NRkYGGzduJCYmhszMTFJTU1EMFiRIhODv3//XxUCoVAOeZ1cqR6GqfxQSdaq2
+UXzlDsTdpnfE98MgSHU/SKZXpRLdp8xtwGaTxq9U7+c+PpZUAAmTx6FSKrB22sgvr6OqsZUaowlv
+DxVxEcHoG1rY9dUV8ivquHD9piuDkOhWz/LFJUempq65ncffyel1oVOlNd22BQEyFsxC46liVWoc
+7+ddwG531Mu4Y+20ubIPapWC1JgIVEoFqbERZOeX09Rm4ZjuGunx4hebufOHxYkEatQsSYpyBSFV
+htYR24+mXQaTuc9hrECNmjVp4kfRUpOens6JEydc22azmcrKSiorKzlz5gzBwcGkpKSwdu1aYvv7
+avT3BwlezoJEncmQ9I6gPaNJoQ/IxInQ2v/9PlJkvbeIjZXEt+DtLbpPAOLiBtfr7w/DfH4kyRIC
+pKUhzJw58vP7ya5KERACCCtWQHW1+H5DpRmVEDZvRuiZMfX0BI1m4BP7sRF8fBzDaBMm9DqmAkc9
+RVxEEOeuNqBvaCGnpBJwBDNKheDKxJRcu+maAg3dMzQNLe0Dams0dY+YNGoPNJ6OaF3jqUKj9qDV
+3EGtsfvY7peXqzG0OrIgsyKCqWp0vIhiJgSSne+wyc6vGDBo6bSNLnHl6+VBiJ8XAJ6qrofQYu07
+ah2KvRjtAvBQKggP1PDAD8azKjWOCYFDf+jXrl1Ldnb2kO2lonWAzsVoNGI0GsnKymL37t0kJyeT
+l5fXy05x8qSUEkXnrtN7+PBYSxgWd53ejz4aawnDQrFv31hLGBaKzZvHWsKwEF55RZoCX4kQFiy4
+bddy5fjmRGo5d2uKc9aXl4GumUHhgRomBPpQ1djK7q9KXSe7zxwK8fWitqmN+EnjOPBKWq8L9Sxa
+Nlk6MJmtaDxVmMxWTBZHvUhYQPcvg2y32TUF+nrStvR+GX1xqYpGk4VAjRoPpYKOThtma1fNwLWb
+LQP/FQa5OzzcIuyh1IwMxX647XJHrLVX3njjDVavXj1qP6Nlz549rF+/vs9jgiAQEhJCSEgIL774
+Is8///xtVicjIyMjc6fgClqSIrVknXDMC3d+9buv4TI3SsuBwlbXMefQkZOU2Aj2nf6W4soGtn1+
+nuU/isbP24MqQysnrtSw51QpuZmLXPZ2O+w4dp6XUuJ4/7jOFdS4X7OlvYNjusHXhujotPFpkZ7l
+ydFEBPlQUd+MyWLlm/IbJE7Rsu3o+QHPD/bxdGU9Sq7dZFZEsKQFrSNplxRotVq0Wu3ghhJTWFjY
+a19wcDBBQUEsXryYjIwMoqKixkCZjIyMjMydRFemJap75+WcCu0kKUrLgcIK17Zz6MjJ2rR4Tl6p
+ofJmC1tzi9maWzzghT1VSvacKuX9413TxTyUClaldq3Ie7j4Ku23Vqp9LGEyO9wKeQFOXqnhmb8d
+B+CTgnKWJ0fzRGIk7xxxrHfwi/eO4jWEgrG5UaGU3XBM4eurHkdsRtKu7ytms5mCAkchsbe3N8HB
+wcyePZvXX3+defPunvVmZGRkZGSkxzWOofXzYvK4rimm00Mdi845mdsjqOm5qFyInxcHX32U3z4c
+y7RQf9QqBRpPFVFaP346O7LXgmcatYrdv0khftI41CoF08P8+fuvH+o23dl9ds3P5vSeYZAcHcb4
+AEcRT35FPVcbWvhdShwrHpxJmL83XioVc6K07F/9yIB/hHXpCaTHT8LfW6Iiux6MpF3fVzZs2EBD
+QwP3338/WVlZlJWVcejQITlgkZGRkZHphWC32+UiAZkxY/v27dPmz59/495775VmNSUZGRkZme8L
+Zf8Df8bEjWpeEHYAAAAASUVORK5CYII=
+"
+         style="image-rendering:optimizeQuality"
+         preserveAspectRatio="none"
+         height="13"
+         width="556.00916"
+         transform="matrix(0.9999936,-0.00357691,0,1,0,0)" />
+    </g>
+    <g
+       id="Graphic_3">
+      <text
+         style="fill:#0f71a9"
+         id="text3844"
+         transform="translate(65,227.5)">
+        <tspan
+           style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
+           id="tspan3846"
+           y="17"
+           x="0.33984375"
+           font-weight="700"
+           font-size="16">PublicKeyCredentialCreateOptions</tspan>
+      </text>
+    </g>
+  </g>
+</svg>

--- a/index.bs
+++ b/index.bs
@@ -707,8 +707,32 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[WRP]=] interacts through the
 client (consisting of the browser and underlying OS platform). Scripts can (with the [=user consent|user's consent=]) request the
-browser to create a new credential for future use by the [=[RP]=]. Scripts can also request the user’s permission to perform
-authentication operations with an existing credential. All such operations are performed in the authenticator and are mediated by
+browser to create a new credential for future use by the [=[RP]=]. 
+
+
+<figure id="fig-registration">
+    <img src="images/webauthn-registration-flow-01.svg"/>
+    <figcaption>Registration Flow</figcaption>
+</figure>
+
+
+
+
+
+Scripts can also request the user’s permission to perform
+authentication operations with an existing credential. 
+
+
+<figure id="fig-authentication">
+    <img src="images/webauthn-authentication-flow-01.svg"/>
+    <figcaption>Authentication Flow</figcaption>
+</figure>
+
+
+
+
+
+All such operations are performed in the authenticator and are mediated by
 the browser and/or platform on the user's behalf. At no point does the script get access to the credentials themselves; it only
 gets information about the credentials in the form of objects.
 

--- a/index.bs
+++ b/index.bs
@@ -440,7 +440,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     In the WebAuthn context, [=attestation=] is employed to <em>attest</em> to the <em>provenance</em> of an [=authenticator=]
     and the data it emits; including, for example: [=credential IDs=], [=credential key pairs=], signature counters, etc. An
     [=attestation statement=] is conveyed in an [=attestation object=] during [=registration=]. See also [[#sctn-attestation]]
-    and [Figure 3](#fig-attStructs). Whether or how the client platform conveys the [=attestation statement=] and [=AAGUID=] 
+    and [Figure 5](#fig-attStructs). Whether or how the client platform conveys the [=attestation statement=] and [=AAGUID=]
     portions of the [=attestation object=] to the [=[RP]=] is described by [=attestation conveyance=].
 
 : <dfn>Attestation Certificate</dfn>
@@ -707,7 +707,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[WRP]=] interacts through the
 client (consisting of the browser and underlying OS platform). Scripts can (with the [=user consent|user's consent=]) request the
-browser to create a new credential for future use by the [=[RP]=]. 
+browser to create a new credential for future use by the [=[RP]=]. See [Figure 1](#fig-registration), below.
 
 
 <figure id="fig-registration">
@@ -716,20 +716,14 @@ browser to create a new credential for future use by the [=[RP]=].
 </figure>
 
 
-
-
-
 Scripts can also request the user’s permission to perform
-authentication operations with an existing credential. 
+[=authentication=] operations with an existing credential. See [Figure 2](#fig-authentication), below.
 
 
 <figure id="fig-authentication">
     <img src="images/webauthn-authentication-flow-01.svg"/>
     <figcaption>Authentication Flow</figcaption>
 </figure>
-
-
-
 
 
 All such operations are performed in the authenticator and are mediated by
@@ -1659,7 +1653,7 @@ during registration.
         [=authenticator=]. It also contains any additional information that the [=[RP]=]'s server requires to validate the
         [=attestation statement=], as well as to decode and validate the [=authenticator data=] along with the
         [=JSON-serialized client data=]. For more details, see [[#sctn-attestation]], [[#generating-an-attestation-object]],
-        and [Figure 3](#fig-attStructs).
+        and [Figure 5](#fig-attStructs).
 </div>
 
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}
@@ -2382,7 +2376,7 @@ Authenticators produce cryptographic signatures for two distinct purposes:
     same user who [=user consent|consented=] to creating that particular [=public key credential=]. It also asserts additional
     information, termed [=client data=], that may be useful to the caller, such as the means by which [=user consent=] was
     provided, and the prompt shown to the user by the [=authenticator=]. The [=assertion signature=] format is illustrated in
-    [Figure 2, below](#fig-signature).
+    [Figure 4, below](#fig-signature).
 
 The formats of these signatures, as well as the procedures for generating them, are specified below.
 
@@ -2893,7 +2887,7 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     specified in [[#sec-authenticator-data]] including |processedExtensions|, if any, as
     the <code>[=authDataExtensions|extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.
 1. Let |signature| be the [=assertion signature=] of the concatenation <code>|authenticatorData| || |hash|</code> using the
-    [=public key credential source/privateKey=] of |selectedCredential| as shown in [Figure 2](#fig-signature), below. A simple,
+    [=public key credential source/privateKey=] of |selectedCredential| as shown in [Figure 4](#fig-signature), below. A simple,
     undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
     client data=] (which potentially has a variable length) is always the last element.
@@ -2954,7 +2948,7 @@ enabling the [=[RP]=] to make a trust decision. However, if an [=attestation key
 MUST perform [=self attestation=] of the [=credential public key=] with the corresponding [=credential private key=]. All this
 information is returned by [=authenticators=] any time a new [=public key credential=] is generated, in the overall form of an
 <dfn>attestation object</dfn>. The relationship of the [=attestation object=] with [=authenticator data=] (containing
-[=attested credential data=]) and the [=attestation statement=] is illustrated in [figure 3](#fig-attStructs), below.
+[=attested credential data=]) and the [=attestation statement=] is illustrated in [figure 5](#fig-attStructs), below.
 
 <figure id="fig-attStructs">
     <img src="images/fido-attestation-structures.svg"/>
@@ -3193,7 +3187,7 @@ WebAuthn supports multiple attestation types:
 
 <h4 id="generating-an-attestation-object" algorithm>Generating an Attestation Object</h4>
 
-To generate an [=attestation object=] (see: [Figure 3](#fig-attStructs)) given:
+To generate an [=attestation object=] (see: [Figure 5](#fig-attStructs)) given:
 
 : |attestationFormat|
 :: An [=attestation statement format=].


### PR DESCRIPTION
this nominally fixes #24.

apowers313 massaged his reg & authn flow diagrams (thanks!), from his most excellent [WebAuthn API MDN article](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API), for us, so here they are. 

At this point, it seems to me that simply placing the figures into the spec is a win, so I did not add additional text describing the flows in detail. However, that is something we may want to eventually do. 

Also, the figures themselves could use polishing. I did a little bit, but am not an expert with Inkscape.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1007.html" title="Last updated on Jul 25, 2018, 9:44 PM GMT (12b951f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1007/0f38025...12b951f.html" title="Last updated on Jul 25, 2018, 9:44 PM GMT (12b951f)">Diff</a>