### PR TITLE
Adopt consistent case for section headings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -296,7 +296,7 @@ scenarios. Additional scenarios, including sample code, are given later in [[#sa
     * Web page shows that the selected user is signed in, and navigates to the signed-in page.
 
 
-### New device registration ### {#usecase-new-device-registration}
+### New Device Registration ### {#usecase-new-device-registration}
 
 This use case scenario illustrates how a [=[RP]=] can leverage a combination of a [=roaming authenticator=] (e.g., a USB security
 key fob) and a [=platform authenticator=] (e.g., a built-in fingerprint sensor) such that the user has:
@@ -336,7 +336,7 @@ Note: This approach of registering multiple [=authenticators=] for an account is
     * Website shows that the user is signed in, and navigates to the signed-in page.
 
 
-### Other use cases and configurations ### {#other-configurations}
+### Other Use Cases and Configurations ### {#other-configurations}
 
 A variety of additional use cases and configurations are also possible, including (but not limited to):
 
@@ -868,7 +868,7 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 </xmp>
 
 
-### Create a new credential - PublicKeyCredential's `[[Create]](origin, options, sameOriginWithAncestors)` method ### {#createCredential}
+### Create a New Credential - PublicKeyCredential's `[[Create]](origin, options, sameOriginWithAncestors)` Method ### {#createCredential}
 
 <div link-for-hint="PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)">
 {{PublicKeyCredential}}'s [=interface object=]'s implementation of the <dfn for="PublicKeyCredential" method>\[[Create]](origin,
@@ -1216,7 +1216,7 @@ authorizing an authenticator.
 </div>
 
 
-### Use an existing credential to make an assertion - PublicKeyCredential's `[[Get]](options)` method ### {#getAssertion}
+### Use an Existing Credential to Make an Assertion - PublicKeyCredential's `[[Get]](options)` Method ### {#getAssertion}
 
 [=[WRPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
 discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[RP]=] script optionally specifies some criteria
@@ -1241,7 +1241,7 @@ This
 {{CredentialsContainer/get()|navigator.credentials.get()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
 
-<h5 id="discover-from-external-source" algorithm>PublicKeyCredential's <code><dfn for="PublicKeyCredential" method>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn></code> method</h5>
+#### PublicKeyCredential's <code><dfn for="PublicKeyCredential" method>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn></code> Method #### {#discover-from-external-source}
 
 <div link-for-hint="PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)">
 
@@ -1579,7 +1579,7 @@ authorizing an authenticator with which to complete the operation.
 </div>
 
 
-### Store an existing credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` method ### {#storeCredential}
+### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Method ### {#storeCredential}
 
 <div link-for-hint="PublicKeyCredential/[[Store]](credential, sameOriginWithAncestors)">
 
@@ -1606,7 +1606,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 </div>
 
-###  Preventing silent access to an existing credential - PublicKeyCredential's `[[preventSilentAccess]](credential, sameOriginWithAncestors)` method ### {#preventSilentAccessCredential}
+###  Preventing Silent Access to an Existing Credential - PublicKeyCredential's `[[preventSilentAccess]](credential, sameOriginWithAncestors)` Method ### {#preventSilentAccessCredential}
 
 <div link-for-hint="PublicKeyCredential/[[preventSilentAccess]](credential, sameOriginWithAncestors)">
 
@@ -1618,7 +1618,7 @@ This [=internal method=] accepts no arguments.
 
 </div>
 
-### Availability of [=User-Verifying Platform Authenticator=] - PublicKeyCredential's `isUserVerifyingPlatformAuthenticatorAvailable()` method ### {#isUserVerifyingPlatformAuthenticatorAvailable}
+### Availability of [=User-Verifying Platform Authenticator=] - PublicKeyCredential's `isUserVerifyingPlatformAuthenticatorAvailable()` Method ### {#isUserVerifyingPlatformAuthenticatorAvailable}
 
 <div link-for-hint="WebAuthentication/isUserVerifyingPlatformAuthenticatorAvailable">
 
@@ -1655,7 +1655,7 @@ This method has no arguments and returns a Boolean value.
         authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}.
 </div>
 
-### Information about Public Key Credential (interface <dfn interface>AuthenticatorAttestationResponse</dfn>) ### {#iface-authenticatorattestationresponse}
+### Information About Public Key Credential (interface <dfn interface>AuthenticatorAttestationResponse</dfn>) ### {#iface-authenticatorattestationresponse}
 
 The {{AuthenticatorAttestationResponse}} interface represents the [=authenticator=]'s response to a client's request
 for the creation of a new [=public key credential=]. It contains information about the new credential that can be used to
@@ -1955,7 +1955,7 @@ attributes.
 </div>
 
 
-### Authenticator Attachment enumeration (enum <dfn enum>AuthenticatorAttachment</dfn>) ### {#attachment}
+### Authenticator Attachment Enumeration (enum <dfn enum>AuthenticatorAttachment</dfn>) ### {#attachment}
 
 <xmp class="idl">
     enum AuthenticatorAttachment {
@@ -1995,7 +1995,7 @@ operation has no [=authenticator attachment modality=] selection option, so the 
 credential|credentials=]. The [=client=] and user will then use whichever is available and convenient at the time.
 
 
-### <dfn>Attestation Conveyance</dfn> Preference enumeration (enum <dfn enum>AttestationConveyancePreference</dfn>) ### {#attestation-convey}
+### <dfn>Attestation Conveyance</dfn> Preference Enumeration (enum <dfn enum>AttestationConveyancePreference</dfn>) ### {#attestation-convey}
 
 [=[WRPS]=] may use {{AttestationConveyancePreference}} to specify their preference regarding [=attestation conveyance=]
 during credential generation.
@@ -2079,7 +2079,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
 </dl>
 
 
-## Abort operations with `AbortSignal` ## {#abortoperation}
+## Abort Operations with `AbortSignal` ## {#abortoperation}
 
 Developers are encouraged to leverage the {{AbortController}} to manage the 
 {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} operations.
@@ -2142,7 +2142,7 @@ The [=public key credential=] type uses certain data structures that are specifi
 follows.
 
 
-### Client data used in WebAuthn signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
+### Client Data Used in WebAuthn Signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#sec-client-data}
 
 The <dfn>client data</dfn> represents the contextual bindings of both the [=[WRP]=] and the [=client=]. It is a key-value
 mapping whose keys are strings. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
@@ -2213,7 +2213,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
 </div>
 
 
-### Credential Type enumeration (enum <dfn enum>PublicKeyCredentialType</dfn>) ### {#credentialType}
+### Credential Type Enumeration (enum <dfn enum>PublicKeyCredentialType</dfn>) ### {#credentialType}
 
 <xmp class="idl">
     enum PublicKeyCredentialType {
@@ -2257,7 +2257,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 </div>
 
 
-### Authenticator Transport enumeration (enum <dfn enum>AuthenticatorTransport</dfn>) ### {#transport}
+### Authenticator Transport Enumeration (enum <dfn enum>AuthenticatorTransport</dfn>) ### {#transport}
 
 <xmp class="idl">
     enum AuthenticatorTransport {
@@ -2303,7 +2303,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 </div>
 
 
-### User Verification Requirement enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
+### User Verification Requirement Enumeration (enum <dfn enum>UserVerificationRequirement</dfn>) ### {#userVerificationRequirement}
 
 <xmp class="idl">
     enum UserVerificationRequirement {
@@ -2410,7 +2410,7 @@ Authenticators produce cryptographic signatures for two distinct purposes:
 
 The formats of these signatures, as well as the procedures for generating them, are specified below.
 
-## Authenticator data ## {#sec-authenticator-data}
+## Authenticator Data ## {#sec-authenticator-data}
 
 The <dfn>authenticator data</dfn> structure encodes contextual bindings made by the [=authenticator=]. These bindings are
 controlled by the authenticator itself, and derive their trust from the [=[WRP]=]'s assessment of the security properties of the
@@ -2543,7 +2543,7 @@ Authenticators:
     accidentally decrease  (e.g., due to hardware failures).
 
 
-### FIDO U2F signature format compatibility ### {#sctn-fido-u2f-sig-format-compat}
+### FIDO U2F Signature Format Compatibility ### {#sctn-fido-u2f-sig-format-compat}
 
 The format for [=assertion signatures=], which sign over the concatenation of an [=authenticator data=] structure and the [=hash
 of the serialized client data=], are compatible with the FIDO U2F authentication signature format (see [=Section 5.4=] of
@@ -2557,7 +2557,7 @@ This is because the first 37 bytes of the signed data in a FIDO U2F authenticati
 the same procedure as other [=assertion signatures=] generated by the [=authenticatorMakeCredential=] operation.
 
 
-## Authenticator taxonomy ## {#sctn-authenticator-taxonomy}
+## Authenticator Taxonomy ## {#sctn-authenticator-taxonomy}
 
 [=Authenticator=] types vary along several different dimensions: [=authenticator attachment modality=], employed [[#transport|transport(s)]],
 [=credential storage modality=], and [=authentication factor capability=]. The combination of these dimensions defines an
@@ -2706,7 +2706,7 @@ The [=[RP]=] can therefore use the [=UV=] flag to verify that additional [=authe
 [=authenticator=]'s [=attestation statement=].
 
 
-## <dfn>Authenticator operations</dfn> ## {#authenticator-ops}
+## <dfn>Authenticator Operations</dfn> ## {#authenticator-ops}
 
 A [=[WAC]=] MUST connect to an authenticator in order to invoke any of the operations of that authenticator. This connection
 defines an <dfn>authenticator session</dfn>. An authenticator must maintain isolation between sessions. It may do this by only allowing one
@@ -2715,7 +2715,7 @@ session to exist at any particular time, or by providing more complicated sessio
 The following operations can be invoked by the client in an authenticator session.
 
 
-<h4 id="op-lookup-credsource-by-credid" algorithm>Lookup Credential Source by Credential ID algorithm</h4>
+### Lookup Credential Source by Credential ID Algorithm ### {#op-lookup-credsource-by-credid}
 
 The result of <dfn for="credential id">looking up</dfn> a [=credential id=] |credentialId| in an [=authenticator=]
 |authenticator| is the result of the following algorithm:
@@ -2727,7 +2727,7 @@ The result of <dfn for="credential id">looking up</dfn> a [=credential id=] |cre
 1. Return `null`.
 
 
-<h4 id="op-make-cred" algorithm>The <dfn>authenticatorMakeCredential</dfn> operation</h4>
+### The <dfn>authenticatorMakeCredential</dfn> Operation ### {#op-make-cred}
 
 It takes the following input parameters:
 
@@ -2860,7 +2860,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 On successful completion of this operation, the authenticator returns the [=attestation object=] to the client.
 
 
-<h4 id="op-get-assertion" algorithm> The <dfn>authenticatorGetAssertion</dfn> operation</h4>
+### The <dfn>authenticatorGetAssertion</dfn> Operation ### {#op-get-assertion}
 
 It takes the following input parameters:
 
@@ -2963,7 +2963,7 @@ If the [=authenticator=] cannot find any [=public key credential|credential=] co
 matches the specified criteria, it terminates the operation and returns an error.
 
 
-### The <dfn>authenticatorCancel</dfn> operation ### {#op-cancel}
+### The <dfn>authenticatorCancel</dfn> Operation ### {#op-cancel}
 
 This operation takes no input parameters and returns no result.
 
@@ -3032,7 +3032,7 @@ understand the characteristics of the [=authenticators=] that they trust, based 
 [=authenticators=]. For example, the FIDO Metadata Service [[FIDOMetadataService]] provides one way to access such information.
 
 
-### Attested credential data ### {#sec-attested-credential-data}
+### Attested Credential Data ### {#sec-attested-credential-data}
 
 <dfn>Attested credential data</dfn> is a variable-length byte array added to the [=authenticator data=] when generating an [=attestation
 object=] for a given credential. Its format is shown in [Table 3](#table-attestedCredentialData).
@@ -3079,7 +3079,7 @@ object=] for a given credential. Its format is shown in [Table 3](#table-atteste
     </figcaption>
 </figure>
 
-#### Examples of `credentialPublicKey` Values encoded in COSE_Key format #### {#sctn-encoded-credPubKey-examples}
+#### Examples of `credentialPublicKey` Values Encoded in COSE_Key Format #### {#sctn-encoded-credPubKey-examples}
 
 This section provides examples of COSE_Key-encoded Elliptic Curve and RSA public keys for the ES256, PS256, and RS256
 signature algorithms. These examples adhere to the rules defined above for the [=credentialPublicKey=] value, and are presented in [[CDDL]] for clarity. 
@@ -3223,7 +3223,7 @@ WebAuthn supports multiple attestation types:
 : No attestation statement (<dfn>None</dfn>)
 :: In this case, no attestation information is available. See also [[#none-attestation]].
 
-<h4 id="generating-an-attestation-object" algorithm>Generating an Attestation Object</h4>
+### Generating an Attestation Object ### {#generating-an-attestation-object}
 
 To generate an [=attestation object=] (see: [Figure 5](#fig-attStructs)) given:
 
@@ -3295,7 +3295,7 @@ the scope of this specification. This section describes the operations that the 
 structures.
 
 
-## Registering a new credential ## {#registering-a-new-credential}
+## Registering a New Credential ## {#registering-a-new-credential}
 
 When registering a new credential, represented by an {{AuthenticatorAttestationResponse}} structure |response| and an
 {{AuthenticationExtensionsClientOutputs}} structure |clientExtensionResults|, as part of a [=registration ceremony=], a
@@ -3398,7 +3398,7 @@ intermediate CA certificates. The [=[RP]=] MUST also be able to build the attest
 provide this chain in the attestation information.
 
 
-## Verifying an authentication assertion ## {#verifying-assertion}
+## Verifying an Authentication Assertion ## {#verifying-assertion}
 
 When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {{AuthenticationExtensionsClientOutputs}} structure
 |clientExtensionResults|, as part of an [=authentication ceremony=], the [=[RP]=] MUST proceed as follows:
@@ -3627,7 +3627,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
             - If successful, return attestation type [=Self=] and empty [=attestation trust path=].
 
 
-### Packed attestation statement certificate requirements ### {#packed-attestation-cert-requirements}
+### Packed Attestation Statement Certificate Requirements ### {#packed-attestation-cert-requirements}
 
 The attestation certificate MUST have the following fields/extensions:
 
@@ -3779,7 +3779,7 @@ engine.
     - If successful, return attestation type [=ECDAA=] and the [=identifier of the ECDAA-Issuer public key=] |ecdaaKeyId|.
 
 
-### TPM attestation statement certificate requirements ### {#tpm-cert-requirements}
+### TPM Attestation Statement Certificate Requirements ### {#tpm-cert-requirements}
 
 TPM [=attestation certificate=] MUST have the following fields/extensions:
 
@@ -4140,7 +4140,7 @@ See the IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn
 for an up-to-date list of registered WebAuthn Extension Identifiers.
 
 
-## Defining extensions ## {#sctn-extension-specification}
+## Defining Extensions ## {#sctn-extension-specification}
 
 A definition of an extension MUST specify an [=extension identifier=], a [=client extension input=] argument
 to be sent via the {{CredentialsContainer/get()}} or {{CredentialsContainer/create()}} call,
@@ -4159,7 +4159,7 @@ extension=] that does not otherwise require any result values MUST return a valu
 [=authenticator extension output=] result, set to [TRUE] to signify that the extension was understood and processed.
 
 
-## Extending request parameters ## {#sctn-extension-request-parameters}
+## Extending Request Parameters ## {#sctn-extension-request-parameters}
 
 An extension defines one or two request arguments. The <dfn>client extension input</dfn>,
 which is a value that can be encoded in JSON, is passed from the [=[WRP]=] to the client
@@ -4197,7 +4197,7 @@ Note: Extensions should aim to define authenticator arguments that are as small 
     over low-bandwidth links such as Bluetooth Low-Energy or NFC.
 
 
-## <dfn>Client extension processing</dfn> ## {#sctn-client-extension-processing}
+## <dfn>Client Extension Processing</dfn> ## {#sctn-client-extension-processing}
 
 Extensions MAY define additional processing requirements on the [=client=] during the creation of credentials or the
 generation of an assertion. The [=client extension input=] for the extension is used as an input to this client processing.
@@ -4213,7 +4213,7 @@ Extensions that require authenticator processing MUST define
 the process by which the [=client extension input=] can be used to determine the [=CBOR=] [=authenticator extension input=] and
 the process by which the [=CBOR=] [=authenticator extension output=] can be used to determine the [=client extension output=].
 
-## <dfn>Authenticator extension processing</dfn> ## {#sctn-authenticator-extension-processing}
+## <dfn>Authenticator Extension Processing</dfn> ## {#sctn-authenticator-extension-processing}
 
 The [=CBOR=] [=authenticator extension input=] value of each processed [=authenticator extension=] is included in the |extensions|
 parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion=] operations. The |extensions| parameter is a
@@ -4845,7 +4845,7 @@ such as registering -257 for "RS256".
 - Reference: Section 4.2 of [[!FIDOEcdaaAlgorithm]]
 - Recommended: Yes
 
-# Sample scenarios # {#sample-scenarios}
+# Sample Scenarios # {#sample-scenarios}
 
 [INFORMATIVE]
 
@@ -5249,7 +5249,7 @@ concern in most [=[RPS]=]' threat models. For example, the [=man-in-the-middle a
 [=man-in-the-middle attack=] against a [=[RP]=] that only uses conventional password authentication.
 
 
-## credentialId Unsigned ## {#credentialIdSecurity}
+## Credential ID Unsigned ## {#credentialIdSecurity}
 
 The [=credential ID=] is not signed.
 This is not a problem because all that would happen if an [=authenticator=] returns
@@ -5270,7 +5270,7 @@ which SHOULD make use of the existing browser permissions framework for the Geol
 The privacy principles in [[!FIDO-Privacy-Principles]] also apply to this specification.
 
 
-## De-anonymization prevention measures ## {#sctn-privacy-attacks}
+## De-anonymization Prevention Measures ## {#sctn-privacy-attacks}
 
 [INFORMATIVE]
 
@@ -5308,7 +5308,7 @@ Some of the above information is necessarily shared with the [=[RP]=]. The follo
 prevent malicious [=[RPS]=] from using it to discover a user's personal identity.
 
 
-## Anonymous, scoped, non-correlatable [=public key credentials=] ## {#sec-non-correlatable-credentials}
+## Anonymous, Scoped, Non-correlatable [=Public Key Credentials=] ## {#sec-non-correlatable-credentials}
 
 [INFORMATIVE]
 
@@ -5339,7 +5339,7 @@ handle=] specified by the [=[RP]=]. The [=public key credential|credential=] can
 without a traditional username, further improving non-correlatability between [=[RPS]=].
 
 
-## Authenticator-local [=biometric recognition=] ## {#sec-biometric-privacy}
+## Authenticator-local [=Biometric Recognition=] ## {#sec-biometric-privacy}
 
 [=Biometric authenticators=] perform the [=biometric recognition=] internally in the [=authenticator=] - though for [=platform
 authenticators=] the biometric data might also be visible to the [=client=], depending on the implementation. Biometric data is
@@ -5421,14 +5421,14 @@ one of the [=public key credential|credentials=] listed in the {{PublicKeyCreden
 available to the user.
 
 
-## Privacy between operating system accounts ## {#sctn-os-account-privacy}
+## Privacy Between Operating System Accounts ## {#sctn-os-account-privacy}
 
 If a [=platform authenticator=] is included in a [=client device=] with a multi-user operating system, the [=platform
 authenticator=] and [=client device=] SHOULD work together to ensure that the existence of any [=platform credential=] is revealed
 only to the operating system user that created that [=platform credential=].
 
 
-## Privacy of [PII] stored in authenticators ## {#sctn-pii-privacy}
+## Privacy of [PII] Stored in Authenticators ## {#sctn-pii-privacy}
 
 [=Authenticators=] MAY provide additional information to [=clients=] outside what's defined by this specification, e.g.,
 to enable the [=client=] to provide a rich UI with which the user can pick which [=credential=] to use for an [=authentication
@@ -5444,7 +5444,7 @@ These recommendations serve to prevent an adversary with physical access to an [
 [=authenticator=]'s enrolled user(s).
 
 
-## User Handle contents ## {#sctn-user-handle-privacy}
+## User Handle Contents ## {#sctn-user-handle-privacy}
 
 Since the [=user handle=] is not considered [PII] in [[#sctn-pii-privacy]], the [=[RP]=] SHOULD NOT include [PII], e.g., e-mail
 addresses or usernames, in the [=user handle=]. This includes hash values of [PII], unless the hash


### PR DESCRIPTION
This fixes #1040.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1055.html" title="Last updated on Sep 5, 2018, 11:27 AM GMT (e29dbac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1055/035ea79...e29dbac.html" title="Last updated on Sep 5, 2018, 11:27 AM GMT (e29dbac)">Diff</a>