### PR TITLE
Fix typo in PR #1195

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -553,7 +553,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>[WAA]</dfn>
 :: A cryptographic entity, existing in hardware or software, that can [=registration|register=] a user with a given [=[RP]=] 
     and later [=Authentication Assertion|assert possession=] of the registered [=public key credential=], and optionally 
-    [=user verification|verifying the user=], when requested by the [=[RP]=]. [=Authenticators=] can report information 
+    [=user verification|verify the user=], when requested by the [=[RP]=]. [=Authenticators=] can report information
     regarding their [=authenticator types|type=] and security characteristics via [=attestation=] during [=registration=].
 
     A [=[WAA]=] could be a [=roaming authenticator=], a dedicated hardware subsystem integrated into the [=client device=], 


### PR DESCRIPTION
I found a grammar error in #1195 a little too late to fix it in that PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1213.html" title="Last updated on May 9, 2019, 1:17 PM UTC (8d2b789)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1213/1b13d2e...8d2b789.html" title="Last updated on May 9, 2019, 1:17 PM UTC (8d2b789)">Diff</a>