### PR TITLE
update token binding citation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -118,7 +118,7 @@ spec: HTML53; urlPrefix: https://w3c.github.io/html/
 
 spec: TokenBinding; urlPrefix: https://tools.ietf.org/html/rfc8471#
     type: dfn
-        text: Token Binding
+        text: Token Binding; url: section-1
         text: Token Binding ID; url: section-3.2
 
 spec: credential-management-1; urlPrefix: https://w3c.github.io/webappsec-credential-management/
@@ -2258,7 +2258,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
         the syntax defined by [[RFC6454]].
 
     :   <dfn>tokenBinding</dfn>
-    ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol used when communicating
+    ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
         with the [=[RP]=]. Its absence indicates that the client doesn't support token binding.
 
         <div dfn-type="dict-member" dfn-for="TokenBinding">
@@ -5884,7 +5884,7 @@ for their contributions as our W3C Team Contacts.
     "title": "The Token Binding Protocol Version 1.0",
     "href": "https://tools.ietf.org/html/rfc8471",
     "status": "IETF Proposed Standard",
-    "date": "September, 2018"
+    "date": "October, 2018"
   },
 
   "EduPersonObjectClassSpec": {

--- a/index.bs
+++ b/index.bs
@@ -116,7 +116,7 @@ spec: HTML53; urlPrefix: https://w3c.github.io/html/
             text: scheme; url: origin-scheme
             text: port; url: origin-port
 
-spec: TokenBinding; urlPrefix: https://tools.ietf.org/html/draft-ietf-tokbind-protocol#
+spec: TokenBinding; urlPrefix: https://tools.ietf.org/html/rfc8471#
     type: dfn
         text: Token Binding
         text: Token Binding ID; url: section-3.2
@@ -5880,11 +5880,11 @@ for their contributions as our W3C Team Contacts.
   },
 
   "TokenBinding": {
-    "authors": ["A. Popov", "M. Nystroem", "D. Balfanz", "A. Langley", "J. Hodges"],
+    "authors": ["A. Popov", "M. Nystroem", "D. Balfanz", "J. Hodges"],
     "title": "The Token Binding Protocol Version 1.0",
-    "href": "https://tools.ietf.org/html/draft-ietf-tokbind-protocol",
-    "status": "Internet-Draft",
-    "date": "February 16, 2017"
+    "href": "https://tools.ietf.org/html/rfc8471",
+    "status": "IETF Proposed Standard",
+    "date": "September, 2018"
   },
 
   "EduPersonObjectClassSpec": {


### PR DESCRIPTION
This fixes #1086 in anticipation of the imminent publication of draft-ietf-tokbind-protocol as RFC8471 (see  https://www.rfc-editor.org/authors/rfc8471.txt)

see here for overall token binding specs' publication status:  https://www.rfc-editor.org/auth48/C366
(I think the publication of the "cluster" is now largely waiting on area director approval of an update we made to section 6 of rfc-to-be 8473)

to be clear: If we merge this PR before RFC8471 is published, then we will have a broken link. IF that is not OK, then perhaps we ought to wait decide whether to merge this until the day we wish to publish WebAuthn Level 1 as PropRec and land it if RFC8471 is published, otherwise not. 

supposedly there are to be no spec changes when transitioning from PropRec to Rec, but updating the actual reference in the bibliography to point to the RFC during said transition seems like a minor editorial item, no?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1087.html" title="Last updated on Oct 9, 2018, 6:55 PM GMT (f945730)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1087/2056fee...f945730.html" title="Last updated on Oct 9, 2018, 6:55 PM GMT (f945730)">Diff</a>