### PR TITLE
Add Username Enumeration section to privacy considerations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3267,10 +3267,8 @@ the [=authenticator=] MUST:
 # [=[WRP]=] Operations # {#rp-operations}
 
 A [=registration=] or [=authentication=] [=ceremony=] begins with the [=[WRP]=] creating a {{PublicKeyCredentialCreationOptions}}
-or {{PublicKeyCredentialRequestOptions}} object |request|, respectively, which encodes the parameters for the [=ceremony=]. Most
-importantly, |request| contains a random challenge and optionally a list of [=credential IDs=] eligible for the [=ceremony=]. The
-[=[RP]=] SHOULD take care to not leak sensitive information while generating |request|; see [[#sctn-username-enumeration]] for
-details.
+or {{PublicKeyCredentialRequestOptions}} object, respectively, which encodes the parameters for the [=ceremony=]. The [=[RP]=]
+SHOULD take care to not leak sensitive information during this stage; see [[#sctn-username-enumeration]] for details.
 
 Upon successful execution of {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}, the [=[RP]=]'s script receives
 a {{PublicKeyCredential}} containing an {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}} structure,

--- a/index.bs
+++ b/index.bs
@@ -5487,9 +5487,9 @@ leakage due to such an attack:
             proceed with the ceremony. Display the same message to the user in the web interface regardless of the contents of the
             sent e-mail and whether or not this e-mail address was already registered.
 
-            Note: This suggestion can be similarly adapted for other externally meaningful identifiers, for example,
-            national ID numbers or credit card numbers &mdash; if they provide similar out-of-band contact information, for
-            example, conventional postal address.
+            Note: This suggestion can be similarly adapted for other externally meaningful identifiers, for example, national ID
+            numbers or credit card numbers &mdash; if they provide similar out-of-band contact information, for example,
+            conventional postal address.
 
 - For [=authentication ceremonies=]:
 

--- a/index.bs
+++ b/index.bs
@@ -3266,7 +3266,7 @@ the [=authenticator=] MUST:
 
 # [=[WRP]=] Operations # {#rp-operations}
 
-A [=registration=] or [=authentication=] [=ceremony=] begins with the [=[WRP]=] creating a {{PublicKeyCredentialCreationOptions}}
+A [=registration ceremony|registration=] or [=authentication ceremony=] begins with the [=[WRP]=] creating a {{PublicKeyCredentialCreationOptions}}
 or {{PublicKeyCredentialRequestOptions}} object, respectively, which encodes the parameters for the [=ceremony=]. The [=[RP]=]
 SHOULD take care to not leak sensitive information during this stage; see [[#sctn-username-enumeration]] for details.
 
@@ -5407,37 +5407,56 @@ only to the operating system user that created that [=platform credential=].
 
 ## Username Enumeration ## {#sctn-username-enumeration}
 
-While initiating a [=registration=] or [=authentication=] [=ceremony=], there is a risk that the [=[WRP]=] might leak sensitive
+While initiating a [=registration ceremony|registration=] or [=authentication ceremony=], there is a risk that the [=[WRP]=] might leak sensitive
 information about its registered users. For example, if a [=[RP]=] uses e-mail addresses as usernames and a user attempts to
 initiate an [=authentication=] [=ceremony=] for "alex.p.mueller@example.com" and the [=[RP]=] responds with a failure, but then
 successfully initiates an [=authentication ceremony=] for "j.doe@example.com", then the user can conclude that "j.doe@example.com"
 is registered and "alex.p.mueller@example.com" is not. The [=[RP]=] has thus leaked the possibly sensitive information that
 "j.doe@example.com" has an account at this [=[RP]=].
 
-The following is a non-normative, non-exhaustive list of measures the [=[RP]=] MAY implement to mitigate or prevent information
-leak due to such an attack:
+The following is a non-normative, non-exhaustive list of measures the [=[RP]=] may implement to mitigate or prevent information
+leakage due to such an attack:
 
-- When initiating an [=authentication ceremony=], generate and return a valid {{PublicKeyCredentialRequestOptions}} object
-    even if the supplied username is not registered. The {{PublicKeyCredentialRequestOptions/allowCredentials}} member may be
-    populated with random values.
+- For [=registration ceremonies=]:
 
-- When verifying an {{AuthenticatorAssertionResponse}} response from the [=authenticator=], make it indistinguishable whether
-    verification failed because the signature is invalid or because no such user or credential is registered.
+    - If the [=[RP]=] uses [=[RP]=]-specific usernames as user identifiers:
 
-- If the [=[RP]=] uses [=[RP]=]-specific usernames as user identifiers:
+        - When initiating a [=registration ceremony=], disallow registration of usernames that are syntactically valid e-mail
+            addresses.
 
-    - When initiating a [=registration ceremony=], disallow registration of usernames that are valid e-mail addresses.
+            Note: The motivation for this suggestion is that in this case the [=[RP]=] probably has no choice but to fail the
+            [=registration ceremony=] if the user attempts to register a username that is already registered, and an information
+            leak might therefore be unavoidable. By disallowing e-mail addresses as usernames, the impact of the leakage can be
+            mitigated since it will be less likely that a user has the same username at this [=[RP]=] as at other [=[RPS]=].
 
-- If the [=[RP]=] uses e-mail addresses as user identifiers:
+    - If the [=[RP]=] uses e-mail addresses as user identifiers:
 
-    - When initiating a [=registration ceremony=], interrupt the user interaction after receiving the e-mail address to register
-        and send a message to this address, containing an unpredictable one-time code and instructions for how to use it to
-        proceed with the ceremony.  Display the same message to the user in the web interface regardless of the contents of the
-        sent e-mail and whether or not this e-mail was already registered.
+        - When initiating a [=registration ceremony=], interrupt the user interaction after receiving the e-mail address to
+            register and send a message to this address, containing an unpredictable one-time code and instructions for how to use
+            it to proceed with the ceremony. Display the same message to the user in the web interface regardless of the contents
+            of the sent e-mail and whether or not this e-mail address was already registered.
 
-- The preceding suggestion can be similarly adapted for other externally meaningful identifiers &mdash; for example, national ID
-    numbers or credit card numbers &mdash; if they provide similar out-of-band contact information &mdash; for example,
-    conventional postal address.
+            Note: This suggestion can be similarly adapted for other externally meaningful identifiers &mdash; for example,
+            national ID numbers or credit card numbers &mdash; if they provide similar out-of-band contact information &mdash; for
+            example, conventional postal address.
+
+- For [=authentication ceremonies=]:
+
+    - If, when initiating an [=authentication ceremony=], there is no account matching the provided username, continue the
+        ceremony by invoking `{{CredentialsContainer/get()|navigator.credentials.get()}}` using a syntactically valid
+        `{{PublicKeyCredentialRequestOptions}}` object that is populated with plausible imaginary values.
+
+        Note: The username may be "provided" in various [=[RP]=]-specific fashions: login form, session cookie, etc.
+
+        Note: If returned imaginary values noticeably differ from actual ones, clever attackers may be able to discern them and
+            thus be able to test for existence of actual accounts. Examples of noticeably different values include if the values
+            are always the same for all username inputs, or are different in repeated attempts with the same username input. The
+            {{PublicKeyCredentialRequestOptions/allowCredentials}} member could therefore be populated with pseudo-random values
+            derived deterministically from the username, for example.
+
+    - When verifying an {{AuthenticatorAssertionResponse}} response from the [=authenticator=], make it indistinguishable whether
+          verification failed because the signature is invalid or because no such user or credential is registered.
+
 
 
 # Acknowledgements # {#acknowledgements}

--- a/index.bs
+++ b/index.bs
@@ -5470,7 +5470,7 @@ leakage due to such an attack:
 
 - For [=registration ceremonies=]:
 
-    - If the [=[RP]=] uses [=[RP]=]-specific usernames as user identifiers:
+    - If the [=[RP]=] uses [=[RP]=]-specific usernames to identify users:
 
         - When initiating a [=registration ceremony=], disallow registration of usernames that are syntactically valid e-mail
             addresses.
@@ -5480,7 +5480,7 @@ leakage due to such an attack:
             leak might therefore be unavoidable. By disallowing e-mail addresses as usernames, the impact of the leakage can be
             mitigated since it will be less likely that a user has the same username at this [=[RP]=] as at other [=[RPS]=].
 
-    - If the [=[RP]=] uses e-mail addresses as user identifiers:
+    - If the [=[RP]=] uses e-mail addresses to identify users:
 
         - When initiating a [=registration ceremony=], interrupt the user interaction after the e-mail address is supplied and
             send a message to this address, containing an unpredictable one-time code and instructions for how to use it to

--- a/index.bs
+++ b/index.bs
@@ -5487,8 +5487,8 @@ leakage due to such an attack:
             proceed with the ceremony. Display the same message to the user in the web interface regardless of the contents of the
             sent e-mail and whether or not this e-mail address was already registered.
 
-            Note: This suggestion can be similarly adapted for other externally meaningful identifiers &mdash; for example,
-            national ID numbers or credit card numbers &mdash; if they provide similar out-of-band contact information &mdash; for
+            Note: This suggestion can be similarly adapted for other externally meaningful identifiers, for example,
+            national ID numbers or credit card numbers &mdash; if they provide similar out-of-band contact information, for
             example, conventional postal address.
 
 - For [=authentication ceremonies=]:

--- a/index.bs
+++ b/index.bs
@@ -3266,7 +3266,13 @@ the [=authenticator=] MUST:
 
 # [=[WRP]=] Operations # {#rp-operations}
 
-Upon successful execution of {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}, the [=[WRP]=]'s script receives
+A [=registration=] or [=authentication=] [=ceremony=] begins with the [=[WRP]=] creating a {{PublicKeyCredentialCreationOptions}}
+or {{PublicKeyCredentialRequestOptions}} object |request|, respectively, which encodes the parameters for the [=ceremony=]. Most
+importantly, |request| contains a random challenge and optionally a list of [=credential IDs=] eligible for the [=ceremony=]. The
+[=[RP]=] SHOULD take care to not leak sensitive information while generating |request|; see [[#sctn-username-enumeration]] for
+details.
+
+Upon successful execution of {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}, the [=[RP]=]'s script receives
 a {{PublicKeyCredential}} containing an {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}} structure,
 respectively, from the client. It must then deliver the contents of this structure to the [=[RP]=] server, using methods outside
 the scope of this specification. This section describes the operations that the [=[RP]=] must perform upon receipt of these
@@ -5399,6 +5405,41 @@ available to the user.
 If a [=platform authenticator=] is included in a [=client device=] with a multi-user operating system, the [=platform
 authenticator=] and [=client device=] SHOULD work together to ensure that the existence of any [=platform credential=] is revealed
 only to the operating system user that created that [=platform credential=].
+
+
+## Username Enumeration ## {#sctn-username-enumeration}
+
+While initiating a [=registration=] or [=authentication=] [=ceremony=], there is a risk that the [=[WRP]=] might leak sensitive
+information about its registered users. For example, if a [=[RP]=] uses e-mail addresses as usernames and a user attempts to
+initiate an [=authentication=] [=ceremony=] for "alex.p.mueller@example.com" and the [=[RP]=] responds with a failure, but then
+successfully initiates an [=authentication ceremony=] for "j.doe@example.com", then the user can conclude that "j.doe@example.com"
+is registered and "alex.p.mueller@example.com" is not. The [=[RP]=] has thus leaked the possibly sensitive information that
+"j.doe@example.com" has an account at this [=[RP]=].
+
+The following is a non-normative, non-exhaustive list of measures the [=[RP]=] MAY implement to mitigate or prevent information
+leak due to such an attack:
+
+- When initiating an [=authentication ceremony=], generate and return a valid {{PublicKeyCredentialRequestOptions}} object
+    even if the supplied username is not registered. The {{PublicKeyCredentialRequestOptions/allowCredentials}} member may be
+    populated with random values.
+
+- When verifying an {{AuthenticatorAssertionResponse}} response from the [=authenticator=], make it indistinguishable whether
+    verification failed because the signature is invalid or because no such user or credential is registered.
+
+- If the [=[RP]=] uses [=[RP]=]-specific usernames as user identifiers:
+
+    - When initiating a [=registration ceremony=], disallow registration of usernames that are valid e-mail addresses.
+
+- If the [=[RP]=] uses e-mail addresses as user identifiers:
+
+    - When initiating a [=registration ceremony=], interrupt the user interaction after receiving the e-mail address to register
+        and send a message to this address, containing an unpredictable one-time code and instructions for how to use it to
+        proceed with the ceremony.  Display the same message to the user in the web interface regardless of the contents of the
+        sent e-mail and whether or not this e-mail was already registered.
+
+- The preceding suggestion can be similarly adapted for other externally meaningful identifiers &mdash; for example, national ID
+    numbers or credit card numbers &mdash; if they provide similar out-of-band contact information &mdash; for example,
+    conventional postal address.
 
 
 # Acknowledgements # {#acknowledgements}

--- a/index.bs
+++ b/index.bs
@@ -5431,10 +5431,10 @@ leakage due to such an attack:
 
     - If the [=[RP]=] uses e-mail addresses as user identifiers:
 
-        - When initiating a [=registration ceremony=], interrupt the user interaction after receiving the e-mail address to
-            register and send a message to this address, containing an unpredictable one-time code and instructions for how to use
-            it to proceed with the ceremony. Display the same message to the user in the web interface regardless of the contents
-            of the sent e-mail and whether or not this e-mail address was already registered.
+        - When initiating a [=registration ceremony=], interrupt the user interaction after the e-mail address is supplied and
+            send a message to this address, containing an unpredictable one-time code and instructions for how to use it to
+            proceed with the ceremony. Display the same message to the user in the web interface regardless of the contents of the
+            sent e-mail and whether or not this e-mail address was already registered.
 
             Note: This suggestion can be similarly adapted for other externally meaningful identifiers &mdash; for example,
             national ID numbers or credit card numbers &mdash; if they provide similar out-of-band contact information &mdash; for
@@ -5443,8 +5443,8 @@ leakage due to such an attack:
 - For [=authentication ceremonies=]:
 
     - If, when initiating an [=authentication ceremony=], there is no account matching the provided username, continue the
-        ceremony by invoking `{{CredentialsContainer/get()|navigator.credentials.get()}}` using a syntactically valid
-        `{{PublicKeyCredentialRequestOptions}}` object that is populated with plausible imaginary values.
+        ceremony by invoking {{CredentialsContainer/get()|navigator.credentials.get()}} using a syntactically valid
+        {{PublicKeyCredentialRequestOptions}} object that is populated with plausible imaginary values.
 
         Note: The username may be "provided" in various [=[RP]=]-specific fashions: login form, session cookie, etc.
 


### PR DESCRIPTION
This fixes #1014.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1036.html" title="Last updated on Sep 10, 2018, 11:10 AM GMT (63b960e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1036/035ea79...63b960e.html" title="Last updated on Sep 10, 2018, 11:10 AM GMT (63b960e)">Diff</a>