### PR TITLE
Issue #294 - Add a non-normative comment about snapshotting BufferSources

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -958,6 +958,10 @@ This [=internal method=] accepts three arguments:
 Note: <strong>This algorithm is synchronous:</strong> the {{Promise}} resolution/rejection is handled by
 {{CredentialsContainer/create()|navigator.credentials.create()}}.
 
+Note: All {{BufferSource}} objects used in this algorithm must be snapshotted when the algorithm begins, to
+avoid potential synchronization issues. The algorithm implementations should [=get a copy of the bytes held
+by the buffer source=] and use that copy for relevant portions of the algorithm.
+
 When this method is invoked, the user agent MUST execute the following algorithm:
 
 1. Assert: <code>|options|.{{CredentialCreationOptions/publicKey}}</code> is [=present=].
@@ -1322,6 +1326,10 @@ This [=internal method=] accepts three arguments:
 
 Note: <strong>This algorithm is synchronous:</strong> the {{Promise}} resolution/rejection is handled by
 {{CredentialsContainer/get()|navigator.credentials.get()}}.
+
+Note: All {{BufferSource}} objects used in this algorithm must be snapshotted when the algorithm begins, to
+avoid potential synchronization issues. The algorithm implementations should [=get a copy of the bytes held
+by the buffer source=] and use that copy for relevant portions of the algorithm.
 
 When this method is invoked, the user agent MUST execute the following algorithm:
 

--- a/index.bs
+++ b/index.bs
@@ -196,6 +196,9 @@ spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
         text: something you know; url: af
         text: something you have; url: af
         text: something you are; url: af
+spec: webidl; urlPrefix: https://heycam.github.io/webidl
+    type: dfn;
+        text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-reference
 
 </pre> <!-- class=anchors -->
 


### PR DESCRIPTION
Slightly different text than https://github.com/w3c/webauthn/issues/294#issuecomment-422892053.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jcjones/webauthn/pull/1074.html" title="Last updated on Sep 19, 2018, 6:48 PM GMT (8f93864)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1074/16fee7b...jcjones:8f93864.html" title="Last updated on Sep 19, 2018, 6:48 PM GMT (8f93864)">Diff</a>