### PR TITLE
Spell out that values expressing attestation type are implementation specific

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3178,7 +3178,7 @@ template:
 
     The procedure returns either:
     - An error indicating that the attestation is invalid, or
-    - The [=attestation type=], and the [=attestation trust path|trust path=]. This <dfn>attestation trust path</dfn> is either
+    - An implementation-specific value representing the [=attestation type=], and the [=attestation trust path|trust path=]. This <dfn>attestation trust path</dfn> is either
         empty (in case of [=self attestation=]), an identifier of an [=ECDAA-Issuer public key=] (in the case of [=ECDAA=]), or a
         set of X.509 certificates.
 


### PR DESCRIPTION
See https://github.com/w3c/webauthn/pull/1054#discussion_r218033959


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1070.html" title="Last updated on Sep 17, 2018, 11:37 AM GMT (80eaffe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1070/5517fee...80eaffe.html" title="Last updated on Sep 17, 2018, 11:37 AM GMT (80eaffe)">Diff</a>