### PR TITLE
Clarify that SafetyNet response uses base64url

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3904,7 +3904,7 @@ even if the SafetyNet API is also present.
     - Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the
         contained fields.
     - Verify that |response| is a valid SafetyNet response of version |ver|.
-    - Verify that the nonce in the |response| is identical to the SHA-256 hash of the concatenation of |authenticatorData| and |clientDataHash|.
+    - Verify that the nonce in the |response| is identical to the Base64url encoding of the SHA-256 hash of the concatenation of |authenticatorData| and |clientDataHash|.
     - Verify that the attestation certificate is issued to the hostname "attest.android.com" (see
         [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response)).
     - Verify that the `ctsProfileMatch` attribute in the payload of |response| is [TRUE].


### PR DESCRIPTION
Fixes #1018.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arnar/webauthn/pull/1021.html" title="Last updated on Aug 1, 2018, 6:21 PM GMT (f25529d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1021/24aed4e...arnar:f25529d.html" title="Last updated on Aug 1, 2018, 6:21 PM GMT (f25529d)">Diff</a>