### PR TITLE
Allow authenticators to do None instead of Self attestation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3084,15 +3084,21 @@ or [=authenticatorGetAssertion=] operation currently in progress.
 
 ## Attestation ## {#sctn-attestation}
 
-[=Authenticators=] MUST also provide some form of [=attestation=]. The basic requirement is that the [=authenticator=] can
+[=Authenticators=] SHOULD also provide some form of [=attestation=], if possible.
+If an authenticator does, the basic requirement is that the [=authenticator=] can
 produce, for each [=credential public key=], an [=attestation statement=] verifiable by the [=[WRP]=]. Typically, this
 [=attestation statement=] contains a signature by an [=attestation private key=] over the attested [=credential public key=] and
 a challenge, as well as a certificate or similar data providing provenance information for the [=attestation public key=],
 enabling the [=[RP]=] to make a trust decision. However, if an [=attestation key pair=] is not available, then the authenticator
-MUST perform [=self attestation=] of the [=credential public key=] with the corresponding [=credential private key=]. All this
+MAY either perform [=self attestation=] of the [=credential public key=] with the corresponding [=credential private key=],
+or otherwise perform [=None|no attestation=]. All this
 information is returned by [=authenticators=] any time a new [=public key credential=] is generated, in the overall form of an
 <dfn>attestation object</dfn>. The relationship of the [=attestation object=] with [=authenticator data=] (containing
 [=attested credential data=]) and the [=attestation statement=] is illustrated in [figure 5](#fig-attStructs), below.
+
+If an [=authenticator=] employs [=self attestation=] or [=None|no attestation=], then no provenance information is provided
+for the [=[RP]=] to base a trust decision on.
+In these cases, the [=authenticator=] provides no guarantees about its operation to the [=[RP]=].
 
 <figure id="fig-attStructs">
     <img src="images/fido-attestation-structures.svg"/>
@@ -4163,6 +4169,9 @@ This attestation statement format is used with FIDO U2F authenticators using the
 ## None Attestation Statement Format ## {#none-attestation}
 
 The none attestation statement format is used to replace any [=authenticator=]-provided [=attestation statement=] when a [=[WRP]=] indicates it does not wish to receive attestation information, see  [[#attestation-convey]].
+
+The [=authenticator=] MAY also directly generate attestation statements of this format
+if the [=authenticator=] does not support [=attestation=].
 
 : Attestation statement format identifier
 :: none


### PR DESCRIPTION
Fixes #978


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1182.html" title="Last updated on Mar 12, 2019, 12:37 PM UTC (88695f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1182/3fc3b1e...88695f4.html" title="Last updated on Mar 12, 2019, 12:37 PM UTC (88695f4)">Diff</a>