### PR TITLE
Clarify behaviour for authnrs not implementing signature counter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2796,6 +2796,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
               [=authenticator data=].
         : a per credential [=signature counter=]
         :: allocate the counter, associate it with the new credential, and initialize the counter value as zero.
+
+        : no [=signature counter=]
+        :: let the [=signature counter=] value for the new credential be constant at zero.
     </dl>
 
 1. Let |attestedCredentialData| be the [=attested credential data=] byte array including the |credentialId| and |publicKey|.
@@ -2868,6 +2871,8 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
 1. Increment the credential associated
     [=signature counter=] or the global [=signature counter=] value, depending on 
     which approach is implemented by the [=authenticator=], by some positive value.
+    If the [=authenticator=] does not implement a [=signature counter=], let the [=signature counter=] value remain constant at
+    zero.
 1. Let |authenticatorData| [=perform the following steps to generate an authenticator data structure|be the byte array=]
     specified in [[#sec-authenticator-data]] including |processedExtensions|, if any, as
     the <code>[=authDataExtensions|extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.


### PR DESCRIPTION
Fixes #1008

I argue that this change is editorial since this was already implied by the [RP operations][rp-ops] as the only acceptable implementation. This merely makes that explicit in the authenticator operations.

[rp-ops]: https://w3c.github.io/webauthn/#ref-for-signature-counter%E2%91%A0%E2%91%A6


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1009.html" title="Last updated on Jul 25, 2018, 1:06 PM GMT (62cdb51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1009/8b0eb71...62cdb51.html" title="Last updated on Jul 25, 2018, 1:06 PM GMT (62cdb51)">Diff</a>