### PR TITLE
fix #1166: clarify extension input/output data type names

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2301,7 +2301,16 @@ SHOULD be aborted.
     See [WHATWG HTML WG Issue #2711](https://github.com/whatwg/html/issues/2711) for more details. 
 
 
-## Authentication Extensions Client Inputs (typedef {{AuthenticationExtensionsClientInputs}}) ## {#iface-authentication-extensions-client-inputs}
+## WebAuthn Extensions Inputs and Outputs
+
+The subsections below define the data types used for conveying [=WebAuthn extension=] inputs and outputs.
+
+Note: [=Authenticator extension outputs=] are conveyed as a part of [=Authenticator data=] (see [Table 1](#table-authData)).
+
+Note: The types defined below&mdash;{{AuthenticationExtensionsClientInputs}}, {{AuthenticationExtensionsClientOutputs}}, and {{AuthenticationExtensionsAuthenticatorInputs}}&mdash;are applicable to both [=registration extensions=] and [=authentication extensions=]. The "Authentication..." portion of their names should be regarded as meaning "WebAuthentication..."
+
+
+### Authentication Extensions Client Inputs (dictionary {{AuthenticationExtensionsClientInputs}}) ## {#iface-authentication-extensions-client-inputs}
 
 <xmp class="idl">
     dictionary AuthenticationExtensionsClientInputs {
@@ -2311,7 +2320,7 @@ SHOULD be aborted.
 This is a dictionary containing the [=client extension input=] values for zero or more [=WebAuthn Extensions=].
 
 
-## Authentication Extensions Client Outputs (typedef {{AuthenticationExtensionsClientOutputs}}) ## {#iface-authentication-extensions-client-outputs}
+### Authentication Extensions Client Outputs (dictionary {{AuthenticationExtensionsClientOutputs}}) ## {#iface-authentication-extensions-client-outputs}
 
 <xmp class="idl">
     dictionary AuthenticationExtensionsClientOutputs {
@@ -2321,7 +2330,7 @@ This is a dictionary containing the [=client extension input=] values for zero o
 This is a dictionary containing the [=client extension output=] values for zero or more [=WebAuthn Extensions=].
 
 
-## Authentication Extensions Authenticator Inputs (typedef {{AuthenticationExtensionsAuthenticatorInputs}}) ## {#iface-authentication-extensions-authenticator-inputs}
+### Authentication Extensions Authenticator Inputs (typedef {{AuthenticationExtensionsAuthenticatorInputs}}) ## {#iface-authentication-extensions-authenticator-inputs}
 
 <xmp class="idl">
     typedef record<DOMString, DOMString> AuthenticationExtensionsAuthenticatorInputs;


### PR DESCRIPTION
fixes #1166


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1210.html" title="Last updated on May 8, 2019, 9:13 PM UTC (5e19249)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1210/1b13d2e...5e19249.html" title="Last updated on May 8, 2019, 9:13 PM UTC (5e19249)">Diff</a>