### PR TITLE
Clarify UP and UV flags in authenticator data section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2575,8 +2575,13 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 
 - Hash [=RP ID=] using SHA-256 to generate the [=rpIdHash=].
 
-- The `UP` [=flag=] SHALL be set if and only if the authenticator detected a user through an authenticator specific gesture. The
-    `RFU` bits SHALL be set to zero.
+- The `UP` [=flag=] SHALL be set if and only if the authenticator performed a [=test of user presence=].
+    The `UV` [=flag=] SHALL be set if and only if the authenticator performed [=user verification=].
+    The `RFU` bits SHALL be set to zero.
+
+    Note: If the authenticator performed both a [=test of user presence=] and [=user verification=],
+    possibly combined in a single [=authorization gesture=],
+    then the authenticator will set both the `UP` [=flag=] and the `UV` [=flag=].
 
 - For [=attestation signatures=], the authenticator MUST set the AT [=flag=] and include the <code>[=attestedCredentialData=]</code>. 
     For [=assertion signature|authentication signatures=], the AT [=flag=] MUST NOT be set and the <code>[=attestedCredentialData=]</code> MUST NOT be included.


### PR DESCRIPTION
This is a counter-proposal to #1108. Fixes #1112.