### PR TITLE
Un-revert change from 8e5f2e0 reverted in daf9522

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3968,7 +3968,8 @@ the attestation=] is consistent with the fields of the attestation certificate's
             trusted execution environment, otherwise use the union of `teeEnforced` and `softwareEnforced`.
             - The value in the `AuthorizationList.origin` field is equal to `KM_ORIGIN_GENERATED`.
             - The value in the `AuthorizationList.purpose` field is equal to `KM_PURPOSE_SIGN`.
-    - If successful, return attestation type [=Basic=] with the [=attestation trust path=] set to |x5c|.
+    - If successful, return implementation-specific values representing [=attestation type=] [=Basic=] and [=attestation trust
+        path=] |x5c|.
 
 ### Android Key Attestation Statement Certificate Requirements ### {#key-attstn-cert-requirements}
 


### PR DESCRIPTION
See https://github.com/w3c/webauthn/pull/1072#pullrequestreview-157217537

This fixes #1042.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1079.html" title="Last updated on Sep 20, 2018, 11:20 AM GMT (327af59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1079/daf9522...327af59.html" title="Last updated on Sep 20, 2018, 11:20 AM GMT (327af59)">Diff</a>