### PR TITLE
Clarify use of authorization lists in Android Key Attestation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3864,7 +3864,7 @@ TPM [=attestation certificate=] MUST have the following fields/extensions:
 
 When the [=authenticator=] in question is a platform-provided Authenticator on the Android "N" or later platform, the
 attestation statement is based on the [Android key
-attestation](https://developer.android.com/preview/api-overview.html#key_attestation). In these cases, the attestation statement
+attestation](https://source.android.com/security/keystore/attestation). In these cases, the attestation statement
 is produced by a component running in a secure operating environment, but the [=authenticator data for the attestation=] is
 produced outside this environment. The [=[WRP]=] is expected to check that the [=authenticator data claimed to have been used for
 the attestation=] is consistent with the fields of the attestation certificate's extension data.
@@ -3918,12 +3918,14 @@ the attestation=] is consistent with the fields of the attestation certificate's
         public key in the first certificate in |x5c| with the algorithm specified in |alg|.
     - Verify that the public key in the first certificate in |x5c| matches the
         <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authenticatorData|.
-    - Verify that in the attestation certificate extension data:
-        - The value of the `attestationChallenge` field is identical to |clientDataHash|.
-        - The `AuthorizationList.allApplications` field is <em>not</em> present, since PublicKeyCredential MUST be [=scoped=] to the
-            [=RP ID=].
-        - The value in the `AuthorizationList.origin` field is equal to `KM_TAG_GENERATED`.
-        - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
+    - Verify that the `attestationChallenge` field in the attestation certificate extension data is identical to |clientDataHash|.
+    - Verify the following using the appropriate authorization list from the attestation certificate extension data:
+        - The `AuthorizationList.allApplications` field is <em>not</em> present on either authorization list
+            (`softwareEnforced` nor `teeEnforced`), since PublicKeyCredential MUST be [=scoped=] to the [=RP ID=].
+        - For the following, use only the `teeEnforced` authorization list if the RP wants to accept only keys from a
+            trusted execution environment, otherwise use the union of `teeEnforced` and `softwareEnforced`.
+            - The value in the `AuthorizationList.origin` field is equal to `KM_ORIGIN_GENERATED`.
+            - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
     - If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
 
 

--- a/index.bs
+++ b/index.bs
@@ -3918,8 +3918,10 @@ the attestation=] is consistent with the fields of the attestation certificate's
         public key in the first certificate in |x5c| with the algorithm specified in |alg|.
     - Verify that the public key in the first certificate in |x5c| matches the
         <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authenticatorData|.
-    - Verify that the `attestationChallenge` field in the attestation certificate extension data is identical to |clientDataHash|.
-    - Verify the following using the appropriate authorization list from the attestation certificate extension data:
+    - Verify that the `attestationChallenge` field in the [=attestation certificate=]
+        [=android key attestation certificate extension data|extension data=] is identical to |clientDataHash|.
+    - Verify the following using the appropriate authorization list from the attestation certificate
+        [=android key attestation certificate extension data|extension data=]:
         - The `AuthorizationList.allApplications` field is <em>not</em> present on either authorization list
             (`softwareEnforced` nor `teeEnforced`), since PublicKeyCredential MUST be [=scoped=] to the [=RP ID=].
         - For the following, use only the `teeEnforced` authorization list if the RP wants to accept only keys from a
@@ -3928,6 +3930,10 @@ the attestation=] is consistent with the fields of the attestation certificate's
             - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
     - If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
 
+### Android Key Attestation Statement Certificate Requirements ### {#key-attstn-cert-requirements}
+
+Android Key Attestation [=attestation certificate=]'s <dfn>android key attestation certificate extension 
+data</dfn> is identified by the OID "1.3.6.1.4.1.11129.2.1.17". 
 
 ## Android SafetyNet Attestation Statement Format ## {#android-safetynet-attestation}
 


### PR DESCRIPTION
Closes #1022


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arnar/webauthn/pull/1072.html" title="Last updated on Sep 19, 2018, 7:35 PM GMT (8256039)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1072/e8ba348...arnar:8256039.html" title="Last updated on Sep 19, 2018, 7:35 PM GMT (8256039)">Diff</a>