### PR TITLE
Clarify user identification in RP assertion verification operation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3501,9 +3501,19 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
     initiated, verify that <code>|credential|.{{Credential/id}}</code> identifies one of the [=public key credentials=] that were
     listed in {{PublicKeyCredentialRequestOptions/allowCredentials}}.
 
-1. If <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present, verify
-    that the user identified by this value is the owner of the [=public key credential=] identified by
-    <code>|credential|.{{Credential/id}}</code>.
+1. Identify the user being authenticated and verify that this user is the owner of the [=public key credential source=]
+    |credentialSource| identified by <code>|credential|.{{Credential/id}}</code>:
+
+    <dl class="switch">
+        :  If the user was identified before the [=authentication ceremony=] was initiated,
+        :: verify that that user is the owner of |credentialSource|. If
+            <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
+            verify that this value identifies the same user as was previously identified.
+
+        :  If the user was not identified before the [=authentication ceremony=] was initiated,
+        :: Verify that <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is
+            present, and that the user identified by this value is the owner of |credentialSource|.
+    </dl>
 
 1. Using |credential|'s {{Credential/id}} attribute (or the corresponding {{PublicKeyCredential/rawId}}, if
     [=base64url encoding=] is inappropriate for your use case), look up the corresponding credential public key.

--- a/index.bs
+++ b/index.bs
@@ -3506,12 +3506,12 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
 
     <dl class="switch">
         :  If the user was identified before the [=authentication ceremony=] was initiated,
-        :: verify that that user is the owner of |credentialSource|. If
+        :: verify that the identified user is the owner of |credentialSource|. If
             <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
             verify that this value identifies the same user as was previously identified.
 
         :  If the user was not identified before the [=authentication ceremony=] was initiated,
-        :: Verify that <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is
+        :: verify that <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is
             present, and that the user identified by this value is the owner of |credentialSource|.
     </dl>
 


### PR DESCRIPTION
This fixes #1078. Could arguably be technical and/or breaking, or arguably just editorial implementation consideration.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1082.html" title="Last updated on Dec 13, 2018, 12:18 PM GMT (6b3389c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1082/daf9522...6b3389c.html" title="Last updated on Dec 13, 2018, 12:18 PM GMT (6b3389c)">Diff</a>