### PR TITLE
clarification of UP/UV flags in authenticator data structure

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2576,7 +2576,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 - Hash [=RP ID=] using SHA-256 to generate the [=rpIdHash=].
 
 - The `UP` [=flag=] SHALL be set if and only if the authenticator detected a user through an authenticator specific gesture. The
-    `RFU` bits SHALL be set to zero.
+    `RFU` bits SHALL be set to zero. The `UV` and `UP` [=flag=]s MAY both be set if the authenticator verified a user.
 
 - For [=attestation signatures=], the authenticator MUST set the AT [=flag=] and include the <code>[=attestedCredentialData=]</code>. 
     For [=assertion signature|authentication signatures=], the AT [=flag=] MUST NOT be set and the <code>[=attestedCredentialData=]</code> MUST NOT be included.


### PR DESCRIPTION
The User Presence (UP) and User Verification (UV) flags in the authenticator data structure (https://www.w3.org/TR/webauthn/#sec-authenticator-data) appear to have a similar purpose to the requireUserPresence and requireUserVerification input parameter booleans in the authenticatorMakeCredential operation. The requireUserPresence and requireUserVerification booleans are explicitly mutually exclusive -- if one is set the other must be unset. My understanding, after discussing the use case for the UP/UV flags, is that both MAY be set (i.e. not mutually exclusive). 

Example: The relying party may specify that user presence is required, but the authenticator may physically perform a user verification operation. In this case, the relying party may end up checking the UP flag and not the UV flag, so it seems like the authenticator should set both flags, not just the UV flag.

Just wanted to clarify this in the doc as there may be the potential for confusion during implementation. Or alternately, if there is a reason they should be mutually exclusive, the spec should probably specify that.