### PR TITLE
In safetynet attestation "nonce" is base64, not base64url

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4035,7 +4035,7 @@ even if the SafetyNet API is also present.
     - Verify that |attStmt| is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract the
         contained fields.
     - Verify that |response| is a valid SafetyNet response of version |ver|.
-    - Verify that the nonce in the |response| is identical to the Base64url encoding of the SHA-256 hash of the concatenation of |authenticatorData| and |clientDataHash|.
+    - Verify that the nonce in the |response| is identical to the Base64 encoding of the SHA-256 hash of the concatenation of |authenticatorData| and |clientDataHash|.
     - Let |attestationCert| be the [=attestation certificate=].
     - Verify that |attestationCert| is issued to the hostname "attest.android.com" (see
         [SafetyNet online documentation](https://developer.android.com/training/safetynet/index.html#compat-check-response)).


### PR DESCRIPTION
cc @christiaanbrand @kpaulh


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/herrjemand/webauthn/pull/1093.html" title="Last updated on Oct 3, 2018, 8:56 AM GMT (7b487ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1093/2056fee...herrjemand:7b487ff.html" title="Last updated on Oct 3, 2018, 8:56 AM GMT (7b487ff)">Diff</a>