### PR TITLE
Determine appid extension output after authenticator returns

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1579,7 +1579,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
         :   If any |authenticator| indicates success,
         ::  1.  [=set/Remove=] |authenticator| from |issuedRequests|.
 
-            1.  Let <var ignore>assertionCreationData</var> be a [=struct=] whose [=items=] are:
+            1.  <span id="assertionCreationDataCreation"></span>
+                Let <var ignore>assertionCreationData</var> be a [=struct=] whose [=items=] are:
 
                 :   <code><dfn for="assertionCreationData">credentialIdResult</code>
                 ::  If <code>|savedCredentialIds|[|authenticator|]</code> exists, set the value of [=credentialIdResult=] to be
@@ -4401,7 +4402,6 @@ JavaScript APIs.
 ::  1. Let |facetId| be the result of passing the caller's [=origin=] to the
         FIDO algorithm for [=determining the FacetID of a calling application=].
     1. Let |appId| be the extension input.
-    1. Let |output| be the Boolean value [FALSE].
     1. Pass |facetId| and |appId| to the FIDO algorithm for [=determining if a
         caller's FacetID is authorized for an AppID=]. If that algorithm rejects
         |appId| then return a "{{SecurityError}}" {{DOMException}}.
@@ -4410,8 +4410,12 @@ JavaScript APIs.
         returning `SW_WRONG_DATA`) then the client MUST retry with the U2F application
         parameter set to the SHA-256 hash of |appId|. If this results in an applicable
         credential, the client MUST include the credential in
-        <var ignore>allowCredentialDescriptorList</var> and set |output| to [TRUE]. The value of |appId| then replaces the `rpId`
+        <var ignore>allowCredentialDescriptorList</var>. The value of |appId| then replaces the `rpId`
         parameter of [=authenticatorGetAssertion=].
+    1. Let |output| be the Boolean value [FALSE].
+    1. When [creating assertionCreationData](#assertionCreationDataCreation),
+        if the [=assertion=] was created by a U2F authenticator with the U2F application parameter set to the SHA-256 hash of |appId|
+        instead of the SHA-256 hash of the [=RP ID=], set |output| to [TRUE].
 
 Note: In practice, several implementations do not implement steps four and onward of the
 algorithm for [=determining if a caller's FacetID is authorized for an AppID=].


### PR DESCRIPTION
Fixes #1034.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1143.html" title="Last updated on Jan 18, 2019, 7:01 PM UTC (776b7b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1143/c610a95...776b7b1.html" title="Last updated on Jan 18, 2019, 7:01 PM UTC (776b7b1)">Diff</a>