### PR TITLE
Define "bound" for credentials and use the term "scoped" where appropriate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2184,7 +2184,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
                 </div>
 
             :   <dfn>id</dfn>
-            ::  This member MUST be present if {{TokenBinding/status}} is {{TokenBindingStatus/present}}, and MUST a [=base64url
+            ::  This member MUST be present if {{TokenBinding/status}} is {{TokenBindingStatus/present}}, and MUST be a [=base64url
                 encoding=] of the [=Token Binding ID=] that was used when communicating with the [=[RP]=].
         </div>
 

--- a/index.bs
+++ b/index.bs
@@ -724,7 +724,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 # <dfn>Web Authentication API</dfn> # {#api}
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
-idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
+idea is that the credentials belong to the user and are [=managing authenticator|managed=] by an authenticator, with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
 browser to create a new credential for future use by the [=[RP]=]. See [Figure 1](#fig-registration), below.
 
 
@@ -756,7 +756,7 @@ deletion are considered to be the responsibility of such a user interface and ar
 scripts.
 
 The security properties of this API are provided by the client and the authenticator working together. The authenticator, which
-holds and manages credentials, ensures that all operations are [=scoped=] to a particular [=origin=], and cannot be replayed against
+holds and [=managing authenticator|manages=] credentials, ensures that all operations are [=scoped=] to a particular [=origin=], and cannot be replayed against
 a different [=origin=], by incorporating the [=origin=] in its responses. Specifically, as defined in [[#authenticator-ops]],
 the full [=origin=] of the requester is included, and signed over, in the [=attestation object=] produced when a new credential
 is created as well as in all assertions produced by WebAuthn credentials.

--- a/index.bs
+++ b/index.bs
@@ -153,10 +153,6 @@ spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
         text: focus
         text: username; url: attr-fe-autocomplete-username
 
-spec: WHATWG Infra; urlPrefix: https://infra.spec.whatwg.org/
-    type: dfn
-        text: JSON stringify and UTF-8 encode to bytes
-
 spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
@@ -2189,7 +2185,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     The {{CollectedClientData}} structure is used by the client to compute the following quantities:
 
     : <dfn dfn>JSON-serialized client data</dfn>
-    :: This is the result of [=JSON stringify and UTF-8 encode to bytes|JSON stringifying and UTF-8 encoding to bytes=] a
+    :: This is the result of [=serialize JSON to bytes|JSON-serializing to bytes=] a
         {{CollectedClientData}} dictionary.
 
     : <dfn dfn>Hash of the serialized client data</dfn>

--- a/index.bs
+++ b/index.bs
@@ -58,7 +58,7 @@ Text Macro: WRPS WebAuthn Relying Parties
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more [=public key
- credentials=], each [=scoped=] to a given [=WebAuthn Relying Party=], are created by and [=bound to authenticator|bound=] to [=authenticators=]
+ credentials=], each [=scoped=] to a given [=WebAuthn Relying Party=], are created by and [=bound=] to [=authenticators=]
  as requested by the web application. The user agent mediates access to [=authenticators=] and their [=public key credentials=] in order to preserve user
  privacy. [=Authenticators=] are responsible for ensuring that no operation is performed without [=user consent=].
  [=Authenticators=] provide cryptographic proof of their properties to [=Relying Parties=] via [=attestation=]. This
@@ -236,7 +236,7 @@ Additionally, privacy across [=[RPS]=] is maintained; [=[RPS]=] are not able to 
 the existence, of credentials [=scoped=] to other [RPS].
 
 [=[RPS]=] employ the [=Web Authentication API=] during two distinct, but related, [=ceremonies=] involving a user. The first
-is [=Registration=], where a [=public key credential=] is created on an [=authenticator=], and [=bound to RP|bound=] to a [=[RP]=]
+is [=Registration=], where a [=public key credential=] is created on an [=authenticator=], and [=scoped=] to a [=[RP]=]
 with the present user's account (the account MAY already exist or MAY be created at this time). The second is
 [=Authentication=], where the [=[RP]=] is presented with an <em>[=Authentication Assertion=]</em> proving the presence
 and [=user consent|consent=] of the user who registered the [=public key credential=]. Functionally, the [=Web Authentication
@@ -486,19 +486,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: Any [=authenticator=] that implements [=biometric recognition=].
 
 : Bound credential
-:: [=Public key credential sources=] and [=public key credentials=] are herein described as being "bound" in two contexts:
-
-    - A [=public key credential source=] or [=public key credential=] is said to be <dfn lt="bound to authenticator">bound</dfn>
-        to its [=managing authenticator=]. This means that only the [=managing authenticator=] can generate [=assertions=] for the
-        [=public key credential sources=] [=bound to authenticator|bound=] to it.
-    - A [=public key credential source=] or [=public key credential=] is said to be <dfn lt="bound to RP">bound</dfn> to the [=RP
-        ID=] stored in the <span link-for="public key credential source">[=rpId=]</span> [=struct/item=] of the [=public key
-        credential source=], and to the [=[RP]=] that this [=RP ID=] refers to. This means that a [=public key
-        credential source=] can generate valid [=assertions=] only for the [=[RP]=] it is [=bound to RP|bound=] to.
-
-    Which of these meanings the term "bound" refers to is given by context. [=Public key credential sources=] and [=public key
-    credentials=] are only said to be "bound" in these two contexts; other subjects may also be said to be "bound" to other
-    things.
+:: A [=public key credential source=] or [=public key credential=] is said to be <dfn>bound</dfn> to its [=managing
+    authenticator=]. This means that only the [=managing authenticator=] can generate [=assertions=] for the [=public key
+    credential sources=] [=bound=] to it.
 
 : <dfn>Ceremony</dfn>
 :: The concept of a [=ceremony=] [[Ceremony]] is an extension of the concept of a network protocol, with human nodes alongside
@@ -521,7 +511,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     source=] whose [=credential private key=] is stored in the [=authenticator=], [=client=] or [=client device=]. Such
     [=client-side=] storage requires a [=resident credential capable=] [=authenticator=] and has the property that the [=authenticator=]
     is able to select the [=credential private key=] given
-    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] [=bound to RP|bound=] to the [=RP ID=]).
+    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] [=scoped=] to the [=RP ID=]).
     By definition, the [=credential private key=] is always exclusively controlled by the [=authenticator=]. In the case of a
     [=resident credential=], the [=authenticator=] might offload storage of wrapped key material to the
     [=client device=], but the [=client device=] is not expected to offload the key storage to remote entities (e.g., [=[WRP]=] Server).
@@ -572,7 +562,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         ::  The [=credential private key=].
 
         :   <dfn>rpId</dfn>
-        ::  The [=Relying Party Identifier=], for the [=[RP]=] this [=public key credential source=] is [=bound to RP|bound=] to.
+        ::  The [=Relying Party Identifier=], for the [=[RP]=] this [=public key credential source=] is [=scoped=] to.
 
         :   <dfn>userHandle</dfn>
         ::  The [=user handle=] associated when this [=public key credential source=] was created. This [=struct/item=] is
@@ -583,7 +573,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             {{displayName}}.
     </dl>
 
-    The [=authenticatorMakeCredential=] operation creates a [=public key credential source=] [=bound to authenticator|bound=] to a <dfn for="public key
+    The [=authenticatorMakeCredential=] operation creates a [=public key credential source=] [=bound=] to a <dfn for="public key
     credential source">managing authenticator</dfn> and returns the [=credential public key=] associated with its [=credential
     private key=]. The [=[RP]=] can use this [=credential public key=] to verify the [=authentication assertions=] created by
     this [=public key credential source=].
@@ -762,7 +752,7 @@ the full [=origin=] of the requester is included, and signed over, in the [=atte
 is created as well as in all assertions produced by WebAuthn credentials.
 
 Additionally, to maintain user privacy and prevent malicious [=[RPS]=] from probing for the presence of [=public key
-credentials=] belonging to other [=[RPS]=], each [=public key credential|credential=] is also [=bound to RP|bound=] to a [=Relying Party
+credentials=] belonging to other [=[RPS]=], each [=public key credential|credential=] is also [=scoped=] to a [=Relying Party
 Identifier=], or [=RP ID=]. This [=RP ID=] is provided by the client to the [=authenticator=] for all operations, and the
 [=authenticator=] ensures that [=public key credential|credentials=] created by a [=[RP]=] can only be used in operations
 requested by the same [=RP ID=]. Separating the [=origin=] from the [=RP ID=] in this way allows the API to be used in cases
@@ -870,7 +860,7 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 {{PublicKeyCredential}}'s [=interface object=]'s implementation of the <dfn for="PublicKeyCredential" method>\[[Create]](origin,
 options, sameOriginWithAncestors)</dfn> [=internal method=] [[CREDENTIAL-MANAGEMENT-1]] allows
 [=[WRP]=] scripts to call {{CredentialsContainer/create()|navigator.credentials.create()}} to request the creation of a new
-[=public key credential source=], [=bound to authenticator|bound=] to an [=authenticator=]. This
+[=public key credential source=], [=bound=] to an [=authenticator=]. This
 {{CredentialsContainer/create()|navigator.credentials.create()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
 
@@ -1116,7 +1106,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             1. Return a {{DOMException}} whose name is "{{InvalidStateError}}" and terminate this algorithm.
 
             Note: This error status is handled separately because the |authenticator| returns it only if
-            |excludeCredentialDescriptorList| identifies a credential [=bound to authenticator|bound=] to the |authenticator| and the user has [=user
+            |excludeCredentialDescriptorList| identifies a credential [=bound=] to the |authenticator| and the user has [=user
             consent|consented=] to the operation. Given this explicit consent, it is acceptable for this case to be
             distinguishable to the [=[RP]=].
 
@@ -1428,7 +1418,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     ::  1. Let |allowCredentialDescriptorList| be a new [=list=].
 
                         1. Execute a [=client platform=]-specific procedure to determine which, if any, [=public key credentials=] described by
-                            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are [=bound to authenticator|bound=] to this
+                            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are [=bound=] to this
                             |authenticator|, by matching with |rpId|,
                             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
                             and
@@ -1473,7 +1463,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         |userVerification| and |clientExtensions| as parameters.
 
                         Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus, the
-                            authenticator is being asked to exercise any credential it may possess that is [=bound to RP|bound=] to
+                            authenticator is being asked to exercise any credential it may possess that is [=scoped=] to
                             the [=[RP]=], as identified by |rpId|.
                 </dl>
 
@@ -1762,8 +1752,8 @@ optionally evidence of [=user consent=] to a specific transaction.
         Its value's {{PublicKeyCredentialEntity/name}} member is REQUIRED. See [[#dictionary-pkcredentialentity]] for further
         details.
 
-        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=RP ID=] to which the credential
-        should be [=bound to RP|bound=]. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
+        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=RP ID=] the credential
+        should be [=scoped=] to. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
         settings object=]'s [=environment settings object/origin=]'s [=effective domain=]. See [[#sctn-rp-credential-params]]
         for further details.
 
@@ -1810,8 +1800,8 @@ optionally evidence of [=user consent=] to a specific transaction.
 
 ### Public Key Entity Description (dictionary <dfn dictionary>PublicKeyCredentialEntity</dfn>) ### {#dictionary-pkcredentialentity}
 
-The {{PublicKeyCredentialEntity}} dictionary describes a user account, or a [=[WRP]=], with which a [=public key credential=] is
-[=bound to RP|bound=].
+The {{PublicKeyCredentialEntity}} dictionary describes a user account, or a [=[WRP]=], which a [=public key credential=] is
+associated with or [=scoped=] to, respectively.
 
 <xmp class="idl">
     dictionary PublicKeyCredentialEntity {
@@ -2431,7 +2421,7 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, laid o
             <td><dfn>rpIdHash</dfn></td>
             <td>32</td>
             <td>
-                SHA-256 hash of the [=RP ID=] the [=public key credential|credential=] is [=bound to RP|bound=] to.
+                SHA-256 hash of the [=RP ID=] the [=public key credential|credential=] is [=scoped=] to.
             </td>
         </tr>
         <tr>
@@ -2486,7 +2476,7 @@ The [=RP ID=] is originally received from the [=client=] when the credential is 
 However, it differs from other [=client data=] in some important ways. First, unlike the client data, the [=RP ID=] of a
 credential does not change between operations but instead remains the same for the lifetime of that credential. Secondly, it is
 validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] that
-the requested [=public key credential|credential=] is [=bound to RP|bound=] to exactly matches the [=RP ID=] supplied by the [=client=].
+the requested [=public key credential|credential=] is [=scoped=] to exactly matches the [=RP ID=] supplied by the [=client=].
 
 [=Authenticators=] <dfn for="authenticator data">perform the following steps to generate an [=authenticator data=] structure</dfn>:
 
@@ -2626,10 +2616,10 @@ are part of the [=client device=] as <dfn>platform authenticators</dfn>, while t
 transport protocols are referred to as <dfn>roaming authenticators</dfn>.
 
 - A [=platform authenticator=] is attached using a [=client device=]-specific transport, called <dfn>platform attachment</dfn>, and is usually not removable from the [=client
-    device=]. A [=public key credential=] [=bound to authenticator|bound=] to a [=platform authenticator=] is called a <dfn>platform credential</dfn>.
+    device=]. A [=public key credential=] [=bound=] to a [=platform authenticator=] is called a <dfn>platform credential</dfn>.
 
 - A [=roaming authenticator=] is attached using cross-platform transports, called <dfn>cross-platform attachment</dfn>. Authenticators of this class are removable from, and
-    can "roam" among, [=client devices=]. A [=public key credential=] [=bound to authenticator|bound=] to a [=roaming authenticator=] is called a <dfn>roaming
+    can "roam" among, [=client devices=]. A [=public key credential=] [=bound=] to a [=roaming authenticator=] is called a <dfn>roaming
     credential</dfn>.
 
 Some [=platform authenticators=] could possibly also act as [=roaming authenticators=] depending on context. For example, a
@@ -3852,7 +3842,7 @@ the attestation=] is consistent with the fields of the attestation certificate's
         <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authenticatorData|.
     - Verify that in the attestation certificate extension data:
         - The value of the `attestationChallenge` field is identical to |clientDataHash|.
-        - The `AuthorizationList.allApplications` field is <em>not</em> present, since PublicKeyCredential MUST be [=bound to RP|bound=] to the
+        - The `AuthorizationList.allApplications` field is <em>not</em> present, since PublicKeyCredential MUST be [=scoped=] to the
             [=RP ID=].
         - The value in the `AuthorizationList.origin` field is equal to `KM_TAG_GENERATED`.
         - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
@@ -3966,7 +3956,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     serialized client data, |clientDataHash| will be 32 bytes long.)
 
     Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] [=Section 4.3=], with the application parameter set to the
-    SHA-256 hash of the [=RP ID=] that the given [=public key credential|credential=] is [=bound to RP|bound=] to, the challenge parameter set to |clientDataHash|, and the key handle
+    SHA-256 hash of the [=RP ID=] that the given [=public key credential|credential=] is [=scoped=] to, the challenge parameter set to |clientDataHash|, and the key handle
     parameter set to the [=credential ID=] of the given credential. Set the raw signature part of this Registration Response Message (i.e., without the [=user public key=],
     key handle, and attestation certificates) as |sig| and set the attestation certificates of
     the attestation public key as |x5c|.
@@ -4234,9 +4224,9 @@ These are RECOMMENDED for implementation by user agents targeting broad interope
 This extension allows [=[WRPS]=] that have previously registered a
 credential using the legacy FIDO JavaScript APIs to request an [=assertion=]. The
 FIDO APIs use an alternative identifier for [=[RPS]=] called an |AppID|
-[[FIDO-APPID]], and any credentials created using those APIs will be [=bound to RP|bound=] to
+[[FIDO-APPID]], and any credentials created using those APIs will be [=scoped=] to
 that identifier. Without this extension, they would need to be re-registered in
-order to be [=bound to RP|bound=] to an [=RP ID=].
+order to be [=scoped=] to an [=RP ID=].
 
 This extension does not allow FIDO-compatible credentials to be created. Thus,
 credentials created with WebAuthn are not backwards compatible with the FIDO
@@ -5223,7 +5213,7 @@ benefits.
 
 In these cases it is possible for a [=man-in-the-middle attack|man-in-the-middle attacker=] - for example, a malicious [=client=]
 or script - to replace the [=credential public key=] to be registered, and subsequently tamper with future [=authentication
-assertions=] bound for the same [=[RP]=] and passing through the same attacker. Accepting these [[#sctn-attestation-types|types]]
+assertions=] [=scoped=] for the same [=[RP]=] and passing through the same attacker. Accepting these [[#sctn-attestation-types|types]]
 of [=attestation statements=] therefore constitutes a [=leap of faith=]. In cases where [=registration=] was accomplished
 securely, subsequent [=authentication=] [=ceremonies=] remain resistant to [=man-in-the-middle attacks=], i.e., benefit (3) is
 retained. Note, however, that such an attack would be easy to detect and very difficult to maintain, since any [=authentication=]
@@ -5306,7 +5296,7 @@ authentication, they are designed to be minimally identifying and not shared bet
 - [=Credential IDs=] and [=credential public keys=] are meaningless in isolation, as they only identify [=credential key pairs=]
     and not users directly.
 
-- Each [=public key credential=] is strictly [=bound to RP|bound=] to a specific [=[RP]=], and the [=client=] ensures that its existence is not
+- Each [=public key credential=] is strictly [=scoped=] to a specific [=[RP]=], and the [=client=] ensures that its existence is not
     revealed to other [=[RPS]=]. A malicious [=[RP]=] thus cannot ask the [=client=] to reveal a user's other identities.
 
 - The [=client=] also ensures that the existence of a [=public key credential=] is not revealed to the [=[RP]=] without [=user
@@ -5373,7 +5363,7 @@ in several ways, including:
 In order to protect users from being identified without [=user consent|consent=], implementations of the
 {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method need to take care to not leak information that
 could enable a malicious [=[WRP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
-credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is [=bound to authenticator|bound=] to the
+credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is [=bound=] to the
 [=authenticator=]:
 
 - No [=authenticators=] are present.

--- a/index.bs
+++ b/index.bs
@@ -58,8 +58,8 @@ Text Macro: WRPS WebAuthn Relying Parties
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more [=public key
- credentials=], each [=scoped=] to a given [=WebAuthn Relying Party=], are created and stored on an [=authenticator=] by the user agent in
- conjunction with the web application. The user agent mediates access to [=public key credentials=] in order to preserve user
+ credentials=], each [=scoped=] to a given [=WebAuthn Relying Party=], are created by and [=bound to authenticator|bound=] to [=authenticators=]
+ as requested by the web application. The user agent mediates access to [=authenticators=] and their [=public key credentials=] in order to preserve user
  privacy. [=Authenticators=] are responsible for ensuring that no operation is performed without [=user consent=].
  [=Authenticators=] provide cryptographic proof of their properties to [=Relying Parties=] via [=attestation=]. This
  specification also describes the functional model for WebAuthn conformant [=authenticators=], including their signature and

--- a/index.bs
+++ b/index.bs
@@ -236,7 +236,7 @@ Additionally, privacy across [=[RPS]=] is maintained; [=[RPS]=] are not able to 
 the existence, of credentials [=scoped=] to other [RPS].
 
 [=[RPS]=] employ the [=Web Authentication API=] during two distinct, but related, [=ceremonies=] involving a user. The first
-is [=Registration=], where a [=public key credential=] is created on an [=authenticator=], and associated by a [=[RP]=]
+is [=Registration=], where a [=public key credential=] is created on an [=authenticator=], and [=bound to RP|bound=] to a [=[RP]=]
 with the present user's account (the account MAY already exist or MAY be created at this time). The second is
 [=Authentication=], where the [=[RP]=] is presented with an <em>[=Authentication Assertion=]</em> proving the presence
 and [=user consent|consent=] of the user who registered the [=public key credential=]. Functionally, the [=Web Authentication
@@ -485,6 +485,21 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Biometric Authenticator</dfn>
 :: Any [=authenticator=] that implements [=biometric recognition=].
 
+: Bound credential
+:: [=Public key credential sources=] and [=public key credentials=] are herein described as being "bound" in two contexts:
+
+    - A [=public key credential source=] or [=public key credential=] is said to be <dfn lt="bound to authenticator">bound</dfn>
+        to its [=managing authenticator=]. This means that only the [=managing authenticator=] can generate [=assertions=] for the
+        [=public key credential sources=] [=bound to authenticator|bound=] to it.
+    - A [=public key credential source=] or [=public key credential=] is said to be <dfn lt="bound to RP">bound</dfn> to the [=RP
+        ID=] stored in the <span link-for="public key credential source">[=rpId=]</span> [=struct/item=] of the [=public key
+        credential source=], and to the [=[RP]=] that this [=RP ID=] refers to. This means that a [=public key
+        credential source=] can generate valid [=assertions=] only for the [=[RP]=] it is [=bound to RP|bound=] to.
+
+    Which of these meanings the term "bound" refers to is given by context. [=Public key credential sources=] and [=public key
+    credentials=] are only said to be "bound" in these two contexts; other subjects may also be said to be "bound" to other
+    things.
+
 : <dfn>Ceremony</dfn>
 :: The concept of a [=ceremony=] [[Ceremony]] is an extension of the concept of a network protocol, with human nodes alongside
     computer nodes and with communication links that include user interface(s), human-to-human communication, and transfers of
@@ -506,7 +521,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     source=] whose [=credential private key=] is stored in the [=authenticator=], [=client=] or [=client device=]. Such
     [=client-side=] storage requires a [=resident credential capable=] [=authenticator=] and has the property that the [=authenticator=]
     is able to select the [=credential private key=] given
-    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] associated with the [=RP ID=]).
+    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] [=bound to RP|bound=] to the [=RP ID=]).
     By definition, the [=credential private key=] is always exclusively controlled by the [=authenticator=]. In the case of a
     [=resident credential=], the [=authenticator=] might offload storage of wrapped key material to the
     [=client device=], but the [=client device=] is not expected to offload the key storage to remote entities (e.g., [=[WRP]=] Server).
@@ -557,7 +572,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         ::  The [=credential private key=].
 
         :   <dfn>rpId</dfn>
-        ::  The [=Relying Party Identifier=], for the [=[RP]=] this [=public key credential source=] is associated with.
+        ::  The [=Relying Party Identifier=], for the [=[RP]=] this [=public key credential source=] is [=bound to RP|bound=] to.
 
         :   <dfn>userHandle</dfn>
         ::  The [=user handle=] associated when this [=public key credential source=] was created. This [=struct/item=] is
@@ -568,7 +583,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             {{displayName}}.
     </dl>
 
-    The [=authenticatorMakeCredential=] operation creates a [=public key credential source=] bound to a <dfn for="public key
+    The [=authenticatorMakeCredential=] operation creates a [=public key credential source=] [=bound to authenticator|bound=] to a <dfn for="public key
     credential source">managing authenticator</dfn> and returns the [=credential public key=] associated with its [=credential
     private key=]. The [=[RP]=] can use this [=credential public key=] to verify the [=authentication assertions=] created by
     this [=public key credential source=].
@@ -747,7 +762,7 @@ the full [=origin=] of the requester is included, and signed over, in the [=atte
 is created as well as in all assertions produced by WebAuthn credentials.
 
 Additionally, to maintain user privacy and prevent malicious [=[RPS]=] from probing for the presence of [=public key
-credentials=] belonging to other [=[RPS]=], each [=public key credential|credential=] is also associated with a [=Relying Party
+credentials=] belonging to other [=[RPS]=], each [=public key credential|credential=] is also [=bound to RP|bound=] to a [=Relying Party
 Identifier=], or [=RP ID=]. This [=RP ID=] is provided by the client to the [=authenticator=] for all operations, and the
 [=authenticator=] ensures that [=public key credential|credentials=] created by a [=[RP]=] can only be used in operations
 requested by the same [=RP ID=]. Separating the [=origin=] from the [=RP ID=] in this way allows the API to be used in cases
@@ -855,7 +870,7 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 {{PublicKeyCredential}}'s [=interface object=]'s implementation of the <dfn for="PublicKeyCredential" method>\[[Create]](origin,
 options, sameOriginWithAncestors)</dfn> [=internal method=] [[CREDENTIAL-MANAGEMENT-1]] allows
 [=[WRP]=] scripts to call {{CredentialsContainer/create()|navigator.credentials.create()}} to request the creation of a new
-[=public key credential source=], bound to an [=authenticator=]. This
+[=public key credential source=], [=bound to authenticator|bound=] to an [=authenticator=]. This
 {{CredentialsContainer/create()|navigator.credentials.create()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
 
@@ -1101,7 +1116,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             1. Return a {{DOMException}} whose name is "{{InvalidStateError}}" and terminate this algorithm.
 
             Note: This error status is handled separately because the |authenticator| returns it only if
-            |excludeCredentialDescriptorList| identifies a credential bound to the |authenticator| and the user has [=user
+            |excludeCredentialDescriptorList| identifies a credential [=bound to authenticator|bound=] to the |authenticator| and the user has [=user
             consent|consented=] to the operation. Given this explicit consent, it is acceptable for this case to be
             distinguishable to the [=[RP]=].
 
@@ -1413,7 +1428,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     ::  1. Let |allowCredentialDescriptorList| be a new [=list=].
 
                         1. Execute a [=client platform=]-specific procedure to determine which, if any, [=public key credentials=] described by
-                            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are bound to this
+                            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are [=bound to authenticator|bound=] to this
                             |authenticator|, by matching with |rpId|,
                             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
                             and
@@ -1458,7 +1473,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         |userVerification| and |clientExtensions| as parameters.
 
                         Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus, the
-                            authenticator is being asked to exercise any credential it may possess that is bound to
+                            authenticator is being asked to exercise any credential it may possess that is [=bound to RP|bound=] to
                             the [=[RP]=], as identified by |rpId|.
                 </dl>
 
@@ -1747,8 +1762,8 @@ optionally evidence of [=user consent=] to a specific transaction.
         Its value's {{PublicKeyCredentialEntity/name}} member is REQUIRED. See [[#dictionary-pkcredentialentity]] for further
         details.
 
-        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=RP ID=] with which the credential
-        should be associated. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
+        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=RP ID=] to which the credential
+        should be [=bound to RP|bound=]. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
         settings object=]'s [=environment settings object/origin=]'s [=effective domain=]. See [[#sctn-rp-credential-params]]
         for further details.
 
@@ -1796,7 +1811,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 ### Public Key Entity Description (dictionary <dfn dictionary>PublicKeyCredentialEntity</dfn>) ### {#dictionary-pkcredentialentity}
 
 The {{PublicKeyCredentialEntity}} dictionary describes a user account, or a [=[WRP]=], with which a [=public key credential=] is
-associated.
+[=bound to RP|bound=].
 
 <xmp class="idl">
     dictionary PublicKeyCredentialEntity {
@@ -2416,7 +2431,7 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, laid o
             <td><dfn>rpIdHash</dfn></td>
             <td>32</td>
             <td>
-                SHA-256 hash of the [=RP ID=] associated with the credential.
+                SHA-256 hash of the [=RP ID=] the [=public key credential|credential=] is [=bound to RP|bound=] to.
             </td>
         </tr>
         <tr>
@@ -2470,8 +2485,8 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, laid o
 The [=RP ID=] is originally received from the [=client=] when the credential is created, and again when an [=assertion=] is generated.
 However, it differs from other [=client data=] in some important ways. First, unlike the client data, the [=RP ID=] of a
 credential does not change between operations but instead remains the same for the lifetime of that credential. Secondly, it is
-validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] associated
-with the requested credential exactly matches the [=RP ID=] supplied by the [=client=].
+validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] that
+the requested [=public key credential|credential=] is [=bound to RP|bound=] to exactly matches the [=RP ID=] supplied by the [=client=].
 
 [=Authenticators=] <dfn for="authenticator data">perform the following steps to generate an [=authenticator data=] structure</dfn>:
 
@@ -2611,10 +2626,10 @@ are part of the [=client device=] as <dfn>platform authenticators</dfn>, while t
 transport protocols are referred to as <dfn>roaming authenticators</dfn>.
 
 - A [=platform authenticator=] is attached using a [=client device=]-specific transport, called <dfn>platform attachment</dfn>, and is usually not removable from the [=client
-    device=]. A [=public key credential=] bound to a [=platform authenticator=] is called a <dfn>platform credential</dfn>.
+    device=]. A [=public key credential=] [=bound to authenticator|bound=] to a [=platform authenticator=] is called a <dfn>platform credential</dfn>.
 
 - A [=roaming authenticator=] is attached using cross-platform transports, called <dfn>cross-platform attachment</dfn>. Authenticators of this class are removable from, and
-    can "roam" among, [=client devices=]. A [=public key credential=] bound to a [=roaming authenticator=] is called a <dfn>roaming
+    can "roam" among, [=client devices=]. A [=public key credential=] [=bound to authenticator|bound=] to a [=roaming authenticator=] is called a <dfn>roaming
     credential</dfn>.
 
 Some [=platform authenticators=] could possibly also act as [=roaming authenticators=] depending on context. For example, a
@@ -3837,7 +3852,7 @@ the attestation=] is consistent with the fields of the attestation certificate's
         <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authenticatorData|.
     - Verify that in the attestation certificate extension data:
         - The value of the `attestationChallenge` field is identical to |clientDataHash|.
-        - The `AuthorizationList.allApplications` field is <em>not</em> present, since PublicKeyCredential MUST be bound to the
+        - The `AuthorizationList.allApplications` field is <em>not</em> present, since PublicKeyCredential MUST be [=bound to RP|bound=] to the
             [=RP ID=].
         - The value in the `AuthorizationList.origin` field is equal to `KM_TAG_GENERATED`.
         - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
@@ -3951,7 +3966,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     serialized client data, |clientDataHash| will be 32 bytes long.)
 
     Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] [=Section 4.3=], with the application parameter set to the
-    SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |clientDataHash|, and the key handle
+    SHA-256 hash of the [=RP ID=] that the given [=public key credential|credential=] is [=bound to RP|bound=] to, the challenge parameter set to |clientDataHash|, and the key handle
     parameter set to the [=credential ID=] of the given credential. Set the raw signature part of this Registration Response Message (i.e., without the [=user public key=],
     key handle, and attestation certificates) as |sig| and set the attestation certificates of
     the attestation public key as |x5c|.
@@ -4219,9 +4234,9 @@ These are RECOMMENDED for implementation by user agents targeting broad interope
 This extension allows [=[WRPS]=] that have previously registered a
 credential using the legacy FIDO JavaScript APIs to request an [=assertion=]. The
 FIDO APIs use an alternative identifier for [=[RPS]=] called an |AppID|
-[[FIDO-APPID]], and any credentials created using those APIs will be bound to
+[[FIDO-APPID]], and any credentials created using those APIs will be [=bound to RP|bound=] to
 that identifier. Without this extension, they would need to be re-registered in
-order to be bound to an [=RP ID=].
+order to be [=bound to RP|bound=] to an [=RP ID=].
 
 This extension does not allow FIDO-compatible credentials to be created. Thus,
 credentials created with WebAuthn are not backwards compatible with the FIDO
@@ -5291,7 +5306,7 @@ authentication, they are designed to be minimally identifying and not shared bet
 - [=Credential IDs=] and [=credential public keys=] are meaningless in isolation, as they only identify [=credential key pairs=]
     and not users directly.
 
-- Each [=public key credential=] is strictly bound to a specific [=[RP]=], and the [=client=] ensures that its existence is not
+- Each [=public key credential=] is strictly [=bound to RP|bound=] to a specific [=[RP]=], and the [=client=] ensures that its existence is not
     revealed to other [=[RPS]=]. A malicious [=[RP]=] thus cannot ask the [=client=] to reveal a user's other identities.
 
 - The [=client=] also ensures that the existence of a [=public key credential=] is not revealed to the [=[RP]=] without [=user
@@ -5358,7 +5373,7 @@ in several ways, including:
 In order to protect users from being identified without [=user consent|consent=], implementations of the
 {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method need to take care to not leak information that
 could enable a malicious [=[WRP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
-credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is bound to the
+credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is [=bound to authenticator|bound=] to the
 [=authenticator=]:
 
 - No [=authenticators=] are present.


### PR DESCRIPTION
This fixes some of #462:

```
CREDENTIAL:

(a credential)   bound to a authenticator
(a credential is)   bound to   an/this authenticator
                    managed by    "         "
                    present on    "         "
                    stored on     "         "
                    owning             authenticator
```

This PR leaves a few occurrences of "managed by authenticator" and "stored on authenticator" in introductory sections. The constructions "present on authenticator" and "owning authenticator" do not seem to appear anywhere in the spec at this time.

These terms in #462 seem to have already been fixed:

>scope, as in:
>- Public key credential's scope
>- strong, attested, scoped, public key-based credentials

This might also let us check off a few items in #358.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1031.html" title="Last updated on Aug 29, 2018, 12:29 AM GMT (48276cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1031/d74f56b...48276cf.html" title="Last updated on Aug 29, 2018, 12:29 AM GMT (48276cf)">Diff</a>