### PR TITLE
Make appid extension always return true

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4412,10 +4412,6 @@ JavaScript APIs.
         credential, the client MUST include the credential in
         <var ignore>allowCredentialDescriptorList</var>. The value of |appId| then replaces the `rpId`
         parameter of [=authenticatorGetAssertion=].
-    1. Let |output| be the Boolean value [FALSE].
-    1. When [creating assertionCreationData](#assertionCreationDataCreation),
-        if the [=assertion=] was created by a U2F authenticator with the U2F application parameter set to the SHA-256 hash of |appId|
-        instead of the SHA-256 hash of the [=RP ID=], set |output| to [TRUE].
 
 Note: In practice, several implementations do not implement steps four and onward of the
 algorithm for [=determining if a caller's FacetID is authorized for an AppID=].
@@ -4423,7 +4419,10 @@ Instead, in step three, the comparison on the host is relaxed to accept hosts on
 [=same site=].
 
 : Client extension output
-:: Returns the value of |output|. If true, the |AppID| was used and thus, when [verifying an assertion](#verifying-assertion), the [=[RP]=] MUST expect the <code>[=rpIdHash=]</code> to be the hash of the |AppID|, not the [=RP ID=].
+:: Returns the value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon.
+    This means the |AppID| might have been used and thus, when [verifying an assertion](#verifying-assertion),
+    the [=[RP]=] MUST expect the <code>[=rpIdHash=]</code> to be the hash of either |appId| or the [=RP ID=],
+    not only the [=RP ID=].
 
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {


### PR DESCRIPTION
This is an extension to PR #1143 and would merge into that.

I expect this might be a controversial proposal which might be closed with no action. Below is the motivation for it, which is also included as a commit message.

---

This greatly simplifies client implementation logic while leaving RP implementation arguably unaffected. The argument for the latter is as follows.

The [PropRec version of the spec][proprec] has some corner cases where the extension output could be `true` although the RP would in fact need to verify against the RP ID instead of the AppID (see issue #1034 and commit message 776b7b14d6e8f64b101db7e92318c877c588e861). In order to work around these corner cases, the RP has to always accept the RP ID as the `rpIdHash` even if the extension output alleges that the `rpIdHash` should be the hash of the AppID instead.

This means that for maximum compatibility with client implementation versions, the RP must keep this workaround behaviour even after the spec fix made in commit 776b7b14d6e8f64b101db7e92318c877c588e861. The precision of the appid extension output is therefore not very useful since it cannot be relied upon with all clients as long as at least one installation of a client with the old behaviour exists.

Therefore, this PR sacrifices the improved extension output accuracy for simplified client implementation logic.

[proprec]: https://www.w3.org/TR/2019/PR-webauthn-20190117/#sctn-appid-extension


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1144.html" title="Last updated on Jan 18, 2019, 7:38 PM UTC (20f0277)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1144/776b7b1...20f0277.html" title="Last updated on Jan 18, 2019, 7:38 PM UTC (20f0277)">Diff</a>