### PR TITLE
Use final name for "serialize JSON to bytes"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -153,10 +153,6 @@ spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
         text: focus
         text: username; url: attr-fe-autocomplete-username
 
-spec: WHATWG Infra; urlPrefix: https://infra.spec.whatwg.org/
-    type: dfn
-        text: JSON stringify and UTF-8 encode to bytes
-
 spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
@@ -2189,7 +2185,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     The {{CollectedClientData}} structure is used by the client to compute the following quantities:
 
     : <dfn dfn>JSON-serialized client data</dfn>
-    :: This is the result of [=JSON stringify and UTF-8 encode to bytes|JSON stringifying and UTF-8 encoding to bytes=] a
+    :: This is the result of [=serialize JSON to bytes|JSON-serializing to bytes=] a
         {{CollectedClientData}} dictionary.
 
     : <dfn dfn>Hash of the serialized client data</dfn>


### PR DESCRIPTION
This is a follow-up to #1017 to use the final name arrived at in https://github.com/whatwg/infra/pull/207 and merged into the Infra Standard.

This will cause Bikeshed linking warnings now (due to the removed link block) but sometime within the next 24 hours it should start working automatically, so as long as you merge then, it'll be fine.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/webauthn/pull/1024.html" title="Last updated on Aug 2, 2018, 9:05 PM GMT (89bfd90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1024/24aed4e...domenic:89bfd90.html" title="Last updated on Aug 2, 2018, 9:05 PM GMT (89bfd90)">Diff</a>