### PR TITLE
Fix #1076 - Don't confuse extension optionality in Sec 10

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4347,7 +4347,7 @@ There MUST NOT be any values returned for ignored extensions.
 
 This section defines the initial set of extensions to be registered in the
 IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]].
-These are RECOMMENDED for implementation by user agents targeting broad interoperability.
+These can be implemented by user agents targeting broad interoperability.
 
 
 ## FIDO <dfn>AppID</dfn> Extension (appid) ## {#sctn-appid-extension}


### PR DESCRIPTION
Language from Mike Jones in https://github.com/w3c/webauthn/issues/1076#issuecomment-423028041


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jcjones/webauthn/pull/1083.html" title="Last updated on Sep 20, 2018, 3:01 PM GMT (2af689e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1083/76cf6df...jcjones:2af689e.html" title="Last updated on Sep 20, 2018, 3:01 PM GMT (2af689e)">Diff</a>