### PR TITLE
fix #1012 determine Attested Credential Data length

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2501,7 +2501,7 @@ The [figure below](#fig-authData) shows a visual representation of the [=authent
     The [=attested credential data=] (which is only present if the AT [=flag=] is set) describes its own length. If the ED [=flag=] is set, then the total length is 37 bytes plus the length of the [=attested credential data=] (if the AT [=flag=] is set), plus the length of the [=authDataExtensions|extensions=] output (a [=CBOR=] map) that
     follows.
 
-    Determining [=attested credential data=]'s length, which is variable, involves determining the  of the <code>[=credentialPublicKey=]</code>'s beginning location given the preceding <code>[=credentialid|credentialId=]</code>'s [=credentialidlength|length=], and then determining the <code>[=credentialPublicKey=]</code>'s length (see also [=Section 7=] of [[RFC8152]]).
+    Determining [=attested credential data=]'s length, which is variable, involves determining <code>[=credentialPublicKey=]</code>'s beginning location given the preceding <code>[=credentialid|credentialId=]</code>'s [=credentialidlength|length=], and then determining the <code>[=credentialPublicKey=]</code>'s length (see also [=Section 7=] of [[RFC8152]]).
 </div>
 
 ### <dfn>Signature Counter</dfn> Considerations ### {#sign-counter}

--- a/index.bs
+++ b/index.bs
@@ -2496,10 +2496,13 @@ The [figure below](#fig-authData) shows a visual representation of the [=authent
     <figcaption>[=Authenticator data=] layout.</figcaption>
 </figure>
 
-Note that the [=authenticator data=] describes its own length: If the AT and ED [=flags=] are not set, it is always 37 bytes long.
-The [=attested credential data=] (which is only present if the AT flag is set) describes its own length. If the ED flag is set,
-then the total length is 37 bytes plus the length of the [=attested credential data=], plus the length of the [=CBOR=] map that
-follows.
+<div class="note">
+    Note: [=authenticator data=] describes its own length: If the AT and ED [=flags=] are not set, it is always 37 bytes long.
+    The [=attested credential data=] (which is only present if the AT [=flag=] is set) describes its own length. If the ED [=flag=] is set, then the total length is 37 bytes plus the length of the [=attested credential data=] (if the AT [=flag=] is set), plus the length of the [=authDataExtensions|extensions=] output (a [=CBOR=] map) that
+    follows.
+
+    Determining [=attested credential data=]'s length, which is variable, involves determining the  of the <code>[=credentialPublicKey=]</code>'s beginning location given the preceding <code>[=credentialid|credentialId=]</code>'s [=credentialidlength|length=], and then determining the <code>[=credentialPublicKey=]</code>'s length (see also [=Section 7=] of [[RFC8152]]).
+</div>
 
 ### <dfn>Signature Counter</dfn> Considerations ### {#sign-counter}
 


### PR DESCRIPTION
fixes #1012


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1023.html" title="Last updated on Aug 2, 2018, 8:13 PM GMT (2d1bdc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1023/24aed4e...2d1bdc8.html" title="Last updated on Aug 2, 2018, 8:13 PM GMT (2d1bdc8)">Diff</a>