### PR TITLE
Let requireUserPresence always be true in authenticator operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1153,8 +1153,6 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                     </dl>
 
-            1. Let |userPresence| be a Boolean value set to the inverse of |userVerification|.
-
             1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
             1. [=list/For each=] credential descriptor |C| in <code>|options|.{{PublicKeyCredentialCreationOptions/excludeCredentials}}</code>:
@@ -1167,7 +1165,6 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                 |clientDataHash|,
                 <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}</code>, <code>|options|.{{PublicKeyCredentialCreationOptions/user}}</code>,
                 <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/requireResidentKey}}</code>,
-                |userPresence|,
                 |userVerification|,
                 |credTypesAndPubKeyAlgs|,
                 |excludeCredentialDescriptorList|,
@@ -1502,8 +1499,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                     </dl>
 
-            1. Let |userPresence| be a Boolean value set to the inverse of |userVerification|.
-
             1. <span id="allowCredentialDescriptorListCreation"></span>
                 If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>
                 <dl class="switch">
@@ -1540,19 +1535,19 @@ When this method is invoked, the user agent MUST execute the following algorithm
                                     selection.
 
                                     Then, using |transport|, invoke the [=authenticatorGetAssertion=] operation on
-                                    |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|, |userPresence|,
+                                    |authenticator|, with |rpId|, |clientDataHash|, |allowCredentialDescriptorList|,
                                     |userVerification|, and |authenticatorExtensions| as parameters.
 
                                 :   [=list/is empty=]
                                 ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|,
                                     invoke the [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|,
-                                    |clientDataHash|, |allowCredentialDescriptorList|, |userPresence|, |userVerification|, and
+                                    |clientDataHash|, |allowCredentialDescriptorList|, |userVerification|, and
                                     |authenticatorExtensions| as parameters.
                             </dl>
 
                     :   [=list/is empty=]
                     ::  Using local configuration knowledge of the appropriate transport to use with |authenticator|, invoke the
-                        [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|, |clientDataHash|, |userPresence|,
+                        [=authenticatorGetAssertion=] operation on |authenticator| with |rpId|, |clientDataHash|,
                         |userVerification| and |authenticatorExtensions| as parameters.
 
                         Note: In this case, the [=[RP]=] did not supply a list of acceptable credential descriptors. Thus, the
@@ -2827,9 +2822,9 @@ It takes the following input parameters:
 : |requireResidentKey|
 :: The {{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}} value given by the [=[RP]=].
 : |requireUserPresence|
-:: A Boolean value provided by the client, which in invocations from a [=[WAC]=]'s
-    {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method is always set to the inverse of
-    |requireUserVerification|.
+:: The constant Boolean value [TRUE].
+    It is included here as a pseudo-parameter to simplify applying this abstract authenticator model to implementations that may
+    wish to make a [=test of user presence=] optional although WebAuthn does not.
 : |requireUserVerification|
 :: The [=effective user verification requirement for credential creation=], a Boolean value provided by the client.
 : |credTypesAndPubKeyAlgs|
@@ -2958,9 +2953,9 @@ It takes the following input parameters:
 :: An OPTIONAL [=list=] of {{PublicKeyCredentialDescriptor}}s describing credentials acceptable to the [=[RP]=] (possibly filtered
     by the client), if any.
 : |requireUserPresence|
-:: A Boolean value provided by the client, which in invocations from a [=[WAC]=]'s
-    {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method is always set to the inverse of
-    |requireUserVerification|.
+:: The constant Boolean value [TRUE].
+    It is included here as a pseudo-parameter to simplify applying this abstract authenticator model to implementations that may
+    wish to make a [=test of user presence=] optional although WebAuthn does not.
 : |requireUserVerification|
 :: The [=effective user verification requirement for assertion=], a Boolean value provided by the client.
 : |extensions|


### PR DESCRIPTION
Fixes #1123.

An alternative solution to this would be to completely delete the `requireUserPresence` pseudo-parameters. I've left them in for now to make the mapping to CTAP slightly clearer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1140.html" title="Last updated on Jan 18, 2019, 5:10 PM UTC (d9de125)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1140/c610a95...d9de125.html" title="Last updated on Jan 18, 2019, 5:10 PM UTC (d9de125)">Diff</a>