### PR TITLE
Use RFC2119 for defined extensions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4367,7 +4367,7 @@ There MUST NOT be any values returned for ignored extensions.
 
 This section defines the initial set of extensions to be registered in the
 IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]].
-These can be implemented by user agents targeting broad interoperability.
+These MAY be implemented by user agents targeting broad interoperability.
 
 
 ## FIDO <dfn>AppID</dfn> Extension (appid) ## {#sctn-appid-extension}


### PR DESCRIPTION
Per
  https://lists.w3.org/Archives/Public/public-webauthn/2018Sep/0435.html

[[
Looking 
at the diff between the CR and the ED I observe the following change in 
Section 10:

    These /-are RECOMMENDED for implementation-/ /+can be implemented+/
    by user agents targeting broad interoperability.

At a minimum this would be more clear if it used the RFC 2119 
terminology "These MAY be implemented ...".
]]


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1134.html" title="Last updated on Jan 16, 2019, 6:46 PM UTC (d97d2e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1134/ad9bd47...d97d2e7.html" title="Last updated on Jan 16, 2019, 6:46 PM UTC (d97d2e7)">Diff</a>