### PR TITLE
Use "authorization gesture" term in authenticator operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3031,8 +3031,9 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
     1.  If [=credential id/looking up=] <code>|descriptor|.{{PublicKeyCredentialDescriptor/id}}</code> in this authenticator
         returns non-null, and the returned [=list/item=]'s [=RP ID=] and [=type=] match
         <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and
-        <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code> respectively, then obtain [=user
-        consent=] for creating a new credential. The method of obtaining [=user consent=] MUST include a [=test
+        <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code> respectively,
+        then collect an [=authorization gesture=] confirming [=user
+        consent=] for creating a new credential. The [=authorization gesture=] MUST include a [=test
         of user presence=]. If the user
         <dl class="switch">
             :   confirms consent to create a new credential
@@ -3051,21 +3052,22 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
 -->
     <li id='op-makecred-step-user-consent'>
-        Obtain [=user consent=] for creating a new credential. The prompt for obtaining this [=user consent|consent=] is shown by the
+        Collect an [=authorization gesture=] confirming [=user consent=] for creating a new credential.
+        The prompt for the [=authorization gesture=] is shown by the
         authenticator if it has its own output capability, or by the user agent otherwise. The prompt SHOULD display
         <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code>, <code>|rpEntity|.{{PublicKeyCredentialEntity/name}}</code>,
         <code>|userEntity|.{{PublicKeyCredentialEntity/name}}</code> and
         <code>|userEntity|.{{PublicKeyCredentialUserEntity/displayName}}</code>, if possible.
 
-        If |requireUserVerification| is [TRUE], the method of obtaining [=user consent=] MUST include [=user verification=].
+        If |requireUserVerification| is [TRUE], the [=authorization gesture=] MUST include [=user verification=].
 
-        If |requireUserPresence| is [TRUE], the method of obtaining [=user consent=] MUST include a [=test of user presence=].
+        If |requireUserPresence| is [TRUE], the [=authorization gesture=] MUST include a [=test of user presence=].
 
         If the user does not [=user consent|consent=] or if [=user verification=] fails, return an error code equivalent to
         "{{NotAllowedError}}" and terminate the operation.
     </li>
 
-1. Once [=user consent=] has been obtained, generate a new credential object:
+1. Once the [=authorization gesture=] has been completed and [=user consent=] has been obtained, generate a new credential object:
     1. Let (|publicKey|, |privateKey|) be a new pair of cryptographic keys using the combination of {{PublicKeyCredentialType}}
         and cryptographic parameters represented by the first [=list/item=] in |credTypesAndPubKeyAlgs| that is supported by
         this authenticator.
@@ -3157,16 +3159,17 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
 1. If |credentialOptions| is now empty, return an error code equivalent to "{{NotAllowedError}}" and terminate the operation.
 
 1. Prompt the user to select a [=public key credential source=] |selectedCredential| from |credentialOptions|.
-    Obtain [=user consent=] for using |selectedCredential|. The prompt for obtaining this [=user consent|consent=] may be shown
+    Collect an [=authorization gesture=] confirming [=user consent=] for using |selectedCredential|.
+    The prompt for the [=authorization gesture=] may be shown
     by the [=authenticator=] if it has its own output capability, or by the user agent otherwise.
 
-    If |requireUserVerification| is [TRUE], the method of obtaining [=user consent=] MUST include [=user verification=].
+    If |requireUserVerification| is [TRUE], the [=authorization gesture=] MUST include [=user verification=].
 
         Note: For the overall WebAuthn security properties to hold, the user verified here must be the same user that was
         verified when this [=authenticator=] created this [=public key credential=] in
         <a href='#op-makecred-step-user-consent'>Step 6</a> of [[#sctn-op-make-cred]].
 
-    If |requireUserPresence| is [TRUE], the method of obtaining [=user consent=] MUST include a
+    If |requireUserPresence| is [TRUE], the [=authorization gesture=] MUST include a
         [=test of user presence=].
 
     If the user does not [=user consent|consent=], return an error code equivalent to


### PR DESCRIPTION
Fixes #1215


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1237.html" title="Last updated on Jun 19, 2019, 5:49 PM UTC (8298663)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1237/00127b7...8298663.html" title="Last updated on Jun 19, 2019, 5:49 PM UTC (8298663)">Diff</a>