### PR TITLE
use 'attacker' instead of 'user'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5408,9 +5408,9 @@ only to the operating system user that created that [=platform credential=].
 ## Username Enumeration ## {#sctn-username-enumeration}
 
 While initiating a [=registration ceremony|registration=] or [=authentication ceremony=], there is a risk that the [=[WRP]=] might leak sensitive
-information about its registered users. For example, if a [=[RP]=] uses e-mail addresses as usernames and a user attempts to
+information about its registered users. For example, if a [=[RP]=] uses e-mail addresses as usernames and an attacker attempts to
 initiate an [=authentication=] [=ceremony=] for "alex.p.mueller@example.com" and the [=[RP]=] responds with a failure, but then
-successfully initiates an [=authentication ceremony=] for "j.doe@example.com", then the user can conclude that "j.doe@example.com"
+successfully initiates an [=authentication ceremony=] for "j.doe@example.com", then the attacker can conclude that "j.doe@example.com"
 is registered and "alex.p.mueller@example.com" is not. The [=[RP]=] has thus leaked the possibly sensitive information that
 "j.doe@example.com" has an account at this [=[RP]=].
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1058.html" title="Last updated on Sep 5, 2018, 4:25 PM GMT (e320eb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1058/dbdf619...e320eb5.html" title="Last updated on Sep 5, 2018, 4:25 PM GMT (e320eb5)">Diff</a>