### PR TITLE
Revert change to new TR link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11,7 +11,7 @@ Notes:
 Title: Web Authentication: An API for accessing Public Key Credentials - Level
 Status: ED
 Prepare for TR: true
-TR: https://www.w3.org/TR/webauthn-2/
+TR: https://www.w3.org/TR/webauthn/
 ED: https://w3c.github.io/webauthn/
 Previous Version: https://www.w3.org/TR/2019/PR-webauthn-20190117/
 Previous Version: https://www.w3.org/TR/2018/CR-webauthn-20180807/


### PR DESCRIPTION
In PR #1161, @jcjones suggests:

>I would be okay with landing this w/o the TR link fix, and we pick that up later when there's a level2 publication.

This PR removes that change from #1161. The sibling PR #1187 will revert this revert, restoring #1161 to its original state.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1186.html" title="Last updated on Mar 21, 2019, 1:20 PM UTC (b894031)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1186/63640b3...b894031.html" title="Last updated on Mar 21, 2019, 1:20 PM UTC (b894031)">Diff</a>