### PR TITLE
Fix typo in Figure 1

### DIFF
--- a/images/webauthn-registration-flow-01.svg
+++ b/images/webauthn-registration-flow-01.svg
@@ -870,7 +870,7 @@ Zf8Df8bEjWpeEHYAAAAASUVORK5CYII=
            y="17"
            x="0.33984375"
            font-weight="700"
-           font-size="16">PublicKeyCredentialCreateOptions</tspan>
+           font-size="16">PublicKeyCredentialCreationOptions</tspan>
       </text>
     </g>
   </g>

--- a/images/webauthn-registration-flow-01.svg
+++ b/images/webauthn-registration-flow-01.svg
@@ -790,7 +790,7 @@
            style="font-weight:700;font-size:16px;font-family:'Open Sans';fill:#0f71a9"
            id="tspan3841"
            y="17"
-           x="0.03125"
+           x="-5.03125"
            font-weight="700"
            font-size="16">AuthenticatorAttestationResponse</tspan>
       </text>


### PR DESCRIPTION
This fixes #1084. I also noticed a piece of the last letter in "AuthenticatorAttestationResponse" gets cropped, so I pulled that a little bit to the left too.