### PR TITLE
feature policy integration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2541,7 +2541,7 @@ to successfully invoke the [=Web Authentication API=], i.e., via
 <code><a idl for="CredentialsContainer" lt="create()">navigator.credentials.create({publicKey:..., ...})</a></code> and
 <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code>.
 If disabled in any document, no content in the document will be [=allowed to use=]
-the foregoing methods: attempting to do so will throw an error.
+the foregoing methods: attempting to do so will [return an error](https://www.w3.org/2001/tag/doc/promises-guide#errors).
 
 Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual feature policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=] do not have such access since they are invoked [=in parallel=] (by algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]]).
 

--- a/index.bs
+++ b/index.bs
@@ -2428,10 +2428,10 @@ needs.
 ## Feature Policy integration ## {#sctn-feature-policy}
 
 This specification defines a [=policy-controlled feature=] identified by
-the string "<code><dfn data-lt="payment-feature">webauthn</dfn></code>".
+the string "<code><dfn data-lt="webauthn-feature">webauthn</dfn></code>".
 Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
-A {{Document}}'s [=Document/feature policy=] determines whether any content in that document is allowed
+A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is allowed
 to successfully invoke the [=Web Authentication API=]&mdash;i.e.,
 {{CredentialsContainer/create()|navigator.credentials.create({"publicKey"})}} and
 {{CredentialsContainer/get()|navigator.credentials.get({"publicKey"})}}.

--- a/index.bs
+++ b/index.bs
@@ -92,6 +92,15 @@ figure.table .overlarge {
 </style>
 
 
+<pre class="link-defaults">
+
+spec: dom; type: interface; for:/; text: Document
+
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/dom.html; type: dfn; url: concept-document-feature-policy; text: feature policy
+
+</pre>
+
+
 <!-- TODO: Clean out these anchor lists once they appear in Shepherd -->
 <pre class="anchors">
 
@@ -154,7 +163,7 @@ spec: page-visibility; urlPrefix: https://www.w3.org/TR/page-visibility/
         text: visibility states
 
 spec: WHATWG HTML; urlPrefix: https://html.spec.whatwg.org/
-    type: dfn 
+    type: dfn
         text: focus
         text: username; url: attr-fe-autocomplete-username
 
@@ -226,12 +235,6 @@ spec:webidl; type:interface; text:Promise
         "publisher": "IANA"
     },
 
-    "Feature-Policy": {
-        "href": "https://wicg.github.io/feature-policy/",
-        "title": "Feature Policy",
-        "publisher": "WICG: Web Incubator Community Group",
-        "status": "Draft Community Group Report"
-    },
 
     "WebAuthnAPIGuide": {
         "href": "https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API",
@@ -2426,9 +2429,9 @@ needs.
 
 This specification defines a [=policy-controlled feature=] identified by
 the string "<code><dfn data-lt="payment-feature">webauthn</dfn></code>".
-Its [=default allowlist=] is '<code>self</code>'. [[!feature-policy]]
+Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
-A [=DOM/document=]'s [=html/feature policy=] determines whether any content in that document is allowed
+A {{Document}}'s [=Document/feature policy=] determines whether any content in that document is allowed
 to successfully invoke the [=Web Authentication API=]&mdash;i.e.,
 {{CredentialsContainer/create()|navigator.credentials.create({"publicKey"})}} and
 {{CredentialsContainer/get()|navigator.credentials.get({"publicKey"})}}.
@@ -2440,9 +2443,8 @@ the foregoing methods: attempting to do so will throw an error.
 
 [INFORMATIVE]
 
-The [=Web Authentication API=] is disabled by default in cross-origin <a>iframe</a>s.
-To override this default policy and indicate that a cross-origin <a>iframe</a> is allowed
-to invoke the [=Web Authentication API=], specify the <code>[=allow=]</code> attribute on the <a>iframe</a> element with a value of `webauthn`.
+The [=Web Authentication API=] is disabled by default in cross-origin <{iframe}>s.
+To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=], specify the <{iframe/allow}> attribute on the <{iframe}> element with a value of `webauthn`.
 
 
 

--- a/index.bs
+++ b/index.bs
@@ -985,7 +985,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialCreationOptions/publicKey}}</code> is [=present=].
 
-1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
+1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], and [=allowed to use=] is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
 
     Note: This "sameOriginWithAncestors" restriction aims to address the concern raised in the
     [[CREDENTIAL-MANAGEMENT-1#security-origin-confusion|Origin Confusion]] section of [[CREDENTIAL-MANAGEMENT-1]],
@@ -1361,7 +1361,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialRequestOptions/publicKey}}</code> is [=present=].
 
-1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
+1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], and [=allowed to use=] is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
 
     Note: This "sameOriginWithAncestors" restriction aims to address the concern raised in the
     [[CREDENTIAL-MANAGEMENT-1#security-origin-confusion|Origin Confusion]] section of [[CREDENTIAL-MANAGEMENT-1]],

--- a/index.bs
+++ b/index.bs
@@ -1792,6 +1792,8 @@ This method has no arguments and returns a Boolean value.
     };
 </xmp>
 
+Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=feature policy=]&mdash;will result in the promise being rejected with a [=DOMException=] whose name is "{{NotAllowedError}}".
+
 </div>
 
 ## Authenticator Responses (interface <dfn interface>AuthenticatorResponse</dfn>) ## {#iface-authenticatorresponse}

--- a/index.bs
+++ b/index.bs
@@ -2533,23 +2533,24 @@ needs.
 ## Feature Policy integration ## {#sctn-feature-policy}
 
 This specification defines a [=policy-controlled feature=] identified by
-the string "<code><dfn data-lt="webauthn-feature">webauthn</dfn></code>".
+the feature policy token "<code><dfn data-lt="webauthn-feature">webauthn</dfn></code>".
 Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
 A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is allowed
-to successfully invoke the [=Web Authentication API=]&mdash;i.e.,
-{{CredentialsContainer/create()|navigator.credentials.create({"publicKey"})}} and
-{{CredentialsContainer/get()|navigator.credentials.get({"publicKey"})}}.
+to successfully invoke the [=Web Authentication API=], i.e., via
+<code><a idl for="CredentialsContainer" lt="create()">navigator.credentials.create({publicKey:..., ...})</a></code> and
+<code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code>.
 If disabled in any document, no content in the document will be [=allowed to use=]
 the foregoing methods: attempting to do so will throw an error.
+
+Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual feature policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=] do not have such access since they are invoked [=in parallel=] (by algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]]).
+
 
 
 ## Using Web Authentication within <code>iframe</code> elements ## {#sctn-iframe-guidance}
 
-[INFORMATIVE]
-
 The [=Web Authentication API=] is disabled by default in cross-origin <{iframe}>s.
-To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=], specify the <{iframe/allow}> attribute on the <{iframe}> element with a value of `webauthn`.
+To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=], specify the <{iframe/allow}> attribute on the <{iframe}> element and include the `webauthn` feature policy token in the <{iframe/allow}> attribute's value.
 
 
 

--- a/index.bs
+++ b/index.bs
@@ -988,7 +988,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialCreationOptions/publicKey}}</code> is [=present=].
 
-1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], and [=allowed to use=] is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
+1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
 
     Note: This "sameOriginWithAncestors" restriction aims to address the concern raised in the
     [[CREDENTIAL-MANAGEMENT-1#security-origin-confusion|Origin Confusion]] section of [[CREDENTIAL-MANAGEMENT-1]],
@@ -1364,7 +1364,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialRequestOptions/publicKey}}</code> is [=present=].
 
-1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], and [=allowed to use=] is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
+1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
 
     Note: This "sameOriginWithAncestors" restriction aims to address the concern raised in the
     [[CREDENTIAL-MANAGEMENT-1#security-origin-confusion|Origin Confusion]] section of [[CREDENTIAL-MANAGEMENT-1]],

--- a/index.bs
+++ b/index.bs
@@ -2422,6 +2422,31 @@ needs.
 </div>
 
 
+## Feature Policy integration ## {#sctn-feature-policy}
+
+This specification defines a [=policy-controlled feature=] identified by
+the string "<code><dfn data-lt="payment-feature">webauthn</dfn></code>".
+Its [=default allowlist=] is '<code>self</code>'. [[!feature-policy]]
+
+A [=DOM/document=]'s [=html/feature policy=] determines whether any content in that document is allowed
+to successfully invoke the [=Web Authentication API=]&mdash;i.e.,
+{{CredentialsContainer/create()|navigator.credentials.create({"publicKey"})}} and
+{{CredentialsContainer/get()|navigator.credentials.get({"publicKey"})}}.
+If disabled in any document, no content in the document will be [=allowed to use=]
+the foregoing methods: attempting to do so will throw an error.
+
+
+## Using Web Authentication within <code>iframe</code> elements ## {#sctn-iframe-guidance}
+
+[INFORMATIVE]
+
+The [=Web Authentication API=] is disabled by default in cross-origin <a>iframe</a>s.
+To override this default policy and indicate that a cross-origin <a>iframe</a> is allowed
+to invoke the [=Web Authentication API=], specify the <code>[=allow=]</code> attribute on the <a>iframe</a> element with a value of `webauthn`.
+
+
+
+
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 
 [[#api|The Web Authentication API]] implies a specific abstract functional model for a [=[WAA]=]. This section


### PR DESCRIPTION
An initial pass at feature policy integration. Possibly is work-in-progress to a modest extent given how associated mods to credman (see w3c/webappsec-credential-management#138) shakes out.  I.e., we may (or may not) need to add a new parameter to the `[[Create]]()` and `[[DiscoverFrom...]]()` internal methods in addition to `SameOriginWithAncestors`, we'll see...

in its present state on 15-May-2019, this PR improves #911


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1214.html" title="Last updated on May 15, 2019, 6:44 PM UTC (7f8e256)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1214/1b13d2e...7f8e256.html" title="Last updated on May 15, 2019, 6:44 PM UTC (7f8e256)">Diff</a>