### PR TITLE
Make implementation-specificness of attestn.verif. return values more explicit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3949,12 +3949,12 @@ even if the SafetyNet API is also present.
         contained fields.
     - Verify that |response| is a valid SafetyNet response of version |ver|.
     - Verify that the nonce in the |response| is identical to the Base64url encoding of the SHA-256 hash of the concatenation of |authenticatorData| and |clientDataHash|.
-    - Let |attestationCert| be the attestation certificate.
+    - Let |attestationCert| be the [=attestation certificate=].
     - Verify that |attestatioCert| is issued to the hostname "attest.android.com" (see
         [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response)).
     - Verify that the `ctsProfileMatch` attribute in the payload of |response| is [TRUE].
-    - If successful, return implementation-specific values representing attestation type [=Basic=] and [=attestation trust path=]
-        |attestationCert|.
+    - If successful, return implementation-specific values representing [=attestation type=] [=Basic=] and [=attestation trust
+        path=] |attestationCert|.
 
 
 ## FIDO U2F Attestation Statement Format ## {#fido-u2f-attestation}

--- a/index.bs
+++ b/index.bs
@@ -3632,19 +3632,21 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
                 value of this extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
             - Optionally, inspect |x5c| and consult externally provided knowledge to determine whether |attStmt| conveys a
                 [=Basic=] or [=AttCA=] attestation.
-            - If successful, return attestation type [=Basic=] or [=AttCA=], or an implementation-specific value expressing
-                uncertainty, and in either case also return [=attestation trust path=] |x5c|.
+            - If successful, return implementation-specific values representing [=attestation type=] [=Basic=], [=AttCA=] or
+                uncertainty, and [=attestation trust path=] |x5c|.
 
         1. If |ecdaaKeyId| is present, then the attestation type is [=ECDAA=]. In this case:
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using
                 ECDAA-Verify with [=ECDAA-Issuer public key=] identified by |ecdaaKeyId| (see [[!FIDOEcdaaAlgorithm]]).
-            - If successful, return attestation type [=ECDAA=] and [=attestation trust path=] |ecdaaKeyId|.
+            - If successful, return implementation-specific values representing [=attestation type=] [=ECDAA=] and [=attestation
+                trust path=] |ecdaaKeyId|.
 
         1. If neither |x5c| nor |ecdaaKeyId| is present, [=self attestation=] is in use.
             - Validate that |alg| matches the algorithm of the <code>[=credentialPublicKey=]</code> in |authenticatorData|.
             - Verify that |sig| is a valid signature over the concatenation of |authenticatorData| and |clientDataHash| using the
                 credential public key with |alg|.
-            - If successful, return attestation type [=Self=] and empty [=attestation trust path=].
+            - If successful, return implementation-specific values representing [=attestation type=] [=Self=] and an empty
+                [=attestation trust path=].
 
 
 ### Packed Attestation Statement Certificate Requirements ### {#packed-attestation-cert-requirements}
@@ -3792,11 +3794,13 @@ engine.
     - Verify that |aikCert| meets the requirements in [[#tpm-cert-requirements]].
     - If |aikCert| contains an extension with OID `1 3 6 1 4 1 45724 1 1 4` (id-fido-gen-ce-aaguid) verify that the value of this
         extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
-    - If successful, return attestation type [=AttCA=] and [=attestation trust path=] |x5c|.
+    - If successful, return implementation-specific values representing [=attestation type=] [=AttCA=] and [=attestation trust
+        path=] |x5c|.
 
     If |ecdaaKeyId| is present, then the attestation type is [=ECDAA=].
     - Perform ECDAA-Verify on |sig| to verify that it is a valid signature over |certInfo| (see [[!FIDOEcdaaAlgorithm]]).
-    - If successful, return attestation type [=ECDAA=] and the [=identifier of the ECDAA-Issuer public key=] |ecdaaKeyId|.
+    - If successful, return implementation-specific values representing [=attestation type=] [=ECDAA=] and [=attestation trust
+        path=] |ecdaaKeyId|.
 
 
 ### TPM Attestation Statement Certificate Requirements ### {#tpm-cert-requirements}
@@ -3883,7 +3887,8 @@ the attestation=] is consistent with the fields of the attestation certificate's
             [=RP ID=].
         - The value in the `AuthorizationList.origin` field is equal to `KM_TAG_GENERATED`.
         - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
-    - If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
+    - If successful, return implementation-specific values representing [=attestation type=] [=Basic=] and [=attestation trust
+        path=] |x5c|.
 
 
 ## Android SafetyNet Attestation Statement Format ## {#android-safetynet-attestation}
@@ -3944,10 +3949,12 @@ even if the SafetyNet API is also present.
         contained fields.
     - Verify that |response| is a valid SafetyNet response of version |ver|.
     - Verify that the nonce in the |response| is identical to the Base64url encoding of the SHA-256 hash of the concatenation of |authenticatorData| and |clientDataHash|.
-    - Verify that the attestation certificate is issued to the hostname "attest.android.com" (see
+    - Let |attestationCert| be the attestation certificate.
+    - Verify that |attestatioCert| is issued to the hostname "attest.android.com" (see
         [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response)).
     - Verify that the `ctsProfileMatch` attribute in the payload of |response| is [TRUE].
-    - If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to the above attestation certificate.
+    - If successful, return implementation-specific values representing attestation type [=Basic=] and [=attestation trust path=]
+        |attestationCert|.
 
 
 ## FIDO U2F Attestation Statement Format ## {#fido-u2f-attestation}
@@ -4024,8 +4031,8 @@ This attestation statement format is used with FIDO U2F authenticators using the
     1. Verify the |sig| using |verificationData| and |certificate public key| per [[!SEC1]].
     1. Optionally, inspect |x5c| and consult externally provided knowledge to determine whether |attStmt| conveys a [=Basic=] or
         [=AttCA=] attestation.
-    1. If successful, return attestation type [=Basic=] or [=AttCA=], or an implementation-specific value expressing uncertainty,
-        and in either case also return [=attestation trust path=] |x5c|.
+    1. If successful, return implementation-specific values representing [=attestation type=] [=Basic=], [=AttCA=] or uncertainty,
+        and [=attestation trust path=] |x5c|.
 
 ## None Attestation Statement Format ## {#none-attestation}
 
@@ -4053,7 +4060,7 @@ The none attestation statement format is used to replace any [=authenticator=]-p
 :: Return the fixed attestation statement defined above.
 
 : Verification procedure
-:: Return attestation type [=None=] with an empty trust path.
+:: Return implementation-specific values representing [=attestation type=] [=None=] and an empty [=attestation trust path=].
 
 # WebAuthn Extensions # {#extensions}
 


### PR DESCRIPTION
See https://github.com/w3c/webauthn/pull/1054#discussion_r218275982


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1071.html" title="Last updated on Sep 18, 2018, 4:44 PM GMT (b254086)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1071/4acaf43...b254086.html" title="Last updated on Sep 18, 2018, 4:44 PM GMT (b254086)">Diff</a>