### PR TITLE
enumerate actual supported attstn types for packed attestation statement format

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3593,7 +3593,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
 :: packed
 
 : Attestation types supported
-:: All
+:: [=Basic=], [=Self=], [=AttCA=], [=ECDAA=]
 
 : Syntax
 :: The syntax of a Packed Attestation statement is defined by the following CDDL:


### PR DESCRIPTION
fixes #1065


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1066.html" title="Last updated on Sep 12, 2018, 10:56 PM GMT (d4faac9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1066/b90f7f5...d4faac9.html" title="Last updated on Sep 12, 2018, 10:56 PM GMT (d4faac9)">Diff</a>