### PR TITLE
Add examples of authenticator types to Authenticator definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -553,6 +553,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     cryptographically signing and returning, in the form of an [=Authentication Assertion=], 
     a challenge and other data presented by a [=[WRP]=] (in concert with the [=[WAC]=]).
 
+    A [=[WAA]=] could be, for example, a dedicated USB or wireless device separate from the [=client device=],
+    a dedicated hardware subsystem integrated into the [=client device=],
+    or a software component of the [=client=].
+    [=Authenticators=] can report their type and security characteristics via [=attestation=].
+
 : <dfn>Authorization Gesture</dfn>
 :: An [=authorization gesture=] is a physical interaction performed by a user with an authenticator as part of a [=ceremony=],
     such as [=registration=] or [=authentication=]. By making such an [=authorization gesture=], a user [=user consent|provides


### PR DESCRIPTION
This would merge into #1130. Fixes the rest of #1128.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1131.html" title="Last updated on Feb 27, 2019, 6:12 PM UTC (a68031a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1131/ca62975...a68031a.html" title="Last updated on Feb 27, 2019, 6:12 PM UTC (a68031a)">Diff</a>