### PR TITLE
Note that the appid extension changes RP ID hash

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4258,7 +4258,7 @@ JavaScript APIs.
         parameter of [=authenticatorGetAssertion=].
 
 : Client extension output
-:: Returns the value of |output|.
+:: Returns the value of |output|. If true, the |AppID| was used and thus, when [verifying an assertion](#verifying-assertion), the [=[RP]=] MUST expect the <code>[=rpIdHash=]</code> to be the hash of the |AppID|, not the [=RP ID=].
 
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {


### PR DESCRIPTION
This change adds a note to clarify that successful use of the `appid`
extension will cause the RP ID hash in the returned assertion to be the
hash of the AppID rather than the hash of the RP ID.

Fixes #980.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1033.html" title="Last updated on Aug 9, 2018, 8:32 PM GMT (b6a48d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1033/d74f56b...agl:b6a48d7.html" title="Last updated on Aug 9, 2018, 8:32 PM GMT (b6a48d7)">Diff</a>