### PR TITLE
Provide transport information during registration.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1194,12 +1194,14 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         :   {{AuthenticatorAttestationResponse/attestationObject}}
                         ::  |attestationObject|
 
-                        :   {{AuthenticatorAttestationResponse/transports}}
-                        ::  A sequence of one or more {{AuthenticatorTransport}} values. The first value is set to the transport used to obtain this registration. Further values are appended to indicate other, distinct, transports that the |authenticator| is believed to support.
+                        :   {{AuthenticatorAttestationResponse/[[transports]]}}
+                        ::  A sequence of zero or more unique {{AuthenticatorTransport}} values, in lexicographical order, that the |authenticator| is believed to support.
 
-                            If a user agent does not wish to divulge this information it MAY choose not to include additional transports and MAY choose the first element to be a generic value rather than the actual transport used. But it MUST still include at least one value and it takes the risk that [=RP=] behaviour may be suboptimital.
+                            If a user agent does not wish to divulge this information it MAY substitute an arbitrary sequence designed to preserve privacy. This sequence MUST still be valid, i.e. lexicographically sorted and free of duplicates. For example, it may use the empty sequence. Either way, in this case the user agent takes the risk that [=[RP]=] behavior may be suboptimal.
 
-                            Note: How user agents discover other transports supported by a given [=authenticator=] is outside the scope of this specification, but may include information from an [=attestation certificate=] (for example [[FIDO-Transports-Ext]]), metadata communicated in an [=authenticator=] protocol such as CTAP2, or special-case knowledge about a [=platform authenticator=].
+                            If the user agent does not have any transport information, it SHOULD set this field to the empty sequence.
+
+                            Note: How user agents discover transports supported by a given [=authenticator=] is outside the scope of this specification, but may include information from an [=attestation certificate=] (for example [[FIDO-Transports-Ext]]), metadata communicated in an [=authenticator=] protocol such as CTAP2, or special-case knowledge about a [=platform authenticator=].
 
                     :   {{PublicKeyCredential/[[clientExtensionsResults]]}}
                     ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
@@ -1697,7 +1699,7 @@ during registration.
     ::  This operation returns the value of {{AuthenticatorAttestationResponse/[[transports]]}}.
 
     :   <dfn>\[[transports]]</dfn>
-    ::  This [=internal slot=] contains a sequence of one or more {{AuthenticatorTransport}} values. The first value is the transport used by the user agent to perform a {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} operation. Subsequent values are additional transports that the [=authenticator=] is believed to support. The sequence MUST NOT contain duplicate values.
+    ::  This [=internal slot=] contains a sequence of zero or more unique {{AuthenticatorTransport}} values in lexicographical order. These values are the transports that the [=authenticator=] is believed to support, or an empty sequence if the information is unavailable.
 </div>
 
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}

--- a/index.bs
+++ b/index.bs
@@ -1194,6 +1194,13 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         :   {{AuthenticatorAttestationResponse/attestationObject}}
                         ::  |attestationObject|
 
+                        :   {{AuthenticatorAttestationResponse/transports}}
+                        ::  A sequence of one or more {{AuthenticatorTransport}} values. The first value is set to the transport used to obtain this registration. Further values are appended to indicate other, distinct, transports that the |authenticator| is believed to support.
+
+                            If a user agent does not wish to divulge this information it MAY choose not to include additional transports and MAY choose the first element to be a generic value rather than the actual transport used. But it MUST still include at least one value and it takes the risk that [=RP=] behaviour may be suboptimital.
+
+                            Note: How user agents discover other transports supported by a given [=authenticator=] is outside the scope of this specification, but may include information from an [=attestation certificate=] (for example [[FIDO-Transports-Ext]]), metadata communicated in an [=authenticator=] protocol such as CTAP2, or special-case knowledge about a [=platform authenticator=].
+
                     :   {{PublicKeyCredential/[[clientExtensionsResults]]}}
                     ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                         <code>|credentialCreationData|.[=credentialCreationData/clientExtensionResults=]</code>.
@@ -1666,6 +1673,7 @@ during registration.
     [SecureContext, Exposed=Window]
     interface AuthenticatorAttestationResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      attestationObject;
+        sequence<AuthenticatorTransport>                 getTransports();
     };
 </xmp>
 <div dfn-type="attribute" dfn-for="AuthenticatorAttestationResponse">
@@ -1684,6 +1692,12 @@ during registration.
         [=attestation statement=], as well as to decode and validate the [=authenticator data=] along with the
         [=JSON-serialized client data=]. For more details, see [[#sctn-attestation]], [[#generating-an-attestation-object]],
         and [Figure 5](#fig-attStructs).
+
+    :   {{AuthenticatorAttestationResponse/getTransports()}}
+    ::  This operation returns the value of {{AuthenticatorAttestationResponse/[[transports]]}}.
+
+    :   <dfn>\[[transports]]</dfn>
+    ::  This [=internal slot=] contains a sequence of one or more {{AuthenticatorTransport}} values. The first value is the transport used by the user agent to perform a {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} operation. Subsequent values are additional transports that the [=authenticator=] is believed to support. The sequence MUST NOT contain duplicate values.
 </div>
 
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}
@@ -5673,6 +5687,13 @@ for their contributions as our W3C Team Contacts.
     "title": "FIDO Privacy Principles",
     "href": "https://fidoalliance.org/wp-content/uploads/2014/12/FIDO_Alliance_Whitepaper_Privacy_Principles.pdf",
     "status": "FIDO Alliance Whitepaper"
+  },
+
+  "FIDO-Transports-Ext": {
+    "authors": ["FIDO Alliance"],
+    "title": "FIDO U2F Authenticator Transports Extension",
+    "href": "https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-authenticator-transports-extension-v1.2-ps-20170411.html",
+    "status": "FIDO Alliance Proposed Standard"
   },
 
   "CDDL": {


### PR DESCRIPTION
This change adds a `getTransports` method to
`AuthenticatorAttestationResponse` that returns the
`AuthenticatorTransport` used to perform a registration, as well as
other transports that the user agent believes that the authenticator
supports.

Fixes #889
Fixes #851
See also #882


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1050.html" title="Last updated on Sep 21, 2018, 9:20 PM GMT (52a5159)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1050/035ea79...agl:52a5159.html" title="Last updated on Sep 21, 2018, 9:20 PM GMT (52a5159)">Diff</a>