### PR TITLE
Highlight Basic/AttCA ambiguity in definitions and verification procedures

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3191,6 +3191,9 @@ The initial list of specified [=attestation statement formats=] is in [[#defined
 
 WebAuthn supports multiple attestation types:
 
+Note: [=Attestation types=] are not expressed in any data structure defined in this specification. Any values representing
+[=attestation types=] are internal and implementation-specific to the [=[RP]=].
+
 : <dfn>Basic Attestation</dfn> (<dfn>Basic</dfn>)
 :: In the case of basic attestation [[UAFProtocol]], the authenticator's [=attestation key pair=] is specific to an
     authenticator model.  Thus, authenticators of the same model often share the same attestation key pair. See

--- a/index.bs
+++ b/index.bs
@@ -3217,7 +3217,7 @@ Note: [=Attestation types=] are not expressed in any data structure defined in t
         is called "active".
 
     Note: [=Attestation statements=] of type [=AttCA=] use the same data structure as [=attestation statements=] of type
-    [=Basic=], so the two attestation types are in general not distinguishable without externally provided knowledge about the
+    [=Basic=], so the two attestation types are, in general, not distinguishable without externally provided knowledge about the
     [=attestation certificates=] conveyed in the [=attestation statement=].
 
 : <dfn>Elliptic Curve based Direct Anonymous Attestation</dfn> (<dfn>ECDAA</dfn>)

--- a/index.bs
+++ b/index.bs
@@ -3213,6 +3213,10 @@ WebAuthn supports multiple attestation types:
     Note: This concept typically leads to multiple attestation certificates. The attestation certificate requested most recently
         is called "active".
 
+    Note: [=Attestation statements=] of type [=AttCA=] use the same data structure as [=attestation statements=] of type
+    [=Basic=], so the two attestation types are in general not distinguishable without externally provided knowledge about the
+    [=attestation certificates=] conveyed in the [=attestation statement=].
+
 : <dfn>Elliptic Curve based Direct Anonymous Attestation</dfn> (<dfn>ECDAA</dfn>)
 :: In this case, the Authenticator receives direct anonymous attestation (DAA) credentials from a single DAA-Issuer.
     These DAA credentials are used along with blinding to sign the [=attested credential data=]. The concept of blinding avoids

--- a/index.bs
+++ b/index.bs
@@ -3223,7 +3223,7 @@ calling {{CredentialsContainer/create()|navigator.credentials.create()}} they se
 
     Note: [=Attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=AttCA=] use the same data structure
     as [=attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=Basic=], so the two attestation types
-    are, in general, distinguishable only with externally provided knowledge aegarding the contents of the [=attestation
+    are, in general, distinguishable only with externally provided knowledge regarding the contents of the [=attestation
     certificates=] conveyed in the [=attestation statement=].
 
 : <dfn>Elliptic Curve based Direct Anonymous Attestation</dfn> (<dfn>ECDAA</dfn>)

--- a/index.bs
+++ b/index.bs
@@ -29,7 +29,7 @@ Shortname: webauthn
 Level: 1
 Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
 Editor: Alexei Czeskis, w3cid 87258, Google, aczeskis@google.com
-Editor: Jeff Hodges, w3cid 43843, PayPal, Jeff.Hodges@paypal.com
+Editor: Jeff Hodges, w3cid 43843, Invited Expert, Jeff.Hodges@KIngsMountain.com
 Editor: J.C. Jones, w3cid 87240, Mozilla, jc@mozilla.com
 Editor: Michael B. Jones, w3cid 38745, Microsoft, mbj@microsoft.com
 Editor: Akshay Kumar, w3cid 99318, Microsoft, akshayku@microsoft.com

--- a/index.bs
+++ b/index.bs
@@ -58,8 +58,9 @@ Text Macro: WRPS WebAuthn Relying Parties
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more [=public key
- credentials=], each [=scoped=] to a given [=WebAuthn Relying Party=], are created and stored on an [=authenticator=] by the user agent in
- conjunction with the web application. The user agent mediates access to [=public key credentials=] in order to preserve user
+ credentials=], each [=scoped=] to a given [=WebAuthn Relying Party=], are created by and [=bound credential|bound=] to
+ [=authenticators=] as requested by the web application. The user agent mediates access to [=authenticators=] and their [=public
+ key credentials=] in order to preserve user
  privacy. [=Authenticators=] are responsible for ensuring that no operation is performed without [=user consent=].
  [=Authenticators=] provide cryptographic proof of their properties to [=Relying Parties=] via [=attestation=]. This
  specification also describes the functional model for WebAuthn conformant [=authenticators=], including their signature and
@@ -240,7 +241,7 @@ Additionally, privacy across [=[RPS]=] is maintained; [=[RPS]=] are not able to 
 the existence, of credentials [=scoped=] to other [=[RPS]=].
 
 [=[RPS]=] employ the [=Web Authentication API=] during two distinct, but related, [=ceremonies=] involving a user. The first
-is [=Registration=], where a [=public key credential=] is created on an [=authenticator=], and associated by a [=[RP]=]
+is [=Registration=], where a [=public key credential=] is created on an [=authenticator=], and [=scoped=] to a [=[RP]=]
 with the present user's account (the account MAY already exist or MAY be created at this time). The second is
 [=Authentication=], where the [=[RP]=] is presented with an <em>[=Authentication Assertion=]</em> proving the presence
 and [=user consent|consent=] of the user who registered the [=public key credential=]. Functionally, the [=Web Authentication
@@ -492,6 +493,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Biometric Authenticator</dfn>
 :: Any [=authenticator=] that implements [=biometric recognition=].
 
+: <dfn>Bound credential</dfn>
+:: A [=public key credential source=] or [=public key credential=] is said to be [=bound credential|bound=] to its [=managing
+    authenticator=]. This means that only the [=managing authenticator=] can generate [=assertions=] for the [=public key
+    credential sources=] [=bound credential|bound=] to it.
+
 : <dfn>Ceremony</dfn>
 :: The concept of a [=ceremony=] [[Ceremony]] is an extension of the concept of a network protocol, with human nodes alongside
     computer nodes and with communication links that include user interface(s), human-to-human communication, and transfers of
@@ -513,7 +519,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     source=] whose [=credential private key=] is stored in the [=authenticator=], [=client=] or [=client device=]. Such
     [=client-side=] storage requires a [=resident credential capable=] [=authenticator=] and has the property that the [=authenticator=]
     is able to select the [=credential private key=] given
-    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] associated with the [=RP ID=]).
+    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] [=scoped=] to the [=RP ID=]).
     By definition, the [=credential private key=] is always exclusively controlled by the [=authenticator=]. In the case of a
     [=resident credential=], the [=authenticator=] might offload storage of wrapped key material to the
     [=client device=], but the [=client device=] is not expected to offload the key storage to remote entities (e.g., [=[WRP]=] Server).
@@ -564,7 +570,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         ::  The [=credential private key=].
 
         :   <dfn>rpId</dfn>
-        ::  The [=Relying Party Identifier=], for the [=[RP]=] this [=public key credential source=] is associated with.
+        ::  The [=Relying Party Identifier=], for the [=[RP]=] this [=public key credential source=] is [=scoped=] to.
 
         :   <dfn>userHandle</dfn>
         ::  The [=user handle=] associated when this [=public key credential source=] was created. This [=struct/item=] is
@@ -575,7 +581,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             {{displayName}}.
     </dl>
 
-    The [=authenticatorMakeCredential=] operation creates a [=public key credential source=] bound to a <dfn for="public key
+    The [=authenticatorMakeCredential=] operation creates a [=public key credential source=] [=bound credential|bound=] to a <dfn for="public key
     credential source">managing authenticator</dfn> and returns the [=credential public key=] associated with its [=credential
     private key=]. The [=[RP]=] can use this [=credential public key=] to verify the [=authentication assertions=] created by
     this [=public key credential source=].
@@ -716,7 +722,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 # <dfn>Web Authentication API</dfn> # {#api}
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
-idea is that the credentials belong to the user and are managed by an authenticator, with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
+idea is that the credentials belong to the user and are [=managing authenticator|managed=] by an authenticator, with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
 browser to create a new credential for future use by the [=[RP]=]. See [Figure 1](#fig-registration), below.
 
 
@@ -748,13 +754,13 @@ deletion are considered to be the responsibility of such a user interface and ar
 scripts.
 
 The security properties of this API are provided by the client and the authenticator working together. The authenticator, which
-holds and manages credentials, ensures that all operations are [=scoped=] to a particular [=origin=], and cannot be replayed against
+holds and [=managing authenticator|manages=] credentials, ensures that all operations are [=scoped=] to a particular [=origin=], and cannot be replayed against
 a different [=origin=], by incorporating the [=origin=] in its responses. Specifically, as defined in [[#authenticator-ops]],
 the full [=origin=] of the requester is included, and signed over, in the [=attestation object=] produced when a new credential
 is created as well as in all assertions produced by WebAuthn credentials.
 
 Additionally, to maintain user privacy and prevent malicious [=[RPS]=] from probing for the presence of [=public key
-credentials=] belonging to other [=[RPS]=], each [=public key credential|credential=] is also associated with a [=Relying Party
+credentials=] belonging to other [=[RPS]=], each [=public key credential|credential=] is also [=scoped=] to a [=Relying Party
 Identifier=], or [=RP ID=]. This [=RP ID=] is provided by the client to the [=authenticator=] for all operations, and the
 [=authenticator=] ensures that [=public key credential|credentials=] created by a [=[RP]=] can only be used in operations
 requested by the same [=RP ID=]. Separating the [=origin=] from the [=RP ID=] in this way allows the API to be used in cases
@@ -862,7 +868,7 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 {{PublicKeyCredential}}'s [=interface object=]'s implementation of the <dfn for="PublicKeyCredential" method>\[[Create]](origin,
 options, sameOriginWithAncestors)</dfn> [=internal method=] [[CREDENTIAL-MANAGEMENT-1]] allows
 [=[WRP]=] scripts to call {{CredentialsContainer/create()|navigator.credentials.create()}} to request the creation of a new
-[=public key credential source=], bound to an [=authenticator=]. This
+[=public key credential source=], [=bound credential|bound=] to an [=authenticator=]. This
 {{CredentialsContainer/create()|navigator.credentials.create()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
 
@@ -1108,7 +1114,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             1. Return a {{DOMException}} whose name is "{{InvalidStateError}}" and terminate this algorithm.
 
             Note: This error status is handled separately because the |authenticator| returns it only if
-            |excludeCredentialDescriptorList| identifies a credential bound to the |authenticator| and the user has [=user
+            |excludeCredentialDescriptorList| identifies a credential [=bound credential|bound=] to the |authenticator| and the user has [=user
             consent|consented=] to the operation. Given this explicit consent, it is acceptable for this case to be
             distinguishable to the [=[RP]=].
 
@@ -1420,7 +1426,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     ::  1. Let |allowCredentialDescriptorList| be a new [=list=].
 
                         1. Execute a [=client platform=]-specific procedure to determine which, if any, [=public key credentials=] described by
-                            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are bound to this
+                            <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are [=bound credential|bound=] to this
                             |authenticator|, by matching with |rpId|,
                             <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
                             and
@@ -1465,7 +1471,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         |userVerification| and |clientExtensions| as parameters.
 
                         Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus, the
-                            authenticator is being asked to exercise any credential it may possess that is bound to
+                            authenticator is being asked to exercise any credential it may possess that is [=scoped=] to
                             the [=[RP]=], as identified by |rpId|.
                 </dl>
 
@@ -1754,8 +1760,8 @@ optionally evidence of [=user consent=] to a specific transaction.
         Its value's {{PublicKeyCredentialEntity/name}} member is REQUIRED. See [[#dictionary-pkcredentialentity]] for further
         details.
 
-        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=RP ID=] with which the credential
-        should be associated. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
+        Its value's {{PublicKeyCredentialRpEntity/id}} member specifies the [=RP ID=] the credential
+        should be [=scoped=] to. If omitted, its value will be the {{CredentialsContainer}} object's [=relevant
         settings object=]'s [=environment settings object/origin=]'s [=effective domain=]. See [[#sctn-rp-credential-params]]
         for further details.
 
@@ -1802,8 +1808,8 @@ optionally evidence of [=user consent=] to a specific transaction.
 
 ### Public Key Entity Description (dictionary <dfn dictionary>PublicKeyCredentialEntity</dfn>) ### {#dictionary-pkcredentialentity}
 
-The {{PublicKeyCredentialEntity}} dictionary describes a user account, or a [=[WRP]=], with which a [=public key credential=] is
-associated.
+The {{PublicKeyCredentialEntity}} dictionary describes a user account, or a [=[WRP]=], which a [=public key credential=] is
+associated with or [=scoped=] to, respectively.
 
 <xmp class="idl">
     dictionary PublicKeyCredentialEntity {
@@ -2423,7 +2429,7 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, laid o
             <td><dfn>rpIdHash</dfn></td>
             <td>32</td>
             <td>
-                SHA-256 hash of the [=RP ID=] associated with the credential.
+                SHA-256 hash of the [=RP ID=] the [=public key credential|credential=] is [=scoped=] to.
             </td>
         </tr>
         <tr>
@@ -2477,8 +2483,8 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, laid o
 The [=RP ID=] is originally received from the [=client=] when the credential is created, and again when an [=assertion=] is generated.
 However, it differs from other [=client data=] in some important ways. First, unlike the client data, the [=RP ID=] of a
 credential does not change between operations but instead remains the same for the lifetime of that credential. Secondly, it is
-validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] associated
-with the requested credential exactly matches the [=RP ID=] supplied by the [=client=].
+validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] that
+the requested [=public key credential|credential=] is [=scoped=] to exactly matches the [=RP ID=] supplied by the [=client=].
 
 [=Authenticators=] <dfn for="authenticator data">perform the following steps to generate an [=authenticator data=] structure</dfn>:
 
@@ -2621,10 +2627,10 @@ are part of the [=client device=] as <dfn>platform authenticators</dfn>, while t
 transport protocols are referred to as <dfn>roaming authenticators</dfn>.
 
 - A [=platform authenticator=] is attached using a [=client device=]-specific transport, called <dfn>platform attachment</dfn>, and is usually not removable from the [=client
-    device=]. A [=public key credential=] bound to a [=platform authenticator=] is called a <dfn>platform credential</dfn>.
+    device=]. A [=public key credential=] [=bound credential|bound=] to a [=platform authenticator=] is called a <dfn>platform credential</dfn>.
 
 - A [=roaming authenticator=] is attached using cross-platform transports, called <dfn>cross-platform attachment</dfn>. Authenticators of this class are removable from, and
-    can "roam" among, [=client devices=]. A [=public key credential=] bound to a [=roaming authenticator=] is called a <dfn>roaming
+    can "roam" among, [=client devices=]. A [=public key credential=] [=bound credential|bound=] to a [=roaming authenticator=] is called a <dfn>roaming
     credential</dfn>.
 
 Some [=platform authenticators=] could possibly also act as [=roaming authenticators=] depending on context. For example, a
@@ -3847,7 +3853,7 @@ the attestation=] is consistent with the fields of the attestation certificate's
         <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authenticatorData|.
     - Verify that in the attestation certificate extension data:
         - The value of the `attestationChallenge` field is identical to |clientDataHash|.
-        - The `AuthorizationList.allApplications` field is <em>not</em> present, since PublicKeyCredential MUST be bound to the
+        - The `AuthorizationList.allApplications` field is <em>not</em> present, since PublicKeyCredential MUST be [=scoped=] to the
             [=RP ID=].
         - The value in the `AuthorizationList.origin` field is equal to `KM_TAG_GENERATED`.
         - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
@@ -3961,7 +3967,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     serialized client data, |clientDataHash| will be 32 bytes long.)
 
     Generate a Registration Response Message as specified in [[FIDO-U2F-Message-Formats]] [=Section 4.3=], with the application parameter set to the
-    SHA-256 hash of the [=RP ID=] associated with the given credential, the challenge parameter set to |clientDataHash|, and the key handle
+    SHA-256 hash of the [=RP ID=] that the given [=public key credential|credential=] is [=scoped=] to, the challenge parameter set to |clientDataHash|, and the key handle
     parameter set to the [=credential ID=] of the given credential. Set the raw signature part of this Registration Response Message (i.e., without the [=user public key=],
     key handle, and attestation certificates) as |sig| and set the attestation certificates of
     the attestation public key as |x5c|.
@@ -4229,9 +4235,9 @@ These are RECOMMENDED for implementation by user agents targeting broad interope
 This extension allows [=[WRPS]=] that have previously registered a
 credential using the legacy FIDO JavaScript APIs to request an [=assertion=]. The
 FIDO APIs use an alternative identifier for [=[RPS]=] called an |AppID|
-[[FIDO-APPID]], and any credentials created using those APIs will be bound to
+[[FIDO-APPID]], and any credentials created using those APIs will be [=scoped=] to
 that identifier. Without this extension, they would need to be re-registered in
-order to be bound to an [=RP ID=].
+order to be [=scoped=] to an [=RP ID=].
 
 This extension does not allow FIDO-compatible credentials to be created. Thus,
 credentials created with WebAuthn are not backwards compatible with the FIDO
@@ -5223,7 +5229,7 @@ benefits.
 
 In these cases it is possible for a [=man-in-the-middle attack|man-in-the-middle attacker=] - for example, a malicious [=client=]
 or script - to replace the [=credential public key=] to be registered, and subsequently tamper with future [=authentication
-assertions=] bound for the same [=[RP]=] and passing through the same attacker. Accepting these [[#sctn-attestation-types|types]]
+assertions=] [=scoped=] for the same [=[RP]=] and passing through the same attacker. Accepting these [[#sctn-attestation-types|types]]
 of [=attestation statements=] therefore constitutes a [=leap of faith=]. In cases where [=registration=] was accomplished
 securely, subsequent [=authentication=] [=ceremonies=] remain resistant to [=man-in-the-middle attacks=], i.e., benefit (3) is
 retained. Note, however, that such an attack would be easy to detect and very difficult to maintain, since any [=authentication=]
@@ -5306,7 +5312,7 @@ authentication, they are designed to be minimally identifying and not shared bet
 - [=Credential IDs=] and [=credential public keys=] are meaningless in isolation, as they only identify [=credential key pairs=]
     and not users directly.
 
-- Each [=public key credential=] is strictly bound to a specific [=[RP]=], and the [=client=] ensures that its existence is not
+- Each [=public key credential=] is strictly [=scoped=] to a specific [=[RP]=], and the [=client=] ensures that its existence is not
     revealed to other [=[RPS]=]. A malicious [=[RP]=] thus cannot ask the [=client=] to reveal a user's other identities.
 
 - The [=client=] also ensures that the existence of a [=public key credential=] is not revealed to the [=[RP]=] without [=user
@@ -5373,7 +5379,7 @@ in several ways, including:
 In order to protect users from being identified without [=user consent|consent=], implementations of the
 {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method need to take care to not leak information that
 could enable a malicious [=[WRP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
-credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is bound to the
+credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is [=bound credential|bound=] to the
 [=authenticator=]:
 
 - No [=authenticators=] are present.

--- a/index.bs
+++ b/index.bs
@@ -48,6 +48,7 @@ group: webauthn
 Issue Tracking: GitHub https://github.com/w3c/webauthn/issues
 !Tests: <a href=https://github.com/web-platform-tests/wpt/tree/master/webauthn>web-platform-tests webauthn/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/webauthn>ongoing work</a>)
 Text Macro: FALSE <code>false</code>
+Text Macro: PII personally identifying information
 Text Macro: RP Relying Party
 Text Macro: RPS Relying Parties
 Text Macro: INFORMATIVE <em>This section is not normative.</em>
@@ -186,6 +187,8 @@ spec: RFC4949; urlPrefix: https://tools.ietf.org/html/rfc4949
     type: dfn
         text: leap of faith; url: page-182
         text: man-in-the-middle attack; url: page-186
+        text: salt; url: page-258
+        text: salted; url: page-258
 
 spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
     type: dfn
@@ -673,6 +676,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
     The user handle is not meant to be displayed to the user, but is used by the [=[RP]=] to control the number of credentials - an
     authenticator will never contain more than one credential for a given [=[RP]=] under the same user handle.
+
+    The user handle SHOULD NOT contain [PII] about the user, such as a username or e-mail address; see
+    [[#sctn-user-handle-privacy]] for details.
 
 : <dfn>User Verification</dfn>
 :: The technical process by which an [=authenticator=] <em>locally authorizes</em> the invocation of the
@@ -5420,6 +5426,30 @@ available to the user.
 If a [=platform authenticator=] is included in a [=client device=] with a multi-user operating system, the [=platform
 authenticator=] and [=client device=] SHOULD work together to ensure that the existence of any [=platform credential=] is revealed
 only to the operating system user that created that [=platform credential=].
+
+
+## Privacy of [PII] stored in authenticators ## {#sctn-pii-privacy}
+
+[=Authenticators=] MAY provide additional information to [=clients=] outside what's defined by this specification, e.g.,
+to enable the [=client=] to provide a rich UI with which the user can pick which [=credential=] to use for an [=authentication
+ceremony=]. If an [=authenticator=] chooses to do so, it SHOULD NOT expose [PII] unless successful [=user verification=] has been
+performed. If the [=authenticator=] supports [=user verification=] with more than one concurrently enrolled user, the
+[=authenticator=] SHOULD NOT expose [PII] of users other than the currently [=user verified|verified=] user. Consequently, an
+[=authenticator=] that is not capable of [=user verification=] SHOULD NOT store [PII].
+
+For the purposes of this discussion, the [=user handle=] conveyed as the {{PublicKeyCredentialUserEntity/id}} member of
+{{PublicKeyCredentialUserEntity}} is not considered [PII]; see [[#sctn-user-handle-privacy]].
+
+These recommendations serve to prevent an adversary with physical access to an [=authenticator=] from extracting [PII] about the
+[=authenticator=]'s enrolled user(s).
+
+
+## User Handle contents ## {#sctn-user-handle-privacy}
+
+Since the [=user handle=] is not considered [PII] in [[#sctn-pii-privacy]], the [=[RP]=] SHOULD NOT include [PII], e.g., e-mail
+addresses or usernames, in the [=user handle=]. This includes hash values of [PII], unless the hash
+function is [=salted=] with [=salt=] values private to the [=[RP]=], since hashing does not prevent probing for guessable input
+values. It is RECOMMENDED to let the [=user handle=] be 64 random bytes, and store this value in the user's account.
 
 
 # Acknowledgements # {#acknowledgements}

--- a/index.bs
+++ b/index.bs
@@ -3189,10 +3189,15 @@ The initial list of specified [=attestation statement formats=] is in [[#defined
      different things having the same nominal name, eg attestation-types-the-section, and attestation-types-the-definition -->
 ### Attestation Types ### {#sctn-attestation-types}
 
-WebAuthn supports multiple attestation types:
+WebAuthn supports several [=attestation types=], defining the semantics of [=attestation statements=] and their underlying trust
+models:
 
-Note: [=Attestation types=] are not expressed in any data structure defined in this specification. Any values representing
-[=attestation types=] are internal and implementation-specific to the [=[RP]=].
+Note: This specification does not define any data structures explicitly expressing the [=attestation types=] employed by
+[=authenticators=]. [=[RPS]=] engaging in [=attestation statement=] [=verification procedure|verification=] &mdash; i.e., when
+calling {{CredentialsContainer/create()|navigator.credentials.create()}} they select an [=attestation conveyance=] other than
+{{AttestationConveyancePreference/none}} and verify the received [=attestation statement=] &mdash; will determine the employed
+[=attestation type=] as a part of [=verification procedure|verification=]. See the "Verification procedure" subsections of
+[[#defined-attestation-formats]]. See also [[#sec-attestation-privacy]].
 
 : <dfn>Basic Attestation</dfn> (<dfn>Basic</dfn>)
 :: In the case of basic attestation [[UAFProtocol]], the authenticator's [=attestation key pair=] is specific to an
@@ -3216,9 +3221,10 @@ Note: [=Attestation types=] are not expressed in any data structure defined in t
     Note: This concept typically leads to multiple attestation certificates. The attestation certificate requested most recently
         is called "active".
 
-    Note: [=Attestation statements=] of type [=AttCA=] use the same data structure as [=attestation statements=] of type
-    [=Basic=], so the two attestation types are, in general, not distinguishable without externally provided knowledge about the
-    [=attestation certificates=] conveyed in the [=attestation statement=].
+    Note: [=Attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=AttCA=] use the same data structure
+    as [=attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=Basic=], so the two attestation types
+    are, in general, distinguishable only with externally provided knowledge aegarding the contents of the [=attestation
+    certificates=] conveyed in the [=attestation statement=].
 
 : <dfn>Elliptic Curve based Direct Anonymous Attestation</dfn> (<dfn>ECDAA</dfn>)
 :: In this case, the Authenticator receives direct anonymous attestation (DAA) credentials from a single DAA-Issuer.
@@ -3627,7 +3633,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
             - Optionally, inspect |x5c| and consult externally provided knowledge to determine whether |attStmt| conveys a
                 [=Basic=] or [=AttCA=] attestation.
             - If successful, return attestation type [=Basic=] or [=AttCA=], or an implementation-specific value expressing
-                uncertainty, and [=attestation trust path=] |x5c|.
+                uncertainty, and in either case also return [=attestation trust path=] |x5c|.
 
         1. If |ecdaaKeyId| is present, then the attestation type is [=ECDAA=]. In this case:
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using
@@ -4019,7 +4025,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
     1. Optionally, inspect |x5c| and consult externally provided knowledge to determine whether |attStmt| conveys a [=Basic=] or
         [=AttCA=] attestation.
     1. If successful, return attestation type [=Basic=] or [=AttCA=], or an implementation-specific value expressing uncertainty,
-        and [=attestation trust path=] |x5c|.
+        and in either case also return [=attestation trust path=] |x5c|.
 
 ## None Attestation Statement Format ## {#none-attestation}
 

--- a/index.bs
+++ b/index.bs
@@ -3620,7 +3620,10 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
             - Verify that |attestnCert| meets the requirements in [[#packed-attestation-cert-requirements]].
             - If |attestnCert| contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (`id-fido-gen-ce-aaguid`) verify that the
                 value of this extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
-            - If successful, return attestation type [=Basic=] and [=attestation trust path=] |x5c|.
+            - Optionally, inspect |x5c| and consult externally provided knowledge to determine whether |attStmt| conveys a
+                [=Basic=] or [=AttCA=] attestation.
+            - If successful, return attestation type [=Basic=] or [=AttCA=], or an implementation-specific value expressing
+                uncertainty, and [=attestation trust path=] |x5c|.
 
         1. If |ecdaaKeyId| is present, then the attestation type is [=ECDAA=]. In this case:
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using
@@ -4009,7 +4012,10 @@ This attestation statement format is used with FIDO U2F authenticators using the
     1. Let |verificationData| be the concatenation of (0x00 || |rpIdHash| ||
         |clientDataHash| || |credentialId| || |publicKeyU2F|) (see [=Section 4.3=] of [[!FIDO-U2F-Message-Formats]]).
     1. Verify the |sig| using |verificationData| and |certificate public key| per [[!SEC1]].
-    1. If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
+    1. Optionally, inspect |x5c| and consult externally provided knowledge to determine whether |attStmt| conveys a [=Basic=] or
+        [=AttCA=] attestation.
+    1. If successful, return attestation type [=Basic=] or [=AttCA=], or an implementation-specific value expressing uncertainty,
+        and [=attestation trust path=] |x5c|.
 
 ## None Attestation Statement Format ## {#none-attestation}
 


### PR DESCRIPTION
This fixes #1042.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1054.html" title="Last updated on Sep 18, 2018, 4:47 PM GMT (721c507)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1054/5bdcae4...721c507.html" title="Last updated on Sep 18, 2018, 4:47 PM GMT (721c507)">Diff</a>