### PR TITLE
add link to 2nd CR version

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,7 +15,6 @@ TR: https://www.w3.org/TR/webauthn/
 ED: https://w3c.github.io/webauthn/
 Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180807/
 Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180320/
-Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180320/
 Previous Version: https://www.w3.org/TR/2018/WD-webauthn-20180315/
 Previous Version: https://www.w3.org/TR/2018/WD-webauthn-20180306/
 Previous Version: https://www.w3.org/TR/2017/WD-webauthn-20171205/

--- a/index.bs
+++ b/index.bs
@@ -13,6 +13,8 @@ Status: ED
 Prepare for TR: true
 TR: https://www.w3.org/TR/webauthn/
 ED: https://w3c.github.io/webauthn/
+Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180807/
+Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180320/
 Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180320/
 Previous Version: https://www.w3.org/TR/2018/WD-webauthn-20180315/
 Previous Version: https://www.w3.org/TR/2018/WD-webauthn-20180306/


### PR DESCRIPTION
to resolve https://github.com/w3c/webauthn/issues/1028


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1029.html" title="Last updated on Aug 8, 2018, 6:28 PM GMT (c8f516f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1029/91c3068...c8f516f.html" title="Last updated on Aug 8, 2018, 6:28 PM GMT (c8f516f)">Diff</a>