### PR TITLE
Add the word "OPTIONAL" to `userVerification` field to match surrounding style.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2145,7 +2145,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
         preferred credential, and so on down the list).
 
     :   <dfn>userVerification</dfn>
-    ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
+    ::  This OPTIONAL member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/get()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
         requirement.
 


### PR DESCRIPTION
Previously, `userVerification` was the only optional field of `PublicKeyCredentialRequestOptions` that didn't include the word "OPTIONAL" in the bullet descriptions, which can suggest at first glance that this field is not optional like the other optional ones. Adding the word is simple, and should avoid potential confusion.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29463 is a case where types based on this doc had this optional field as required (along with `rpId`). I don't know if that was a mistake or simply outdated, but the inconsistency in the word "OPTIONAL" made this a bit confusing to check at first.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgarron/webauthn/pull/1094.html" title="Last updated on Oct 5, 2018, 5:26 AM GMT (0225a13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1094/2056fee...lgarron:0225a13.html" title="Last updated on Oct 5, 2018, 5:26 AM GMT (0225a13)">Diff</a>