### PR TITLE
Re-focus resident key definitions around allowCredentials aspect

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -919,7 +919,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Client-side-resident Public Key Credential Source</dfn>
 : <dfn>Resident Credential</dfn>
 :: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short,
-    is a [=public key credential source=] that is discoverable and usable in  [=authentication ceremonies=]
+    is a [=public key credential source=] that is discoverable and usable in [=authentication ceremonies=]
     without providing [=credential ID=]s,
     i.e., calling {{CredentialsContainer/get()|navigator.credentials.get()}}
     with an [=list/is empty|empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
@@ -933,6 +933,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     but does not require [=client-side=] storage of the [=public key credential source=].
 
     See also: [=client-side credential storage modality=].
+
+    Note: [=Resident credentials=] are also usable in [=authentication ceremonies=] where [=credential ID=]s are given,
+    i.e., when calling {{CredentialsContainer/get()|navigator.credentials.get()}}
+    with a non-[=list/is empty|empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
 : <dfn>Conforming User Agent</dfn>
 :: A user agent implementing, in cooperation with the underlying [=client device=], the [=Web Authentication API=] and algorithms

--- a/index.bs
+++ b/index.bs
@@ -922,7 +922,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     is a [=public key credential source=] that is discoverable and usable in  [=authentication ceremonies=]
     without providing [=credential ID=]s,
     i.e., calling {{CredentialsContainer/get()|navigator.credentials.get()}}
-    with an [=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+    with an [=list/is empty|empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
     As a consequence, a [=resident credential capable=] [=authenticator=] can generate an [=assertion signature=]
     for a [=resident credential=] given only an [=RP ID=],

--- a/index.bs
+++ b/index.bs
@@ -918,14 +918,19 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Client-side-resident Public Key Credential Source</dfn>
 : <dfn>Resident Credential</dfn>
-:: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short, is a [=public key credential
-    source=] whose [=credential private key=] is stored in the [=authenticator=], [=client=] or [=client device=]. Such
-    [=client-side=] storage requires a [=resident credential capable=] [=authenticator=] and has the property that the [=authenticator=]
-    is able to select the [=credential private key=] given
-    only an [=RP ID=], possibly with user assistance (e.g., by providing the user a pick list of [=public key credential|credentials=] [=scoped=] to the [=RP ID=]).
-    By definition, the [=credential private key=] is always exclusively controlled by the [=authenticator=]. In the case of a
-    [=resident credential=], the [=authenticator=] might offload storage of wrapped key material to the
-    [=client device=], but the [=client device=] is not expected to offload the key storage to remote entities (e.g., [=[WRP]=] Server).
+:: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short,
+    is a [=public key credential source=] that can be used in an [=authentication ceremony=]
+    without providing the [=authenticator=] with a [=credential ID=], i.e.,
+    in an [=authentication ceremony=] with an [=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+
+    As a consequence, a [=resident credential capable=] [=authenticator=] can generate an [=assertion signature=]
+    for a [=resident credential=] given only an [=RP ID=],
+    which in turn means that the corresponding [=credential private key=]
+    is stored in the [=authenticator=], [=client=] or [=client device=].
+    This is in contrast to a [=server-side-resident public key credential source=],
+    which requires that the [=authenticator=] is given both the [=RP ID=] and the [=credential ID=]
+    but does not require [=client-side=] storage of the [=credential private key=].
+
     See also: [=client-side credential storage modality=].
 
 : <dfn>Conforming User Agent</dfn>
@@ -1076,9 +1081,17 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Server-side-resident Public Key Credential Source</dfn>
 : <dfn>Non-Resident Credential</dfn>
-:: A [=Server-side-resident Public Key Credential Source=], or [=Non-Resident Credential=] for short, is a [=public key credential
-    source=] whose [=credential private key=] is not stored in the [=authenticator=], [=client=] or [=client device=], but is instead
-    encrypted (i.e. wrapped) and returned to the server as the [=credential ID=]. See also: [=server-side credential storage modality=].
+:: A [=Server-side-resident Public Key Credential Source=], or [=Non-Resident Credential=] for short,
+    is a [=public key credential source=] that cannot be used in an [=authentication ceremony=]
+    without providing the [=authenticator=] with the [=credential ID=], e.g.,
+    it can only be used when specified in the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+
+    As a consequence, [=client-side=] storage of the [=credential private key=] is not required for a [=non-resident credential=].
+    This is in contrast to a [=client-side-resident public key credential source=],
+    which does not require the [=credential ID=] to be used
+    but instead requires [=client-side=] storage of the [=credential private key=].
+
+    See also: [=server-side credential storage modality=].
 
 : <dfn>Test of User Presence</dfn>
 :: A [=test of user presence=] is a simple form of [=authorization gesture=] and technical process where a user interacts with
@@ -3228,8 +3241,8 @@ backup [=public key credential|credentials=] in case another [=authenticator=] i
 
 An [=authenticator=] can store a [=public key credential source=] in one of two ways:
 
- 1. In persistent storage embedded in the [=authenticator=], [=client=] or [=client device=], e.g., in a secure element. A
-    [=public key credential source=] stored in this way is a [=resident credential=].
+ 1. In persistent storage embedded in the [=authenticator=], [=client=] or [=client device=], e.g., in a secure element.
+    This is a technical requirement for a [=client-side-resident public key credential source=].
 
  1. By encrypting (i.e., wrapping) the [=credential private key=] such that only this [=authenticator=] can decrypt (i.e., unwrap) it and letting the resulting
     ciphertext be the [=credential ID=] for the [=public key credential source=]. The [=credential ID=] is stored by the [=[RP]=]

--- a/index.bs
+++ b/index.bs
@@ -925,11 +925,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
     As a consequence, a [=resident credential capable=] [=authenticator=] can generate an [=assertion signature=]
     for a [=resident credential=] given only an [=RP ID=],
-    which in turn means that the corresponding [=credential private key=]
-    is stored in the [=authenticator=], [=client=] or [=client device=].
+    which in turn means that the [=public key credential source=]
+    is stored in the [=authenticator=] or [=client platform=].
     This is in contrast to a [=server-side-resident public key credential source=],
     which requires that the [=authenticator=] is given both the [=RP ID=] and the [=credential ID=]
-    but does not require [=client-side=] storage of the [=credential private key=].
+    but does not require [=client-side=] storage of the [=public key credential source=].
 
     See also: [=client-side credential storage modality=].
 
@@ -1086,10 +1086,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     without providing the [=authenticator=] with the [=credential ID=], e.g.,
     the credential is only usable when its [=credential ID=] is specified in the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
-    As a consequence, [=client-side=] storage of the [=credential private key=] is not required for a [=non-resident credential=].
+    As a consequence, [=client-side=] storage of the [=public key credential source=]
+    is not required for a [=non-resident credential=].
     This is in contrast to a [=client-side-resident public key credential source=],
     which does not require the [=credential ID=] to be provided
-    but instead requires [=client-side=] storage of the [=credential private key=].
+    but instead requires [=client-side=] storage of the [=public key credential source=].
 
     See also: [=server-side credential storage modality=].
 

--- a/index.bs
+++ b/index.bs
@@ -919,8 +919,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Client-side-resident Public Key Credential Source</dfn>
 : <dfn>Resident Credential</dfn>
 :: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short,
-    is a [=public key credential source=] that can be used in an [=authentication ceremony=]
-    without providing the [=authenticator=] with a [=credential ID=], i.e.,
+    is a [=public key credential source=] that is discoverable and usable in  [=authentication ceremonies=]
+    without providing [=credential ID=]s, i.e.,
      calling {{CredentialsContainer/get()|navigator.credentials.get()}} with an [=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
     As a consequence, a [=resident credential capable=] [=authenticator=] can generate an [=assertion signature=]

--- a/index.bs
+++ b/index.bs
@@ -921,7 +921,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short,
     is a [=public key credential source=] that can be used in an [=authentication ceremony=]
     without providing the [=authenticator=] with a [=credential ID=], i.e.,
-    in an [=authentication ceremony=] with an [=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+     calling {{CredentialsContainer/get()|navigator.credentials.get()}} with an [=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
     As a consequence, a [=resident credential capable=] [=authenticator=] can generate an [=assertion signature=]
     for a [=resident credential=] given only an [=RP ID=],
@@ -1084,11 +1084,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: A [=Server-side-resident Public Key Credential Source=], or [=Non-Resident Credential=] for short,
     is a [=public key credential source=] that cannot be used in an [=authentication ceremony=]
     without providing the [=authenticator=] with the [=credential ID=], e.g.,
-    it can only be used when specified in the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+    the credential is only usable when its [=credential ID=] is specified in the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
     As a consequence, [=client-side=] storage of the [=credential private key=] is not required for a [=non-resident credential=].
     This is in contrast to a [=client-side-resident public key credential source=],
-    which does not require the [=credential ID=] to be used
+    which does not require the [=credential ID=] to be provided
     but instead requires [=client-side=] storage of the [=credential private key=].
 
     See also: [=server-side credential storage modality=].

--- a/index.bs
+++ b/index.bs
@@ -920,8 +920,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Resident Credential</dfn>
 :: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short,
     is a [=public key credential source=] that is discoverable and usable in  [=authentication ceremonies=]
-    without providing [=credential ID=]s, i.e.,
-     calling {{CredentialsContainer/get()|navigator.credentials.get()}} with an [=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+    without providing [=credential ID=]s,
+    i.e., calling {{CredentialsContainer/get()|navigator.credentials.get()}}
+    with an [=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
     As a consequence, a [=resident credential capable=] [=authenticator=] can generate an [=assertion signature=]
     for a [=resident credential=] given only an [=RP ID=],


### PR DESCRIPTION
Closes #1197.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1249.html" title="Last updated on Jul 3, 2019, 2:47 PM UTC (4154a53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1249/126223e...4154a53.html" title="Last updated on Jul 3, 2019, 2:47 PM UTC (4154a53)">Diff</a>