### PR TITLE
Fix typos in get() algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1545,13 +1545,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
                                 ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|,
                                     invoke the [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|,
                                     |clientDataHash|, |allowCredentialDescriptorList|, |userPresence|, |userVerification|, and
-                                    |clientExtensions| as parameters.
+                                    |authenticatorExtensions| as parameters.
                             </dl>
 
                     :   [=list/is empty=]
                     ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|, invoke the
                         [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|, |clientDataHash|, |userPresence|,
-                        |userVerification| and |clientExtensions| as parameters.
+                        |userVerification| and |authenticatorExtensions| as parameters.
 
                         Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus, the
                             authenticator is being asked to exercise any credential it may possess that is [=scoped=] to


### PR DESCRIPTION
This fixes #1089.

Arguably editorial, but it does technically change the technical algorithm specification.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1092.html" title="Last updated on Oct 1, 2018, 1:59 PM GMT (24cd9df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1092/2056fee...24cd9df.html" title="Last updated on Oct 1, 2018, 1:59 PM GMT (24cd9df)">Diff</a>