### PR TITLE
Use "user handle mapped to user" language in user identification step

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3501,9 +3501,19 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
     initiated, verify that <code>|credential|.{{Credential/id}}</code> identifies one of the [=public key credentials=] that were
     listed in {{PublicKeyCredentialRequestOptions/allowCredentials}}.
 
-1. If <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present, verify
-    that the user identified by this value is the owner of the [=public key credential=] identified by
-    <code>|credential|.{{Credential/id}}</code>.
+1. Identify the user being authenticated and verify that this user is the owner of the [=public key credential source=]
+    |credentialSource| identified by <code>|credential|.{{Credential/id}}</code>:
+
+    <dl class="switch">
+        :  If the user was identified before the [=authentication ceremony=] was initiated,
+        :: verify that that user is the owner of |credentialSource|. If
+            <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
+            verify that this value identifies the same user as was previously identified.
+
+        :  If the user was not identified before the [=authentication ceremony=] was initiated,
+        :: Verify that <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is
+            present, and that the user identified by this value is the owner of |credentialSource|.
+    </dl>
 
 1. Using |credential|'s {{Credential/id}} attribute (or the corresponding {{PublicKeyCredential/rawId}}, if
     [=base64url encoding=] is inappropriate for your use case), look up the corresponding credential public key.

--- a/index.bs
+++ b/index.bs
@@ -3505,7 +3505,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
     |credentialSource| identified by <code>|credential|.{{Credential/id}}</code>:
 
     <dl class="switch">
-        :  If the user was identified before the [=authentication ceremony=] was initiated,
+        :  If the user was identified before the [=authentication ceremony=] was initiated, e.g., via a username or cookie,
         :: verify that that user is the owner of |credentialSource|. If
             <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
             let |userHandle| be its value. Verify that |userHandle| is also mapped to the same user.

--- a/index.bs
+++ b/index.bs
@@ -3517,7 +3517,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
         :  If the user was identified before the [=authentication ceremony=] was initiated, e.g., via a username or cookie,
         :: verify that the identified user is the owner of |credentialSource|. If
             <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
-            let |userHandle| be its value. Verify that |userHandle| is also mapped to the same user.
+            let |userHandle| be its value. Verify that |userHandle| also maps to the same user.
 
         :  If the user was not identified before the [=authentication ceremony=] was initiated,
         :: verify that <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is

--- a/index.bs
+++ b/index.bs
@@ -3508,7 +3508,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
         :  If the user was identified before the [=authentication ceremony=] was initiated,
         :: verify that that user is the owner of |credentialSource|. If
             <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
-            verify that this value identifies the same user as was previously identified.
+            let |userHandle| be its value. Verify that |userHandle| is also mapped to the same user.
 
         :  If the user was not identified before the [=authentication ceremony=] was initiated,
         :: Verify that <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is


### PR DESCRIPTION
This would merge into PR #1082.

These are pretty much all the changes I managed to come up with based on the comments in https://github.com/w3c/webauthn/pull/1082#pullrequestreview-158780427. :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1091.html" title="Last updated on Feb 6, 2019, 12:51 PM UTC (10e5b47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1091/c610a95...10e5b47.html" title="Last updated on Feb 6, 2019, 12:51 PM UTC (10e5b47)">Diff</a>