### PR TITLE
Add "Webauthn Authenticator" definition alias

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -546,6 +546,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     spec="credential-management">credentials</a>.
 
 : <dfn>Authenticator</dfn>
+: <dfn>WebAuthn Authenticator</dfn>
 :: A cryptographic entity used by a [=[WAC]=] to (i) generate a [=public key credential=] and register it with a [=[RP]=],
     and (ii) [=authentication|authenticate=] by potentially [=user verification|verifying the user=], and then 
     cryptographically signing and returning, in the form of an [=Authentication Assertion=], 

--- a/index.bs
+++ b/index.bs
@@ -53,6 +53,7 @@ Text Macro: RP Relying Party
 Text Macro: RPS Relying Parties
 Text Macro: INFORMATIVE <em>This section is not normative.</em>
 Text Macro: TRUE <code>true</code>
+Text Macro: WAA WebAuthn Authenticator
 Text Macro: WAC WebAuthn Client
 Text Macro: WRP WebAuthn Relying Party
 Text Macro: WRPS WebAuthn Relying Parties
@@ -247,7 +248,7 @@ spec:webidl; type:interface; text:Promise
 
 This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
 credentials by [=web applications=], for the purpose of strongly authenticating users. A [=public key credential=] is
-created and stored by an <em>[=authenticator=]</em> at the behest of a <em>[=[WRP]=]</em>, subject to <em>[=user
+created and stored by a <em>[=[WAA]=]</em> at the behest of a <em>[=[WRP]=]</em>, subject to <em>[=user
 consent=]</em>. Subsequently, the [=public key credential=] can only be accessed by [=origins=] belonging to that [=[RP]=].
 This scoping is enforced jointly by <em>[=conforming User Agents=]</em> and <em>[=authenticators=]</em>.
 Additionally, privacy across [=[RPS]=] is maintained; [=[RPS]=] are not able to detect any properties, or even
@@ -432,7 +433,7 @@ A conforming User Agent MUST also be a conforming implementation of the IDL frag
 
 ## Authenticators ## {#conforming-authenticators}
 
-An [=authenticator=] MUST provide the operations defined by [[#sctn-authenticator-model]], and those operations MUST behave as
+A [=[WAA]=] MUST provide the operations defined by [[#sctn-authenticator-model]], and those operations MUST behave as
 described there. This is a set of functional and security requirements for an authenticator to be usable by a [=Conforming User
 Agent=].
 
@@ -546,7 +547,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     spec="credential-management">credentials</a>.
 
 : <dfn>Authenticator</dfn>
-: <dfn>WebAuthn Authenticator</dfn>
+: <dfn>[WAA]</dfn>
 :: A cryptographic entity used by a [=[WAC]=] to (i) generate a [=public key credential=] and register it with a [=[RP]=],
     and (ii) [=authentication|authenticate=] by potentially [=user verification|verifying the user=], and then 
     cryptographically signing and returning, in the form of an [=Authentication Assertion=], 
@@ -797,7 +798,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 # <dfn>Web Authentication API</dfn> # {#api}
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
-idea is that the credentials belong to the user and are [=managing authenticator|managed=] by an authenticator, with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
+idea is that the credentials belong to the user and are [=managing authenticator|managed=] by a [=[WAA]=], with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
 browser to create a new credential for future use by the [=[RP]=]. See [Figure 1](#fig-registration), below.
 
 
@@ -2415,7 +2416,7 @@ needs.
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 
-[[#api|The Web Authentication API]] implies a specific abstract functional model for an [=authenticator=]. This section
+[[#api|The Web Authentication API]] implies a specific abstract functional model for a [=[WAA]=]. This section
 describes that [=authenticator model=].
 
 [=Client platforms=] MAY implement and expose this abstract model in any way desired. However, the behavior of the client's Web
@@ -2779,7 +2780,7 @@ There are three broad classes of [=authentication factors=] that can be used to 
 ceremony=]: [=something you have=], [=something you know=] and [=something you are=]. Examples include a physical key, a password,
 and a fingerprint, respectively.
 
-All WebAuthn [=authenticators=] belong to the [=something you have=] class, but an [=authenticator=] that supports [=user
+All [=[WAA]s=] belong to the [=something you have=] class, but an [=authenticator=] that supports [=user
 verification=] can also act as one or two additional kinds of [=authentication factor=]. For example, if the [=authenticator=] can
 verify a PIN, the PIN is [=something you know=], and a [=biometric authenticator=] can verify [=something you are=]. Therefore, an
 [=authenticator=] that supports [=user verification=] is <dfn>multi-factor capable</dfn>. Conversely, an [=authenticator=] that is
@@ -4185,7 +4186,7 @@ client.
 
 When creating a [=public key credential=] or requesting an [=authentication assertion=], a [=[WRP]=] can request the use of a set
 of extensions. These extensions will be invoked during the requested operation if they are supported by the client and/or the
-authenticator. The [=[RP]=] sends the [=client extension input=] for each extension in the {{CredentialsContainer/get()}} call
+[=[WAA]=]. The [=[RP]=] sends the [=client extension input=] for each extension in the {{CredentialsContainer/get()}} call
 (for [=authentication extensions=]) or {{CredentialsContainer/create()}} call (for [=registration extensions=]) to the [=client=].
 The [=client=] performs [=client extension processing=] for each extension that the [=client platform=] supports, and augments the
 [=client data=] as specified by each extension, by including the [=extension identifier=] and [=client extension output=]
@@ -5277,7 +5278,7 @@ handled on the server side and do not need support from the API specified here.
 This specification defines a [[#api|Web API]] and a cryptographic peer-entity authentication protocol.
 The [=Web Authentication API=] allows Web developers (i.e., "authors") to utilize the Web Authentication protocol in their
 [=registration=] and [=authentication=] [=ceremonies=].
-The entities comprising the Web Authentication protocol endpoints are user-controlled [=authenticators=] and a [=[WRP]=]'s
+The entities comprising the Web Authentication protocol endpoints are user-controlled [=[WAA]s=] and a [=[WRP]=]'s
 computing environment hosting the [=[RP]=]'s [=web application=].
 In this model, the user agent, together with the [=[WAC]=], comprise an intermediary between [=authenticators=] and [=[RPS]=].
 Additionally, [=authenticators=] can [=attestation|attest=] to [=[RPS]=] as to their provenance.
@@ -5307,26 +5308,26 @@ therefore be at least 16 bytes long.
 ### Attestation Certificate Hierarchy ### {#cert-hierarchy}
 
 A 3-tier hierarchy for attestation certificates is RECOMMENDED (i.e., Attestation Root, Attestation Issuing CA, Attestation
-Certificate). It is also RECOMMENDED that for each WebAuthn Authenticator device line (i.e., model), a separate issuing CA is
+Certificate). It is also RECOMMENDED that for each [=[WAA]=] device line (i.e., model), a separate issuing CA is
 used to help facilitate isolating problems with a specific version of an authenticator model.
 
-If the attestation root certificate is not dedicated to a single WebAuthn Authenticator device line (i.e., AAGUID), the AAGUID
+If the attestation root certificate is not dedicated to a single [=[WAA]=] device line (i.e., AAGUID), the AAGUID
 SHOULD be specified in the attestation certificate itself, so that it can be verified against the [=authenticator data=].
 
 
 ### Attestation Certificate and Attestation Certificate CA Compromise ### {#ca-compromise}
 
-When an intermediate CA or a root CA used for issuing attestation certificates is compromised, WebAuthn [=authenticator=]
-attestation keys are still safe although their certificates can no longer be trusted. A WebAuthn Authenticator manufacturer that
+When an intermediate CA or a root CA used for issuing attestation certificates is compromised, [=[WAA]=]
+attestation keys are still safe although their certificates can no longer be trusted. A [=[WAA]=] manufacturer that
 has recorded the public attestation keys for their [=authenticator=] models can issue new attestation certificates for these keys from a new
 intermediate CA or from a new root CA. If the root CA changes, the [=[WRPS]=]  MUST update their trusted root certificates
 accordingly.
 
-A WebAuthn Authenticator attestation certificate MUST be revoked by the issuing CA if its key has been compromised. A WebAuthn
+A [=[WAA]=] attestation certificate MUST be revoked by the issuing CA if its key has been compromised. A WebAuthn
 Authenticator manufacturer may need to ship a firmware update and inject new attestation keys and certificates into already
-manufactured WebAuthn Authenticators, if the exposure was due to a firmware flaw. (The process by which this happens is out of
-scope for this specification.) If the WebAuthn Authenticator manufacturer does not have this capability, then it may not be
-possible for [=[RPS]=] to trust any further attestation statements from the affected WebAuthn Authenticators.
+manufactured [=[WAA]s=], if the exposure was due to a firmware flaw. (The process by which this happens is out of
+scope for this specification.) If the [=[WAA]=] manufacturer does not have this capability, then it may not be
+possible for [=[RPS]=] to trust any further attestation statements from the affected [=[WAA]s=].
 
 If attestation certificate validation fails due to a revoked intermediate attestation CA certificate, and the [=[RP]=]'s policy
 requires rejecting the registration/authentication request in these situations, then it is RECOMMENDED that the [=[RP]=] also
@@ -5511,14 +5512,14 @@ instead of revealing the biometric data itself to the [=[RP]=].
 Attestation keys can be used to track users or link various online identities of the same user together. This can be mitigated
 in several ways, including:
 
-- A WebAuthn [=authenticator=] manufacturer may choose to ship all of their [=authenticators=] with the same (or a fixed number of)
+- A [=[WAA]=] manufacturer may choose to ship all of their [=authenticators=] with the same (or a fixed number of)
     attestation key(s) (called [=Basic Attestation=]). This will anonymize the user at the risk of not being able to revoke a
     particular attestation key if its private key is compromised.
 
     [[UAFProtocol]] requires that at least 100,000 [=authenticator=] devices share the same attestation certificate in order to produce
     sufficiently large groups. This may serve as guidance about suitable batch sizes.
 
-- A WebAuthn [=authenticator=] may be capable of dynamically generating different attestation keys (and requesting related
+- A [=[WAA]=] may be capable of dynamically generating different attestation keys (and requesting related
     certificates) per-[=origin=] (similar to the [=Attestation CA=] approach). For example, an [=authenticator=] can ship with a
     master attestation key (and certificate), and combined with a cloud-operated <dfn>Anonymization CA</dfn>, can dynamically generate per-[=origin=] attestation keys and attestation certificates.
 
@@ -5528,7 +5529,7 @@ in several ways, including:
         of an [=Anonymization CA=] is not firmly established, we are using the term [=Anonymization CA=] here to try to mitigate
         confusion in the specific context of this specification.
 
-- A WebAuthn Authenticator can implement [=Elliptic Curve based direct anonymous attestation=] (see [[FIDOEcdaaAlgorithm]]).
+- A [=[WAA]=] can implement [=Elliptic Curve based direct anonymous attestation=] (see [[FIDOEcdaaAlgorithm]]).
     Using this scheme, the authenticator generates a blinded attestation signature. This allows the [=[WRP]=] to verify the
     signature using the [=ECDAA-Issuer public key=], but the attestation signature does not serve as a global correlation handle.
 


### PR DESCRIPTION
Fixes part of #1128.

- Re-link existing occurrences of "WebAuthn authenticator"
- Replace first occurrence of "authenticator" in each major section
  - except section 7 because the first occurrence is in one of the algorithm steps.
  - except section 8 because the first occurrence is in the second subsection.
  - except section 10 because the first occurrence is in the extension definitions.
  - except section 11 because the first occurrence is in an item in a bullet-point list.
  - except section 12 because the first occurrence is already linked to "first-factor roaming authenticator".
  - except section 14 because the first occurrence is in an item in a bullet-point list.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1130.html" title="Last updated on Feb 19, 2019, 12:21 PM UTC (df3eb9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1130/52d4685...df3eb9f.html" title="Last updated on Feb 19, 2019, 12:21 PM UTC (df3eb9f)">Diff</a>