### PR TITLE
Fix typo in Authentication example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5175,7 +5175,7 @@ credential.
 1. If an assertion was successfully generated and returned,
     - The script sends the assertion to the server.
     - The server examines the assertion, extracts the [=credential ID=], looks up the registered
-        credential public key it is database, and verifies the assertion's authentication signature.
+        credential public key in its database, and verifies the assertion's authentication signature.
         If valid, it looks up the identity associated with the assertion's [=credential ID=]; that
         identity is now authenticated. If the [=credential ID=] is not recognized by the server (e.g.,
         it has been deregistered due to inactivity) then the authentication has failed; each [=[RP]=]


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jtescher/webauthn/pull/1190.html" title="Last updated on Mar 24, 2019, 7:03 PM UTC (982edc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1190/8678b43...jtescher:982edc7.html" title="Last updated on Mar 24, 2019, 7:03 PM UTC (982edc7)">Diff</a>