### PR TITLE
fix #712 JSON-serialized client data is wrong

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -153,6 +153,10 @@ spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
         text: focus
         text: username; url: attr-fe-autocomplete-username
 
+spec: WHATWG Infra; urlPrefix: https://infra.spec.whatwg.org/
+    type: dfn
+        text: JSON stringify and UTF-8 encode to bytes
+
 spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
@@ -2185,7 +2189,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     The {{CollectedClientData}} structure is used by the client to compute the following quantities:
 
     : <dfn dfn>JSON-serialized client data</dfn>
-    :: This is the [=UTF-8 encoding=] of the result of calling the initial value of {{JSON/stringify|JSON.stringify}} on a
+    :: This is the result of [=JSON stringify and UTF-8 encode to bytes|JSON stringifying and UTF-8 encoding to bytes=] a
         {{CollectedClientData}} dictionary.
 
     : <dfn dfn>Hash of the serialized client data</dfn>


### PR DESCRIPTION
fixes #712 

This depends upon:

https://github.com/whatwg/infra/pull/207  (fixes whatwg/infra#193), and

https://github.com/tc39/ecma262/pull/1272 (which apparently depends to some degree on https://github.com/tc39/ecma262/pull/1105)

At this point, we're waiting on the above to land before landing this.

cc: @annevk


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1017.html" title="Last updated on Jul 27, 2018, 4:06 PM GMT (acb0f6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1017/243e72f...acb0f6a.html" title="Last updated on Jul 27, 2018, 4:06 PM GMT (acb0f6a)">Diff</a>