### PR TITLE
Match text for identical verification steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3431,7 +3431,7 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
     {{AuthenticatorAttestationResponse}} structure to obtain the attestation statement format |fmt|, the [=authenticator data=]
     |authData|, and the attestation statement |attStmt|.
 
-1. Verify that the [=RP ID=] hash in |authData| is indeed the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
+1. Verify that the <code>[=rpIdHash=]</code> in |authData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
 
 1. Verify that the [=User Present=] bit of the <code>[=flags=]</code> in |authData| is set.
 


### PR DESCRIPTION
When verifying the registration response, we use different text than the identical step in verifying assertion. The hash is also referred/linked as 'RP ID Hash'  in the registration step text, rather than being referred/linked as the more helpful `rpIdHash`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicksteele/webauthn/pull/1119.html" title="Last updated on Dec 12, 2018, 4:54 PM GMT (142cb06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1119/8fd57e3...nicksteele:142cb06.html" title="Last updated on Dec 12, 2018, 4:54 PM GMT (142cb06)">Diff</a>