### PR TITLE
Add note about actual implementations of appid.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -154,6 +154,10 @@ spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
         text: focus
         text: username; url: attr-fe-autocomplete-username
 
+spec: WHATWG URL; urlPrefix: https://url.spec.whatwg.org/
+    type: dfn
+        text: same site; url: host-same-site
+
 spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
@@ -416,6 +420,9 @@ below and in [[#index-defined-elsewhere]].
 : HTML
 :: The concepts of [=relevant settings object=], [=origin=],
     [=opaque origin=], and [=is a registrable domain suffix of or is equal to=] are defined in [[!HTML52]].
+
+: URL
+:: The concept of [=same site=] is defined in [[!URL]].
 
 : Web IDL
 :: Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL-1]]. This updated version of
@@ -4256,6 +4263,11 @@ JavaScript APIs.
         credential, the client MUST include the credential in
         <var ignore>allowCredentialDescriptorList</var> and set |output| to [TRUE]. The value of |appId| then replaces the `rpId`
         parameter of [=authenticatorGetAssertion=].
+
+Note: In practice, several implementations do not implement steps four and onward of the
+algorithm for [=determining if a caller's FacetID is authorized for an AppID=].
+Instead, in step three, the comparison on the host is relaxed to accept hosts on the
+[=same site=].
 
 : Client extension output
 :: Returns the value of |output|.


### PR DESCRIPTION
This change adds a note to the `appid` extension remarking that, in
practice, I don't think anyone actually implements the FIDO FacetID spec
fully and instead checks whether the claimed AppID is same host with the
origin.

Fixes #972.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1032.html" title="Last updated on Aug 9, 2018, 8:16 PM GMT (b738a04)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1032/d74f56b...agl:b738a04.html" title="Last updated on Aug 9, 2018, 8:16 PM GMT (b738a04)">Diff</a>