### PR TITLE
[Spelling] Added missing "be"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2179,7 +2179,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
                 </div>
 
             :   <dfn>id</dfn>
-            ::  This member MUST be present if {{TokenBinding/status}} is {{TokenBindingStatus/present}}, and MUST a [=base64url
+            ::  This member MUST be present if {{TokenBinding/status}} is {{TokenBindingStatus/present}}, and MUST be a [=base64url
                 encoding=] of the [=Token Binding ID=] that was used when communicating with the [=[RP]=].
         </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/abergs/webauthn/pull/1038.html" title="Last updated on Aug 14, 2018, 9:45 AM GMT (66327de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1038/d74f56b...abergs:66327de.html" title="Last updated on Aug 14, 2018, 9:45 AM GMT (66327de)">Diff</a>