### PR TITLE
Fix typo in credential registration steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3454,8 +3454,8 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
 
 1. Determine the attestation statement format by performing a USASCII case-sensitive match on |fmt| against the set of
     supported WebAuthn Attestation Statement Format Identifier values.
-    The up-to-date list of registered WebAuthn Attestation Statement Format Identifier values
-    is maintained in the in the IANA registry of the same name [[!WebAuthn-Registries]].
+    An up-to-date list of registered WebAuthn Attestation Statement Format Identifier values
+    is maintained in the IANA registry of the same name [[!WebAuthn-Registries]].
 
 1. Verify that |attStmt| is a correct [=attestation statement=], conveying a valid [=attestation signature=], by using the
     [=attestation statement format=] |fmt|'s [=verification procedure=] given |attStmt|, |authData| and the [=hash of the serialized


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicksteele/webauthn/pull/1120.html" title="Last updated on Dec 12, 2018, 7:35 PM GMT (5b083f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1120/8fd57e3...nicksteele:5b083f9.html" title="Last updated on Dec 12, 2018, 7:35 PM GMT (5b083f9)">Diff</a>