### PR TITLE
Add a WebDriver Virtual Authenticator extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5499,19 +5499,19 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 
 # Automation # {#sctn-automation}
 
-For the purposes of user-agent automation and application testing, this document defines a number of <a>extension
-commands</a> for the [[WebDriver]] specification. 
+For the purposes of user-agent automation and application testing, this document defines a number of [=extension
+commands=] for the [[WebDriver]] specification. 
 
 ## <dfn>Virtual Authenticators</dfn> ## {#sctn-automation-virtual-authenticators}
 
-These <a>extension commands</a> create and interact with <a>Virtual Authenticators</a>: software implementations of the
+These [=extension commands=] create and interact with [=Virtual Authenticators=]: software implementations of the
 <a>Authenticator Model</a>. <a>Virtual Authenticators</a> are stored in a <dfn>Virtual Authenticator Database</dfn> and
 have the following properties:
 
 : |authenticatorId|
-:: An arbitrary non-null string that uniquely identifies the <a>Virtual Authenticator</a>.
+:: An arbitrary non-null string that uniquely identifies the [=Virtual Authenticator=].
 : |protocol|
-:: The protocol the <a>Virtual Authenticator</a> uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
+:: The protocol the [=Virtual Authenticator=] uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
     or `u2f` for the [[FIDO-U2F-Message-Formats]].
 : |transport|
 :: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
@@ -5521,14 +5521,14 @@ have the following properties:
 : |hasUserVerification|
 :: If set to `true`, the authenticator will support [=user verification=].
 : |isUserVerified|
-:: Determines the result of <a>User Verification</a> performed on the <a>Virtual Authenticator</a>. If set to `true`,
-    <a>User Verification</a> will always succeed. If set to `false`, it will fail. This property has no effect if
+:: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to `true`,
+    [=User Verification=] will always succeed. If set to `false`, it will fail. This property has no effect if
     |hasUserVerification| is set to `false`.
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
-The <a>Add Virtual Authenticator</a> <a>extension command</a> creates a software <a>Virtual Authenticator</a>. The
-<a>extension command</a> is defined as follows:
+The [=Add Virtual Authenticator=] [=extension command=] creates a software [=Virtual Authenticator=]. The
+[=extension command=] is defined as follows:
 
     <xmp class="idl">
     enum AuthenticatorProtocol {
@@ -5562,26 +5562,26 @@ The <a>Add Virtual Authenticator</a> <a>extension command</a> creates a software
     </table>
 </figure>
 
-The <a>remote end steps</a> are:
+The [=remote end steps=] are:
 
- 1. If |parameters| is not a JSON <a>Object</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
-     <a>invalid argument</a>.
- 1. Let |protocol| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/protocol}}
+ 1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+ 1. Let |protocol| be the result of [=trying=] to get the |parameter|'s {{AddVirtualAuthenticatorParameters/protocol}}
     property.
- 1. If |protocol| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Let |transport| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/transport}}
+ 1. If |protocol| is null, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |transport| be the result of [=trying=] to get the |parameter|'s {{AddVirtualAuthenticatorParameters/transport}}
     property.
- 1. If |transport| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. If |transport| is null, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Generate an arbitrary and unique string |authenticatorId|.
- 1. Create a new <a>Virtual Authenticator</a> with the fields |authenticatorId|, |protocol|, |transport|,
+ 1. Create a new [=Virtual Authenticator=] with the fields |authenticatorId|, |protocol|, |transport|,
     |hasResidentKey|, |hasUserVerification|, and |isUserVerified|.
- 1. Store the authenticator in the <a>Virtual Authenticator Database</a>.
- 1. Return <a>success</a> with |authenticatorId|.
+ 1. Store the authenticator in the [=Virtual Authenticator Database=].
+ 1. Return [=success=] with |authenticatorId|.
 
 ## <dfn>Remove Virtual Authenticator</dfn> ## {#sctn-automation-remove-virtual-authenticator}
 
-The <a>Remove Virtual Authenticator</a> <a>extension command</a> removes a previously created <a>Virtual Authenticator</a>.
-The <a>extension command</a> is defined as follows:
+The [=Remove Virtual Authenticator=] [=extension command=] removes a previously created [=Virtual Authenticator=].
+The [=extension command=] is defined as follows:
 
 <figure id="table-removeVirtualAuthenticator" class="table">
     <table class="data">
@@ -5600,17 +5600,17 @@ The <a>extension command</a> is defined as follows:
     </table>
 </figure>
 
-The <a>remote end steps</a> are:
+The [=remote end steps=] are:
 
- 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
-     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Remove the <a>Virtual Authenticator</a> identified by |authenticatorId| from the <a>Virtual Authenticator Database</a>
- 1. Return <a>success</a>.
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Remove the [=Virtual Authenticator=] identified by |authenticatorId| from the [=Virtual Authenticator Database=]
+ 1. Return [=success=].
 
 ## <dfn>Add Credential</dfn> ## {#sctn-automation-add-credential}
 
-The <a>Add Credential</a> <a>extension command</a> injects a <a>Credential Key Pair</a> and associated <a>Authenticator Data</a>
-into an existing <a>Virtual Authenticator</a>. The <a>extension command</a> is defined as follows:
+The [=Add Credential=] [=extension command=] injects a [=Credential Key Pair=] and associated [=Authenticator Data=]
+into an existing [=Virtual Authenticator=]. The [=extension command=] is defined as follows:
 
     <xmp class="idl">
     dictionary CredentialParams {
@@ -5638,35 +5638,35 @@ into an existing <a>Virtual Authenticator</a>. The <a>extension command</a> is d
     </table>
 </figure>
 
-The <a>remote end steps</a> are:
+The [=remote end steps=] are:
 
- 1. If |parameters| is not a JSON <a>Object</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
-     <a>invalid argument</a>.
- 1. Let |credentialId| be the result of <a>trying</a> to decode <a>Base64url Encoding</a> on the |parameter|'s
+ 1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+ 1. Let |credentialId| be the result of [=trying=] to decode [=Base64url Encoding=] on the |parameter|'s
      {{CredentialParams/credentialId}} property.
- 1. If |credentialId| is failure, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Let |rpIdHash| be the result of <a>trying</a> to decode <a>Base64url Encoding</a> on the |parameter|'s
+ 1. If |credentialId| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |rpIdHash| be the result of [=trying=] to decode [=Base64url Encoding=] on the |parameter|'s
      {{CredentialParams/rpIdHash}} property.
- 1. If |rpIdHash| is failure, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. If |rpIdHash| is not a valid <a>rpIdHash</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
-    <a>invalid argument</a>.
- 1. Let |privateKey| be the result of <a>trying</a> to decode <a>Base64url Encoding</a> on the |parameter|'s
+ 1. If |rpIdHash| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |rpIdHash| is not a valid [=rpIdHash=], return a [=WebDriver error=] with [=WebDriver error code=]
+    [=invalid argument=].
+ 1. Let |privateKey| be the result of [=trying=] to decode [=Base64url Encoding=] on the |parameter|'s
      {{CredentialParams/privateKey}} property.
- 1. If |privateKey| is failure, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
-     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. If |privateKey| is not a valid PKCS #8 encoded private key [[RFC5958]], return a <a>WebDriver error</a> with
-     <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Create a <a>Credential Key Pair</a> from |privateKey| identified by |credentialId| and an <a>Authenticator Data</a>
-     structure from |rpIdHash| and |signCount|, and store them in the database of the <a>Virtual Authenticator</a>
+ 1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |privateKey| is not a valid PKCS #8 encoded private key [[RFC5958]], return a [=WebDriver error=] with
+     [=WebDriver error code=] [=invalid argument=].
+ 1. Create a [=Credential Key Pair=] from |privateKey| identified by |credentialId| and an [=Authenticator Data=]
+     structure from |rpIdHash| and |signCount|, and store them in the database of the [=Virtual Authenticator=]
      identified by |authenticatorId|.
- 1. Return <a>success</a>.
+ 1. Return [=success=].
 
 ## <dfn>Get Credentials</dfn> ## {#sctn-automation-get-credentials}
 
-The <a>Get Credentials</a> <a>extension command</a> returns one {{CredentialParams}} for every <a>Credential Key Pair</a>
-and associated <a>Authenticator Data</a> stored in a <a>Virtual Authenticator</a>, regardless of whether they were
-stored using <a>Add Credential</a> or {{CredentialsContainer/create()|navigator.credentials.create()}}. The <a>extension command</a>
+The [=Get Credentials=] [=extension command=] returns one {{CredentialParams}} for every [=Credential Key Pair=]
+and associated [=Authenticator Data=] stored in a [=Virtual Authenticator=], regardless of whether they were
+stored using [=Add Credential=] or {{CredentialsContainer/create()|navigator.credentials.create()}}. The [=extension command=]
 is defined as follows:
 
 <figure id="table-getCredentials" class="table">
@@ -5686,17 +5686,17 @@ is defined as follows:
     </table>
 </figure>
 
-The <a>remote end steps</a> are:
+The [=remote end steps=] are:
 
- 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
-     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. For every <a>Credential Key Pair</a>, construct a corresponding {{CredentialParams}}.
- 1. Return <a>success</a> with the array of {{CredentialParams}}.
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. For every [=Credential Key Pair=], construct a corresponding {{CredentialParams}}.
+ 1. Return [=success=] with the array of {{CredentialParams}}.
 
 ## <dfn>Remove Credentials</dfn> ## {#sctn-automation-remove-credentials}
 
-The <a>Remove Credentials</a> <a>extension command</a> removes all <a>Credential Key Pairs</a> stored on a <a>Virtual Authenticator</a>.
-The <a>extension command</a> is defined as follows:
+The [=Remove Credentials=] [=extension command=] removes all [=Credential Key Pairs=] stored on a [=Virtual Authenticator=].
+The [=extension command=] is defined as follows:
 
 <figure id="table-removeCredentials" class="table">
     <table class="data">
@@ -5715,18 +5715,18 @@ The <a>extension command</a> is defined as follows:
     </table>
 </figure>
 
-The <a>remote end steps</a> are:
+The [=remote end steps=] are:
 
- 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
-     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Remove all <a>Credential Key Pairs</a> from the <a>Virtual Authenticator</a>'s database.
- 1. Return <a>success</a>.
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Remove all [=Credential Key Pairs=] from the [=Virtual Authenticator=]'s database.
+ 1. Return [=success=].
 
 ## <dfn>Set User Verified</dfn> ## {#sctn-automation-set-user-verified}
 
-The <a>Set User Verified</a> <a>extension command</a> sets the |isUserVerified| property on the <a>Virtual Authenticator</a>.
+The [=Set User Verified=] [=extension command=] sets the |isUserVerified| property on the [=Virtual Authenticator=].
 
-The <a>extension command</a> is defined as follows:
+The [=extension command=] is defined as follows:
 
     <xmp class="idl">
     dictionary UserVerifiedParams {
@@ -5751,12 +5751,12 @@ The <a>extension command</a> is defined as follows:
     </table>
 </figure>
 
-The <a>remote end steps</a> are:
+The [=remote end steps=] are:
 
- 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
-     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Set the <a>Virtual Authenticator</a>'s |isUserVerified| flag to {{UserVerifiedParams/isUserVerified}}.
- 1. Return <a>success</a>.
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Set the [=Virtual Authenticator=]'s |isUserVerified| flag to {{UserVerifiedParams/isUserVerified}}.
+ 1. Return [=success=].
 
 # IANA Considerations # {#sctn-IANA}
 

--- a/index.bs
+++ b/index.bs
@@ -245,6 +245,10 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
         text: success; url: dfn-success
         text: trying; url: dfn-try
 
+spec: RFC4122; urlPrefix: https://tools.ietf.org/html/rfc4122
+    type: dfn
+        text: generating a uuid; url: section-4.2
+
 spec: UTR29
     urlPrefix: https://unicode.org/reports/tr29/
         type: dfn; for:/; url: Grapheme_Cluster_Boundaries; text: grapheme cluster
@@ -5514,9 +5518,9 @@ Each stored [=virtual authenticator=] has the following properties:
 :: An non-null string made using up to 48 characters from the `unreserved` production defined in Appendix A of [[RFC3986]]
     that uniquely identifies the [=Virtual Authenticator=].
 
-    Note: This string can be a UUID [[RFC4122]].
+    Note: [=generating a uuid|Generating this string as a UUID=] is recommended.
 : |protocol|
-:: The protocol the [=Virtual Authenticator=] speaks: either `ctap2` or `ctap1-u2f` [[FIDO-CTAP]].
+:: The protocol the [=Virtual Authenticator=] speaks: either `ctap2` or `ctap1/u2f` [[FIDO-CTAP]].
 : |transport|
 :: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
     authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].

--- a/index.bs
+++ b/index.bs
@@ -5601,7 +5601,7 @@ The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=
                 <td>|isUserVerified|</td>
                 <td>boolean</td>
                 <td>[TRUE], [FALSE]</td>
-                <td>[TRUE]</td>
+                <td>[FALSE]</td>
             </tr>
         </tbody>
     </table>
@@ -5611,11 +5611,12 @@ The [=remote end steps=] are:
 
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
      [=invalid argument=].
+     Note: |parameters| is a [=Authenticator Configuration=] object.
  1. Let |authenticator| be a new [=Virtual Authenticator=].
  1. For each enumerable [=own property=] in |parameters|:
     1. Let |key| be the name of the property.
-    1. Let |value| be the result of [=getting a property=] named |name| from |parameter|.
-    1. If there is no matching `key` for |key| in the [=Authenticator Configuration=], return a [=WebDriver error=] with
+    1. Let |value| be the result of [=getting a property=] named |key| from |parameter|.
+    1. If there is no matching `key` for |key| in |parameters|, return a [=WebDriver error=] with
         [=WebDriver error code=] [=invalid argument=].
     1. If |value| is not one of the `valid values` for that |key|, return a [=WebDriver error=] with [=WebDriver error code=]
         [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -5522,9 +5522,10 @@ Each stored [=virtual authenticator=] has the following properties:
 :: If set to [TRUE] the authenticator will support [=resident credentials=].
 : |hasUserVerification|
 :: If set to [TRUE], the authenticator supports [=user verification=].
-: |isUserPresent|
-:: Determines the result of a [=test of user presence=] performed on the [=Virtual Authenticator=]. If set to [TRUE],
-    a [=test of user presence=] will always succeed. If set to [FALSE], it will fail.
+: |isUserConsenting|
+:: Determines the result of all [=user consent=] [=authorization gestures=], and by extension, any [=test of user presence=]
+    performed on the [=Virtual Authenticator=]. If set to [TRUE], a [=user consent=] will always be granted. If set to
+    [FALSE], it will not be granted.
 : |isUserVerified|
 :: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to [TRUE],
     [=User Verification=] will always succeed. If set to [FALSE], it will fail.
@@ -5591,7 +5592,7 @@ The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=
                 <td>[FALSE]</td>
             </tr>
             <tr>
-                <td>|isUserPresent|</td>
+                <td>|isUserConsenting|</td>
                 <td>boolean</td>
                 <td>[TRUE], [FALSE]</td>
                 <td>[TRUE]</td>

--- a/index.bs
+++ b/index.bs
@@ -5511,7 +5511,8 @@ These WebDriver [=extension commands=] create and interact with [=Virtual Authen
 Each stored [=virtual authenticator=] has the following properties:
 
 : <dfn>authenticatorId</dfn>
-:: An non-null string made of up to 48 Unreserved Characters [[RFC3986]] that uniquely identifies the [=Virtual Authenticator=].
+:: An non-null string made using up to 48 characters from the `unreserved` production defined in Appendix A of [[RFC3986]]
+    that uniquely identifies the [=Virtual Authenticator=].
 
     Note: This string can be a UUID [[RFC4122]].
 : |protocol|

--- a/index.bs
+++ b/index.bs
@@ -5721,7 +5721,7 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
             <tr>
                 <td>|userHandle|</td>
                 <td>
-                    The [=public key credential source/userHandle] associated to the credential encoded using
+                    The [=public key credential source/userHandle=] associated to the credential encoded using
                     [=Base64url Encoding=]. This property may not be defined.
                 </td>
                 <td>string</td>

--- a/index.bs
+++ b/index.bs
@@ -5665,15 +5665,6 @@ The [=remote end steps=] are:
 The [=Add Credential=] WebDriver [=extension command=] injects a [=Credential Key Pair=] and associated [=Authenticator Data=]
 into an existing [=Virtual Authenticator=]. It is defined as follows:
 
-    <xmp class="idl">
-    dictionary CredentialParams {
-        required USVString credentialId;
-        required USVString rpIdHash;
-        required USVString privateKey;
-        unsigned long signCount = 0;
-    };
-    </xmp>
-
 <figure id="table-addCredential" class="table">
     <table class="data">
         <thead>
@@ -5691,34 +5682,72 @@ into an existing [=Virtual Authenticator=]. It is defined as follows:
     </table>
 </figure>
 
+The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|. It contains the following |key| and |value| pairs:
+
+<figure id="table-credentialParameters" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Value Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>|credentialId|</td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|rpId|</td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|privateKey|</td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|signCount|</td>
+                <td>number</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
 The [=remote end steps=] are:
 
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
      [=invalid argument=].
- 1. Let |credentialId| be the result of [=trying=] to decode [=Base64url Encoding=] on the |parameter|'s
-     {{CredentialParams/credentialId}} property.
+     Note: |parameters| is a [=Credential Parameters=] object.
+ 1. Let |credentialId| be the result of decoding [=Base64url Encoding=] on the |parameter|'s |credentialId| property.
  1. If |credentialId| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |rpIdHash| be the result of [=trying=] to decode [=Base64url Encoding=] on the |parameter|'s
-     {{CredentialParams/rpIdHash}} property.
- 1. If |rpIdHash| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. If |rpIdHash| is not a valid [=rpIdHash=], return a [=WebDriver error=] with [=WebDriver error code=]
-    [=invalid argument=].
- 1. Let |privateKey| be the result of [=trying=] to decode [=Base64url Encoding=] on the |parameter|'s
-     {{CredentialParams/privateKey}} property.
+ 1. Let |rpId| be the the |parameter|'s |rpId| property.
+ 1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameter|'s |privateKey| property.
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single private key per [[RFC5958]],
+     return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single private key per [[RFC5958]], return a [=WebDriver error=] with
-     [=WebDriver error code=] [=invalid argument=].
- 1. Create a [=Credential Key Pair=] from |privateKey| identified by |credentialId| and an [=Authenticator Data=]
-     structure from |rpIdHash| and |signCount|, and store them in the database of the [=Virtual Authenticator=]
-     identified by |authenticatorId|.
+ 1. Let |credential| be a new [=Public Key Credential Source=] whose items are:
+    : [=public key credential source/type=]
+    :: {{public-key}}
+    : [=public key credential source/id=]
+    :: |credentialId|
+    : [=public key credential source/privateKey=]
+    :: |privateKey|
+    : [=public key credential source/rpId=]
+    :: |rpId|
+    : [=public key credential source/userHandle=]
+    :: `null`
+ 1. Let |signCount| be the |parameter|'s |signCount| parameter or `0` if |signCount| is `null`.
+ 1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to |signCount|.
+ 1. Store the |credential| and |counter| in the database of the [=Virtual Authenticator=] identified by |authenticatorId|.
  1. Return [=success=].
 
 ## <dfn>Get Credentials</dfn> ## {#sctn-automation-get-credentials}
 
-The [=Get Credentials=] WebDriver [=extension command=] returns one {{CredentialParams}} for every [=Credential Key Pair=]
-and associated [=Authenticator Data=] stored in a [=Virtual Authenticator=], regardless of whether they were
+The [=Get Credentials=] WebDriver [=extension command=] returns one [=Credential Parameters=] object for every
+[=Public Key Credential Source=] stored in a [=Virtual Authenticator=], regardless of whether they were
 stored using [=Add Credential=] or {{CredentialsContainer/create()|navigator.credentials.create()}}. It is defined as follows:
 
 <figure id="table-getCredentials" class="table">

--- a/index.bs
+++ b/index.bs
@@ -5519,6 +5519,9 @@ Each stored [=virtual authenticator=] has the following properties:
 :: If set to [TRUE] the authenticator will support [=resident credentials=].
 : |hasUserVerification|
 :: If set to [TRUE], the authenticator supports [=user verification=].
+: |isUserPresent|
+:: Determines the result of a [=test of user presence=] performed on the [=Virtual Authenticator=]. If set to `true`,
+    a [=test of user presence=] will always succeed. If set to `false`, it will fail.
 : |isUserVerified|
 :: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to `true`,
     [=User Verification=] will always succeed. If set to `false`, it will fail. This property has no effect if
@@ -5540,6 +5543,7 @@ WebDriver [=extension command=] is defined as follows:
         required AuthenticatorTransport transport;
         boolean hasResidentKey = false;
         boolean hasUserVerification = false;
+        boolean isUserPresent = true;
         boolean isUserVerified = true;
     };
     </xmp>
@@ -5573,7 +5577,7 @@ The [=remote end steps=] are:
  1. If |transport| is null, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Generate an arbitrary and unique string |authenticatorId|.
  1. Create a new [=Virtual Authenticator=] with the fields |authenticatorId|, |protocol|, |transport|,
-    |hasResidentKey|, |hasUserVerification|, and |isUserVerified|.
+    |hasResidentKey|, |hasUserVerification|, |isUserPresent|, and |isUserVerified|.
  1. Store the authenticator in the [=Virtual Authenticator Database=].
  1. Return [=success=] with data |authenticatorId|.
 

--- a/index.bs
+++ b/index.bs
@@ -5594,7 +5594,7 @@ The [=extension command=] is defined as follows:
         <tbody>
             <tr>
                 <td>DELETE</td>
-                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId`</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}</td>
             </tr>
         </tbody>
     </table>
@@ -5632,7 +5632,7 @@ into an existing [=Virtual Authenticator=]. The [=extension command=] is defined
         <tbody>
             <tr>
                 <td>POST</td>
-                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/credential`</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credential`</td>
             </tr>
         </tbody>
     </table>
@@ -5680,7 +5680,7 @@ is defined as follows:
         <tbody>
             <tr>
                 <td>GET</td>
-                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/credentials`</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credentials`</td>
             </tr>
         </tbody>
     </table>
@@ -5709,7 +5709,7 @@ The [=extension command=] is defined as follows:
         <tbody>
             <tr>
                 <td>DELETE</td>
-                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/credentials`</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credentials`</td>
             </tr>
         </tbody>
     </table>
@@ -5745,7 +5745,7 @@ The [=extension command=] is defined as follows:
         <tbody>
             <tr>
                 <td>POST</td>
-                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/uv`</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/uv`</td>
             </tr>
         </tbody>
     </table>

--- a/index.bs
+++ b/index.bs
@@ -5739,6 +5739,7 @@ The [=remote end steps=] are:
 
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
      [=invalid argument=].
+
      Note: |parameters| is a [=Credential Parameters=] object.
  1. Let |credentialId| be the result of decoding [=Base64url Encoding=] on the |parameters|' |credentialId| property.
  1. If |credentialId| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
@@ -5805,7 +5806,7 @@ The [=remote end steps=] are:
 
 ## <dfn>Remove Credential</dfn> ## {#sctn-automation-remove-credential}
 
-The [=Remove Credential=] WebDriver [=extension command=] removes a [=Public Key Credential Sources=] stored on a
+The [=Remove Credential=] WebDriver [=extension command=] removes a [=Public Key Credential Source=] stored on a
 [=Virtual Authenticator=]. It is defined as follows:
 
 <figure id="table-removeCredential" class="table">

--- a/index.bs
+++ b/index.bs
@@ -5758,6 +5758,7 @@ The [=remote end steps=] are:
      1. Let |userHandle| be the result of decoding [=Base64url Encoding=] on the |parameters|' |userHandle| property.
      1. If |userHandle| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Otherwise:
+    1. If |isResidentCredential| is [TRUE], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
     1. Let |userHandle| be `null`.
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -5509,7 +5509,7 @@ These WebDriver [=extension commands=] create and interact with [=Virtual Authen
 Each stored [=virtual authenticator=] has the following properties:
 
 : |authenticatorId|
-:: An arbitrary non-null string that uniquely identifies the [=Virtual Authenticator=].
+:: An non-null string made of up to 48 Unreserved Characters [[RFC3986]] that uniquely identifies the [=Virtual Authenticator=].
 : |protocol|
 :: The protocol the [=Virtual Authenticator=] uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
 : |transport|

--- a/index.bs
+++ b/index.bs
@@ -5708,13 +5708,8 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
             <tr>
                 <td>|privateKey|</td>
                 <td>
-                    The [=public key credential source/privateKey|private key=] encoded in COSE_Key format,
-                    as defined in [=Section 7=] of [[!RFC8152]], using the [=CTAP2 canonical CBOR encoding form=].
-                    The COSE_Key-encoded [=public key credential source/privateKey|private key=] MUST contain the "alg"
-                    parameter and MUST NOT contain any other OPTIONAL parameters. The "alg" parameter MUST contain a
-                    {{COSEAlgorithmIdentifier}} value. The encoded [=credential public key=] MUST also contain any
-                    additional REQUIRED parameters stipulated by the relevant key type specification, i.e., REQUIRED for
-                    the key type "kty" and algorithm "alg" (see Section 8 of [[!RFC8152]]).
+                    An asymmetric key package containing a single [=public key credential source/privateKey|private key=]
+                    per [[RFC5958]], encoded using [=Base64url Encoding=].
                 </td>
                 <td>string</td>
             </tr>
@@ -5747,8 +5742,8 @@ The [=remote end steps=] are:
  1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameters|' |privateKey| property.
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. If |privateKey| is not a validly-encoded COSE_Key private key per [[RFC8152]], return a [=WebDriver error=] with
-     [=WebDriver error code=] [=invalid argument=].
+ 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single private key per [[RFC5958]],
+     return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. If the |parameters|' |userHandle| property is defined:
      1. Let |userHandle| be the result of decoding [=Base64url Encoding=] on the |parameters|' |userHandle| property.
      1. If |userHandle| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -5719,6 +5719,14 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>string</td>
             </tr>
             <tr>
+                <td>|userHandle|</td>
+                <td>
+                    The [=public key credential source/userHandle] associated to the credential encoded using
+                    [=Base64url Encoding=]. This property may not be defined.
+                </td>
+                <td>string</td>
+            </tr>
+            <tr>
                 <td>|signCount|</td>
                 <td>The initial value for a [=signature counter=] associated to the [=public key credential source=].</td>
                 <td>number</td>
@@ -5740,6 +5748,11 @@ The [=remote end steps=] are:
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. If |privateKey| is not a validly-encoded COSE_Key private key per [[RFC8152]], return a [=WebDriver error=] with
      [=WebDriver error code=] [=invalid argument=].
+ 1. If the |parameters|' |userHandle| property is defined:
+     1. Let |userHandle| be the result of decoding [=Base64url Encoding=] on the |parameters|' |userHandle| property.
+     1. If |userHandle| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Otherwise:
+    1. Let |userHandle| be `null`.
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |credential| be a new [=Public Key Credential Source=] whose items are:
@@ -5752,7 +5765,7 @@ The [=remote end steps=] are:
     : [=public key credential source/rpId=]
     :: |rpId|
     : [=public key credential source/userHandle=]
-    :: `null`
+    :: |userHandle|
  1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'
      |signCount| or `0` if |signCount| is `null`.
  1. Store the |credential| and |counter| in the database of the [=Virtual Authenticator=] identified by |authenticatorId|.

--- a/index.bs
+++ b/index.bs
@@ -245,10 +245,6 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
         text: success; url: dfn-success
         text: trying; url: dfn-try
 
-spec: RFC4122; urlPrefix: https://tools.ietf.org/html/rfc4122
-    type: dfn
-        text: generating a uuid; url: section-4.2
-
 spec: UTR29
     urlPrefix: https://unicode.org/reports/tr29/
         type: dfn; for:/; url: Grapheme_Cluster_Boundaries; text: grapheme cluster
@@ -5517,8 +5513,6 @@ Each stored [=virtual authenticator=] has the following properties:
 : <dfn>authenticatorId</dfn>
 :: An non-null string made using up to 48 characters from the `unreserved` production defined in Appendix A of [[RFC3986]]
     that uniquely identifies the [=Virtual Authenticator=].
-
-    Note: [=generating a uuid|Generating this string as a UUID=] is recommended.
 : |protocol|
 :: The protocol the [=Virtual Authenticator=] speaks: either `ctap2` or `ctap1/u2f` [[FIDO-CTAP]].
 : |transport|

--- a/index.bs
+++ b/index.bs
@@ -5708,8 +5708,13 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
             <tr>
                 <td>|privateKey|</td>
                 <td>
-                    An asymmetric key package containing a single [=public key credential source/privateKey|private key=]
-                    per [[RFC5958]], encoded using [=Base64url Encoding=].
+                    The [=public key credential source/privateKey|private key=] encoded in COSE_Key format,
+                    as defined in [=Section 7=] of [[!RFC8152]], using the [=CTAP2 canonical CBOR encoding form=].
+                    The COSE_Key-encoded [=public key credential source/privateKey|private key=] MUST contain the "alg"
+                    parameter and MUST NOT contain any other OPTIONAL parameters. The "alg" parameter MUST contain a
+                    {{COSEAlgorithmIdentifier}} value. The encoded [=credential public key=] MUST also contain any
+                    additional REQUIRED parameters stipulated by the relevant key type specification, i.e., REQUIRED for
+                    the key type "kty" and algorithm "alg" (see Section 8 of [[!RFC8152]]).
                 </td>
                 <td>string</td>
             </tr>
@@ -5733,8 +5738,8 @@ The [=remote end steps=] are:
  1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameters|' |privateKey| property.
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single private key per [[RFC5958]],
-     return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |privateKey| is not a validly-encoded COSE_Key private key per [[RFC8152]], return a [=WebDriver error=] with
+     [=WebDriver error code=] [=invalid argument=].
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |credential| be a new [=Public Key Credential Source=] whose items are:

--- a/index.bs
+++ b/index.bs
@@ -5510,8 +5510,11 @@ These WebDriver [=extension commands=] create and interact with [=Virtual Authen
 <a>Authenticator Model</a>. <a>Virtual Authenticators</a> are stored in a <dfn>Virtual Authenticator Database</dfn>.
 Each stored [=virtual authenticator=] has the following properties:
 
-: |authenticatorId|
+: <dfn>authenticatorId</dfn>
 :: An non-null string made of up to 48 Unreserved Characters [[RFC3986]] that uniquely identifies the [=Virtual Authenticator=].
+    <div class="note">
+        Note: This string can be a UUID [[RFC4122]].
+    </div>
 : |protocol|
 :: The protocol the [=Virtual Authenticator=] uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
 : |transport|
@@ -5553,7 +5556,7 @@ WebDriver [=extension command=] is defined as follows:
 
 The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] containing the following parameters:
 
-<figure id="table-addVirtualAuthenticator" class="table">
+<figure id="table-authenticatorConfiguration" class="table">
     <table class="data">
         <thead>
             <tr>
@@ -5622,10 +5625,7 @@ The [=remote end steps=] are:
  1. For each property in [=Authenticator Configuration=]:
     1. If `key` is not a defined property of |authenticator|, return a [=WebDriver error=] with [=WebDriver error code=]
         [=invalid argument=].
- 1. Generate an unique string |authenticatorId| out of Unreserved Characters [[RFC3986]].
-    <div class="note">
-        Note: This string can be a UUID [[RFC4122]].
-    </div>
+ 1. Generate an valid unique [=authenticatorId=].
  1. [=Set a property=] `authenticatorId` to |authenticatorId| on |authenticator|.
  1. Store |authenticator| in the [=Virtual Authenticator Database=].
  1. Return [=success=] with data |authenticatorId|.

--- a/index.bs
+++ b/index.bs
@@ -5506,7 +5506,7 @@ For the purposes of user agent automation and [=web application=] testing, this 
 
 These WebDriver [=extension commands=] create and interact with [=Virtual Authenticators=]: software implementations of the
 <a>Authenticator Model</a>. <a>Virtual Authenticators</a> are stored in a <dfn>Virtual Authenticator Database</dfn>.
-have the following properties:
+Each stored [=virtual authenticator=] has the following properties:
 
 : |authenticatorId|
 :: An arbitrary non-null string that uniquely identifies the [=Virtual Authenticator=].

--- a/index.bs
+++ b/index.bs
@@ -5512,9 +5512,8 @@ Each stored [=virtual authenticator=] has the following properties:
 
 : <dfn>authenticatorId</dfn>
 :: An non-null string made of up to 48 Unreserved Characters [[RFC3986]] that uniquely identifies the [=Virtual Authenticator=].
-    <div class="note">
-        Note: This string can be a UUID [[RFC4122]].
-    </div>
+
+    Note: This string can be a UUID [[RFC4122]].
 : |protocol|
 :: The protocol the [=Virtual Authenticator=] speaks: either `ctap2` or `ctap1-u2f` [[FIDO-CTAP]].
 : |transport|
@@ -5529,8 +5528,9 @@ Each stored [=virtual authenticator=] has the following properties:
     a [=test of user presence=] will always succeed. If set to [FALSE], it will fail.
 : |isUserVerified|
 :: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to [TRUE],
-    [=User Verification=] will always succeed. If set to [FALSE], it will fail. This property has no effect if
-    |hasUserVerification| is set to [FALSE].
+    [=User Verification=] will always succeed. If set to [FALSE], it will fail.
+
+    Note: This property has no effect if |hasUserVerification| is set to [FALSE].
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
@@ -5611,11 +5611,12 @@ The [=remote end steps=] are:
 
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
      [=invalid argument=].
+
      Note: |parameters| is a [=Authenticator Configuration=] object.
  1. Let |authenticator| be a new [=Virtual Authenticator=].
  1. For each enumerable [=own property=] in |parameters|:
     1. Let |key| be the name of the property.
-    1. Let |value| be the result of [=getting a property=] named |key| from |parameter|.
+    1. Let |value| be the result of [=getting a property=] named |key| from |parameters|.
     1. If there is no matching `key` for |key| in |parameters|, return a [=WebDriver error=] with
         [=WebDriver error code=] [=invalid argument=].
     1. If |value| is not one of the `valid values` for that |key|, return a [=WebDriver error=] with [=WebDriver error code=]
@@ -5626,7 +5627,7 @@ The [=remote end steps=] are:
  1. For each property in [=Authenticator Configuration=]:
     1. If `key` is not a defined property of |authenticator|, return a [=WebDriver error=] with [=WebDriver error code=]
         [=invalid argument=].
- 1. Generate an valid unique [=authenticatorId=].
+ 1. Generate a valid unique [=authenticatorId=].
  1. [=Set a property=] `authenticatorId` to |authenticatorId| on |authenticator|.
  1. Store |authenticator| in the [=Virtual Authenticator Database=].
  1. Return [=success=] with data |authenticatorId|.
@@ -5718,11 +5719,11 @@ The [=remote end steps=] are:
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
      [=invalid argument=].
      Note: |parameters| is a [=Credential Parameters=] object.
- 1. Let |credentialId| be the result of decoding [=Base64url Encoding=] on the |parameter|'s |credentialId| property.
+ 1. Let |credentialId| be the result of decoding [=Base64url Encoding=] on the |parameters|' |credentialId| property.
  1. If |credentialId| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |rpId| be the the |parameter|'s |rpId| property.
+ 1. Let |rpId| be the the |parameters|'' |rpId| property.
  1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameter|'s |privateKey| property.
+ 1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameters|' |privateKey| property.
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. If |privateKey| is not a validly-encoded asymmetric key package containing a single private key per [[RFC5958]],
      return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
@@ -5739,8 +5740,8 @@ The [=remote end steps=] are:
     :: |rpId|
     : [=public key credential source/userHandle=]
     :: `null`
- 1. Let |signCount| be the |parameter|'s |signCount| parameter or `0` if |signCount| is `null`.
- 1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to |signCount|.
+ 1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'
+     |signCount| or `0` if |signCount| is `null`.
  1. Store the |credential| and |counter| in the database of the [=Virtual Authenticator=] identified by |authenticatorId|.
  1. Return [=success=].
 
@@ -5771,13 +5772,15 @@ The [=remote end steps=] are:
 
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. For every [=Credential Key Pair=], construct a corresponding {{CredentialParams}}.
+ 1. Let |credentialsArray| be an empty array.
+ 1. For each [=Public Key Credential Source=] |credential|, managed by the authenticator identified by |authenticatorId|,
+    construct a corresponding [=Credential Parameters=] [=Object=] and add it to |credentialsArray|.
  1. Return [=success=] with data containing |credentialsArray|.
 
 ## <dfn>Remove Credentials</dfn> ## {#sctn-automation-remove-credentials}
 
-The [=Remove Credentials=] WebDriver [=extension command=] removes all [=Credential Key Pairs=] stored on a [=Virtual Authenticator=].
-It is defined as follows:
+The [=Remove Credentials=] WebDriver [=extension command=] removes all [=Public Key Credential Sources=] stored on a
+[=Virtual Authenticator=]. It is defined as follows:
 
 <figure id="table-removeCredentials" class="table">
     <table class="data">
@@ -5800,19 +5803,13 @@ The [=remote end steps=] are:
 
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Remove all [=Credential Key Pairs=] from the [=Virtual Authenticator=]'s database.
+ 1. Remove all [=Public Key Credential Sources=] managed by the [=Virtual Authenticator=] identified by |authenticatorId|.
  1. Return [=success=].
 
 ## <dfn>Set User Verified</dfn> ## {#sctn-automation-set-user-verified}
 
 The [=Set User Verified=] [=extension command=] sets the |isUserVerified| property on the [=Virtual Authenticator=]. It
 is defined as follows:
-
-    <xmp class="idl">
-    dictionary UserVerifiedParams {
-        required boolean isUserVerified;
-    };
-    </xmp>
 
 <figure id="table-setUserVerified" class="table">
     <table class="data">
@@ -5833,9 +5830,14 @@ is defined as follows:
 
 The [=remote end steps=] are:
 
+ 1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Set the [=Virtual Authenticator=]'s |isUserVerified| flag to {{UserVerifiedParams/isUserVerified}}.
+ 1. If |isUserVerified| is not a defined property of |parameters|, return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+ 1. Let |authenticator| be the [=Virtual Authenticator=] identified by |authenticatorId|.
+ 1. Set the |authenticator|'s |isUserVerified| property to the |parameters|' |isUserVerified| property.
  1. Return [=success=].
 
 # IANA Considerations # {#sctn-IANA}

--- a/index.bs
+++ b/index.bs
@@ -5721,7 +5721,7 @@ The [=remote end steps=] are:
      Note: |parameters| is a [=Credential Parameters=] object.
  1. Let |credentialId| be the result of decoding [=Base64url Encoding=] on the |parameters|' |credentialId| property.
  1. If |credentialId| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |rpId| be the the |parameters|'' |rpId| property.
+ 1. Let |rpId| be the the |parameters|' |rpId| property.
  1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameters|' |privateKey| property.
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -5181,9 +5181,9 @@ have the following properties:
 : |hasUserVerification|
 :: If set to `true`, the authenticator will support [=user verification=].
 
-## Add Virtual Authenticator ## {#sctn-automation-add-virtual-authenticator}
+## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
-The <dfn>Add Virtual Authenticator</dfn> <a>extension command</a> creates a software <a>Virtual Authenticator</a> and 
+The <a>Add Virtual Authenticator</a> <a>extension command</a> creates a software <a>Virtual Authenticator</a> and 
 The <a>extension command</a> is defined as follows:
 
     <xmp class="idl">
@@ -5236,6 +5236,37 @@ The <a>remote end steps</a> are:
  1. Create a new <a>Virtual Authenticator</a> with the fields |authenticatorId|, |protocol|, |transport|, |attachment|,
     |hasResidentKey|, and |hasUserVerification|.
  1. Store the authenticator in the <a>Virtual Authenticator Database</a>.
+ 1. Return <a>success</a>.
+
+## <dfn>Remove Virtual Authenticator</dfn> ## {#sctn-automation-remove-virtual-authenticator}
+
+The <a>Remove Virtual Authenticator</a> <a>extension command</a> removes a previously created <a>Virtual Authenticator</a>.
+The <a>extension command</a> is defined as follows:
+
+<figure id="table-removeVirtualAuthenticator" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>DELETE</td>
+                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <a>remote end steps</a> are:
+
+ 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
+     Database</a>, return is not a JSON <a>Object</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
+     <a>invalid argument</a>.
+ 1. Remove the <a>Virtual Authenticator</a> identified by |authenticatorId| from the <a>Virtual Authenticator Database</a>
+ 1. Return <a>success</a>.
 
 # IANA Considerations # {#sctn-IANA}
 

--- a/index.bs
+++ b/index.bs
@@ -113,6 +113,7 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
         url: sec-object-internal-methods-and-internal-slots
             text: internal method
             text: internal slot
+        text: own property; url: sec-own-property
 
 spec: RFC8152; urlPrefix: https://tools.ietf.org/html/rfc8152
     type: dfn
@@ -235,6 +236,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
         text: extension command; url: dfn-extension-command
         text: extension command name; url: dfn-extension-command-name
         text: getting a property; url: dfn-getting-properties
+        text: set a property; url: dfn-set-a-property
         text: prefix; url: dfn-url-prefix
         text: invalid argument; url: dfn-invalid-argument
         text: local end; url: dfn-local-end
@@ -5520,33 +5522,17 @@ Each stored [=virtual authenticator=] has the following properties:
 : |hasUserVerification|
 :: If set to [TRUE], the authenticator supports [=user verification=].
 : |isUserPresent|
-:: Determines the result of a [=test of user presence=] performed on the [=Virtual Authenticator=]. If set to `true`,
-    a [=test of user presence=] will always succeed. If set to `false`, it will fail.
+:: Determines the result of a [=test of user presence=] performed on the [=Virtual Authenticator=]. If set to [TRUE],
+    a [=test of user presence=] will always succeed. If set to [FALSE], it will fail.
 : |isUserVerified|
-:: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to `true`,
-    [=User Verification=] will always succeed. If set to `false`, it will fail. This property has no effect if
-    |hasUserVerification| is set to `false`.
+:: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to [TRUE],
+    [=User Verification=] will always succeed. If set to [FALSE], it will fail. This property has no effect if
+    |hasUserVerification| is set to [FALSE].
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
 The [=Add Virtual Authenticator=] [=extension command=] creates a software [=Virtual Authenticator=]. The
 WebDriver [=extension command=] is defined as follows:
-
-    <xmp class="idl">
-    enum AuthenticatorProtocol {
-        "u2f",
-        "ctap2",
-    };
-
-    dictionary AddVirtualAuthenticatorParameters {
-        required AuthenticatorProtocol protocol;
-        required AuthenticatorTransport transport;
-        boolean hasResidentKey = false;
-        boolean hasUserVerification = false;
-        boolean isUserPresent = true;
-        boolean isUserVerified = true;
-    };
-    </xmp>
 
 <figure id="table-addVirtualAuthenticator" class="table">
     <table class="data">
@@ -5565,20 +5551,83 @@ WebDriver [=extension command=] is defined as follows:
     </table>
 </figure>
 
+The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] containing the following parameters:
+
+<figure id="table-addVirtualAuthenticator" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Value Type</th>
+                <th>Valid Values</th>
+                <th>Default</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>|protocol|</td>
+                <td>string</td>
+                <td>`"u2f"`, `"ctap2"`</td>
+                <td>None</td>
+            </tr>
+            <tr>
+                <td>|transport|</td>
+                <td>string</td>
+                <td>{{AuthenticatorTransport}} values</td>
+                <td>None</td>
+            </tr>
+            <tr>
+                <td>|hasResidentKey|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[FALSE]</td>
+            </tr>
+            <tr>
+                <td>|hasUserVerification|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[FALSE]</td>
+            </tr>
+            <tr>
+                <td>|isUserPresent|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[TRUE]</td>
+            </tr>
+            <tr>
+                <td>|isUserVerified|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[TRUE]</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
 The [=remote end steps=] are:
 
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
      [=invalid argument=].
- 1. Let |protocol| be the result of [=trying=] to get the |parameter|'s {{AddVirtualAuthenticatorParameters/protocol}}
-    property.
- 1. If |protocol| is null, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |transport| be the result of [=trying=] to get the |parameter|'s {{AddVirtualAuthenticatorParameters/transport}}
-    property.
- 1. If |transport| is null, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Generate an arbitrary and unique string |authenticatorId|.
- 1. Create a new [=Virtual Authenticator=] with the fields |authenticatorId|, |protocol|, |transport|,
-    |hasResidentKey|, |hasUserVerification|, |isUserPresent|, and |isUserVerified|.
- 1. Store the authenticator in the [=Virtual Authenticator Database=].
+ 1. Let |authenticator| be a new [=Virtual Authenticator=].
+ 1. For each enumerable [=own property=] in |parameters|:
+    1. Let |key| be the name of the property.
+    1. Let |value| be the result of [=getting a property=] named |name| from |parameter|.
+    1. If there is no matching `key` for |key| in the [=Authenticator Configuration=], return a [=WebDriver error=] with
+        [=WebDriver error code=] [=invalid argument=].
+    1. If |value| is not one of the `valid values` for that |key|, return a [=WebDriver error=] with [=WebDriver error code=]
+        [=invalid argument=].
+    1. [=Set a property=] |key| to |value| on |authenticator|.
+ 1. For each property in [=Authenticator Configuration=] with a default defined:
+    1. If `key` is not a defined property of |authenticator|, [=set a property=] `key` to `default` on |authenticator|.
+ 1. For each property in [=Authenticator Configuration=]:
+    1. If `key` is not a defined property of |authenticator|, return a [=WebDriver error=] with [=WebDriver error code=]
+        [=invalid argument=].
+ 1. Generate an unique string |authenticatorId| out of Unreserved Characters [[RFC3986]].
+    <div class="note">
+        Note: This string can be a UUID [[RFC4122]].
+    </div>
+ 1. [=Set a property=] `authenticatorId` to |authenticatorId| on |authenticator|.
+ 1. Store |authenticator| in the [=Virtual Authenticator Database=].
  1. Return [=success=] with data |authenticatorId|.
 
 ## <dfn>Remove Virtual Authenticator</dfn> ## {#sctn-automation-remove-virtual-authenticator}

--- a/index.bs
+++ b/index.bs
@@ -5663,8 +5663,8 @@ The [=remote end steps=] are:
 
 ## <dfn>Add Credential</dfn> ## {#sctn-automation-add-credential}
 
-The [=Add Credential=] WebDriver [=extension command=] injects a [=Credential Key Pair=] and associated [=Authenticator Data=]
-into an existing [=Virtual Authenticator=]. It is defined as follows:
+The [=Add Credential=] WebDriver [=extension command=] injects a [=Public Key Credential Source=] into an existing
+[=Virtual Authenticator=]. It is defined as follows:
 
 <figure id="table-addCredential" class="table">
     <table class="data">
@@ -5690,24 +5690,32 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
         <thead>
             <tr>
                 <th>Key</th>
+                <th>Description</th>
                 <th>Value Type</th>
             </tr>
         </thead>
         <tbody>
             <tr>
                 <td>|credentialId|</td>
+                <td>The [=public key credential source/id|Credential ID=] encoded using [=Base64url Encoding=].</td>
                 <td>string</td>
             </tr>
             <tr>
                 <td>|rpId|</td>
+                <td>The [=public key credential source/rpId|Relying Party ID=] the credential is scoped to.</td>
                 <td>string</td>
             </tr>
             <tr>
                 <td>|privateKey|</td>
+                <td>
+                    An asymmetric key package containing a single [=public key credential source/privateKey|private key=]
+                    per [[RFC5958]], encoded using [=Base64url Encoding=].
+                </td>
                 <td>string</td>
             </tr>
             <tr>
                 <td>|signCount|</td>
+                <td>The initial value for a [=signature counter=] associated to the [=public key credential source=].</td>
                 <td>number</td>
             </tr>
         </tbody>

--- a/index.bs
+++ b/index.bs
@@ -5761,6 +5761,9 @@ The [=remote end steps=] are:
     1. Let |userHandle| be `null`.
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |authenticator| be the [=Virtual Authenticator=] matched by |authenticatorId|.
+ 1. If |isResidentCredential| is [TRUE] and the |authenticator|'s |hasResidentKey| property is [FALSE], return a
+     [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |credential| be a new [=Client-side-resident Public Key Credential Source=] if |isResidentCredential| is [TRUE]
      or a [=Server-side-resident Public Key Credential Source=] otherwise whose items are:
     : [=public key credential source/type=]
@@ -5775,7 +5778,7 @@ The [=remote end steps=] are:
     :: |userHandle|
  1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'
      |signCount| or `0` if |signCount| is `null`.
- 1. Store the |credential| and |counter| in the database of the [=Virtual Authenticator=] identified by |authenticatorId|.
+ 1. Store the |credential| and |counter| in the database of the |authenticator|.
  1. Return [=success=].
 
 ## <dfn>Get Credentials</dfn> ## {#sctn-automation-get-credentials}

--- a/index.bs
+++ b/index.bs
@@ -217,6 +217,20 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl
     type: dfn;
         text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-reference
 
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
+    type: dfn
+        text: WebDriver error; url: dfn-error
+        text: WebDriver error code; url: dfn-error-code
+        text: extension command; url: dfn-extension-command
+        text: extension command name; url: dfn-extension-command-name
+        text: prefix; url: dfn-url-prefix
+        text: invalid argument; url: dfn-invalid-argument
+        text: local end; url: dfn-local-end
+        text: remote end steps; url: dfn-remote-end-steps
+        text: session; url: dfn-session
+        text: success; url: dfn-success
+        text: trying; url: dfn-try
+
 </pre> <!-- class=anchors -->
 
 <!-- L128 spec:webappsec-credential-management-1; type:dictionary; for:/; text:CredentialRequestOptions -->
@@ -5141,6 +5155,87 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 : Authenticator extension output
 :: None.
 
+
+# Automation # {#sctn-automation}
+
+For the purposes of user-agent automation and application testing, this document defines a number of <a>extension
+commands</a> for the [[WebDriver]] specification. 
+
+## <dfn>Virtual Authenticators</dfn> ## {#sctn-automation-virtual-authenticators}
+
+These <a>extension commands</a> create and interact with <a>Virtual Authenticators</a>: software implementations of the
+<a>Authenticator Model</a>. <a>Virtual Authenticators</a> are stored in a <dfn>Virtual Authenticator Database</dfn> and
+have the following properties:
+
+: |authenticatorId|
+:: An arbitrary non-null string that uniquely identifies the <a>Virtual Authenticator</a>.
+: |protocol|
+:: The protocol the <a>Virtual Authenticator</a> uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
+    or `u2f` for the [[FIDO-U2F-Message-Formats]].
+: |transport|
+:: The {{AuthenticatorTransport}} simulated.
+: |attachment|
+:: The {{AuthenticatorAttachment}} simulated.
+: |hasResidentKey|
+:: If set to `true`, the authenticator will support [=resident credentials=].
+: |hasUserVerification|
+:: If set to `true`, the authenticator will support [=user verification=].
+
+## Add Virtual Authenticator ## {#sctn-automation-add-virtual-authenticator}
+
+The <dfn>Add Virtual Authenticator</dfn> <a>extension command</a> creates a software <a>Virtual Authenticator</a> and 
+The <a>extension command</a> is defined as follows:
+
+    <xmp class="idl">
+    enum AuthenticatorProtocol {
+        "u2f",
+        "ctap2",
+    };
+
+    dictionary AddVirtualAuthenticatorParameters {
+        required AuthenticatorProtocol protocol;
+        required AuthenticatorTransport transport;
+        required AuthenticatorAttachment attachment;
+        boolean hasResidentKey = false;
+        boolean hasUserVerification = false;
+    };
+    </xmp>
+
+<figure id="table-addVirtualAuthenticator" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>POST</td>
+                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <a>remote end steps</a> are:
+
+ 1. If |parameters| is not a JSON <a>Object</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
+     <a>invalid argument</a>.
+ 1. Let |protocol| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/protocol}}
+    property.
+ 1. If |protocol| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Let |transport| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/transport}}
+    property.
+ 1. If |transport| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Let |attachment| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/attachment}}
+    property.
+ 1. If |attachment| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. If a <a>Virtual Authenticator</a> with the same |authenticatorId| already exists in the <a>Virtual Authenticator
+    Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Create a new <a>Virtual Authenticator</a> with the fields |authenticatorId|, |protocol|, |transport|, |attachment|,
+    |hasResidentKey|, and |hasUserVerification|.
+ 1. Store the authenticator in the <a>Virtual Authenticator Database</a>.
 
 # IANA Considerations # {#sctn-IANA}
 

--- a/index.bs
+++ b/index.bs
@@ -5777,12 +5777,44 @@ The [=remote end steps=] are:
     construct a corresponding [=Credential Parameters=] [=Object=] and add it to |credentialsArray|.
  1. Return [=success=] with data containing |credentialsArray|.
 
-## <dfn>Remove Credentials</dfn> ## {#sctn-automation-remove-credentials}
+## <dfn>Remove Credential</dfn> ## {#sctn-automation-remove-credential}
 
-The [=Remove Credentials=] WebDriver [=extension command=] removes all [=Public Key Credential Sources=] stored on a
+The [=Remove Credential=] WebDriver [=extension command=] removes a [=Public Key Credential Sources=] stored on a
 [=Virtual Authenticator=]. It is defined as follows:
 
-<figure id="table-removeCredentials" class="table">
+<figure id="table-removeCredential" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>DELETE</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credentials/{credentialId}`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |authenticator| be the [=Virtual Authenticator=] identified by |authenticatorId|.
+ 1. If |credentialId| does not match any [=Public Key Credential Source=] managed by |authenticator|, return a [=WebDriver error=]
+     with [=WebDriver error code=] [=invalid argument=].
+ 1. Remove the [=Public Key Credential Source=] identified by |credentialId| managed by |authenticator|.
+ 1. Return [=success=].
+
+## <dfn>Remove All Credentials</dfn> ## {#sctn-automation-remove-all-credentials}
+
+The [=Remove All Credentials=] WebDriver [=extension command=] removes all [=Public Key Credential Sources=] stored on a
+[=Virtual Authenticator=]. It is defined as follows:
+
+<figure id="table-removeAllCredentials" class="table">
     <table class="data">
         <thead>
             <tr>

--- a/index.bs
+++ b/index.bs
@@ -5263,9 +5263,60 @@ The <a>extension command</a> is defined as follows:
 The <a>remote end steps</a> are:
 
  1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
-     Database</a>, return is not a JSON <a>Object</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
-     <a>invalid argument</a>.
+     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
  1. Remove the <a>Virtual Authenticator</a> identified by |authenticatorId| from the <a>Virtual Authenticator Database</a>
+ 1. Return <a>success</a>.
+
+## <dfn>Add Credential</dfn> ## {#sctn-automation-add-credential}
+
+The <a>Add Credential</a> <a>extension command</a> injects a <a>Credential Key Pair</a> and associated <a>Authenticator Data</a>
+into an existing <a>Virtual Authenticator</a>. The <a>extension command</a> is defined as follows:
+
+    <xmp class="idl">
+    dictionary CredentialParams {
+        required USVString credentialId;
+        required USVString rpIdHash;
+        required USVString privateKey;
+        unsigned long signCount = 0;
+    };
+    </xmp>
+
+<figure id="table-addCredential" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>POST</td>
+                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/credential`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <a>remote end steps</a> are:
+
+ 1. If |parameters| is not a JSON <a>Object</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
+     <a>invalid argument</a>.
+ 1. Let |credentialId| be the result of <a>trying</a> to decode <a>Base64url Encoding</a> on the |parameter|'s
+     {{CredentialParams/credentialId}} property.
+ 1. If |credentialId| is failure, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Let |rpIdHash| be the result of <a>trying</a> to decode <a>Base64url Encoding</a> on the |parameter|'s
+     {{CredentialParams/rpIdHash}} property.
+ 1. If |rpIdHash| is failure, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. If |rpIdHash| is not a valid <a>rpIdHash</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a>
+    <a>invalid argument</a>.
+ 1. Let |privateKey| be the result of <a>trying</a> to decode <a>Base64url Encoding</a> on the |parameter|'s
+     {{CredentialParams/privateKey}} property.
+ 1. If |privateKey| is failure, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. If |privateKey| is not a valid PKCS #8 encoded private key [[RFC5958]], return a <a>WebDriver error</a> with
+     <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Create a <a>Credential Key Pair</a> from |privateKey| and an <a>Authenticator Data</a> structure from |rpIdHash| and
+    |signCount|, and store them in the database of the <a>Virtual Authenticator</a> identified by |authenticatorId|.
  1. Return <a>success</a>.
 
 # IANA Considerations # {#sctn-IANA}

--- a/index.bs
+++ b/index.bs
@@ -5534,8 +5534,8 @@ Each stored [=virtual authenticator=] has the following properties:
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
-The [=Add Virtual Authenticator=] [=extension command=] creates a software [=Virtual Authenticator=]. The
-WebDriver [=extension command=] is defined as follows:
+The [=Add Virtual Authenticator=] WebDriver [=extension command=] creates a software [=Virtual Authenticator=]. It is
+defined as follows:
 
 <figure id="table-addVirtualAuthenticator" class="table">
     <table class="data">
@@ -5633,7 +5633,7 @@ The [=remote end steps=] are:
 ## <dfn>Remove Virtual Authenticator</dfn> ## {#sctn-automation-remove-virtual-authenticator}
 
 The [=Remove Virtual Authenticator=] WebDriver [=extension command=] removes a previously created [=Virtual Authenticator=].
-The [=extension command=] is defined as follows:
+It is defined as follows:
 
 <figure id="table-removeVirtualAuthenticator" class="table">
     <table class="data">
@@ -5662,7 +5662,7 @@ The [=remote end steps=] are:
 ## <dfn>Add Credential</dfn> ## {#sctn-automation-add-credential}
 
 The [=Add Credential=] WebDriver [=extension command=] injects a [=Credential Key Pair=] and associated [=Authenticator Data=]
-into an existing [=Virtual Authenticator=]. The [=extension command=] is defined as follows:
+into an existing [=Virtual Authenticator=]. It is defined as follows:
 
     <xmp class="idl">
     dictionary CredentialParams {
@@ -5718,8 +5718,7 @@ The [=remote end steps=] are:
 
 The [=Get Credentials=] WebDriver [=extension command=] returns one {{CredentialParams}} for every [=Credential Key Pair=]
 and associated [=Authenticator Data=] stored in a [=Virtual Authenticator=], regardless of whether they were
-stored using [=Add Credential=] or {{CredentialsContainer/create()|navigator.credentials.create()}}. The [=extension command=]
-is defined as follows:
+stored using [=Add Credential=] or {{CredentialsContainer/create()|navigator.credentials.create()}}. It is defined as follows:
 
 <figure id="table-getCredentials" class="table">
     <table class="data">
@@ -5748,7 +5747,7 @@ The [=remote end steps=] are:
 ## <dfn>Remove Credentials</dfn> ## {#sctn-automation-remove-credentials}
 
 The [=Remove Credentials=] WebDriver [=extension command=] removes all [=Credential Key Pairs=] stored on a [=Virtual Authenticator=].
-The [=extension command=] is defined as follows:
+It is defined as follows:
 
 <figure id="table-removeCredentials" class="table">
     <table class="data">
@@ -5776,9 +5775,8 @@ The [=remote end steps=] are:
 
 ## <dfn>Set User Verified</dfn> ## {#sctn-automation-set-user-verified}
 
-The [=Set User Verified=] [=extension command=] sets the |isUserVerified| property on the [=Virtual Authenticator=].
-
-The [=extension command=] is defined as follows:
+The [=Set User Verified=] [=extension command=] sets the |isUserVerified| property on the [=Virtual Authenticator=]. It
+is defined as follows:
 
     <xmp class="idl">
     dictionary UserVerifiedParams {

--- a/index.bs
+++ b/index.bs
@@ -5180,11 +5180,15 @@ have the following properties:
 :: If set to `true`, the authenticator will support [=resident credentials=].
 : |hasUserVerification|
 :: If set to `true`, the authenticator will support [=user verification=].
+: |isUserVerified|
+:: Determines the result of <a>User Verification</a> performed on the <a>Virtual Authenticator</a>. If set to `true`,
+    <a>User Verification</a> will always succeed. If set to `false`, it will fail. This property has no effect if
+    |hasUserVerification| is set to `false`.
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
-The <a>Add Virtual Authenticator</a> <a>extension command</a> creates a software <a>Virtual Authenticator</a> and 
-The <a>extension command</a> is defined as follows:
+The <a>Add Virtual Authenticator</a> <a>extension command</a> creates a software <a>Virtual Authenticator</a>. The
+<a>extension command</a> is defined as follows:
 
     <xmp class="idl">
     enum AuthenticatorProtocol {
@@ -5198,6 +5202,7 @@ The <a>extension command</a> is defined as follows:
         required AuthenticatorAttachment attachment;
         boolean hasResidentKey = false;
         boolean hasUserVerification = false;
+        boolean isUserVerified = true;
     };
     </xmp>
 
@@ -5212,7 +5217,7 @@ The <a>extension command</a> is defined as follows:
         <tbody>
             <tr>
                 <td>POST</td>
-                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId`</td>
+                <td>`/session/{session id}/webauthn/authenticator`</td>
             </tr>
         </tbody>
     </table>
@@ -5231,12 +5236,11 @@ The <a>remote end steps</a> are:
  1. Let |attachment| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/attachment}}
     property.
  1. If |attachment| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. If a <a>Virtual Authenticator</a> with the same |authenticatorId| already exists in the <a>Virtual Authenticator
-    Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Generate an arbitrary and unique string |authenticatorId|.
  1. Create a new <a>Virtual Authenticator</a> with the fields |authenticatorId|, |protocol|, |transport|, |attachment|,
-    |hasResidentKey|, and |hasUserVerification|.
+    |hasResidentKey|, |hasUserVerification|, and |isUserVerified|.
  1. Store the authenticator in the <a>Virtual Authenticator Database</a>.
- 1. Return <a>success</a>.
+ 1. Return <a>success</a> with |authenticatorId|.
 
 ## <dfn>Remove Virtual Authenticator</dfn> ## {#sctn-automation-remove-virtual-authenticator}
 
@@ -5313,10 +5317,109 @@ The <a>remote end steps</a> are:
  1. Let |privateKey| be the result of <a>trying</a> to decode <a>Base64url Encoding</a> on the |parameter|'s
      {{CredentialParams/privateKey}} property.
  1. If |privateKey| is failure, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
+     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
  1. If |privateKey| is not a valid PKCS #8 encoded private key [[RFC5958]], return a <a>WebDriver error</a> with
      <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Create a <a>Credential Key Pair</a> from |privateKey| and an <a>Authenticator Data</a> structure from |rpIdHash| and
-    |signCount|, and store them in the database of the <a>Virtual Authenticator</a> identified by |authenticatorId|.
+ 1. Create a <a>Credential Key Pair</a> from |privateKey| identified by |credentialId| and an <a>Authenticator Data</a>
+     structure from |rpIdHash| and |signCount|, and store them in the database of the <a>Virtual Authenticator</a>
+     identified by |authenticatorId|.
+ 1. Return <a>success</a>.
+
+## <dfn>Get Credentials</dfn> ## {#sctn-automation-get-credentials}
+
+The <a>Get Credentials</a> <a>extension command</a> returns one {{CredentialParams}} for every <a>Credential Key Pair</a>
+and associated <a>Authenticator Data</a> stored in a <a>Virtual Authenticator</a>, regardless of whether they were
+stored using <a>Add Credential</a> or {{CredentialsContainer/create()|navigator.credentials.create()}}. The <a>extension command</a>
+is defined as follows:
+
+<figure id="table-getCredentials" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>GET</td>
+                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/credentials`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <a>remote end steps</a> are:
+
+ 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
+     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. For every <a>Credential Key Pair</a>, construct a corresponding {{CredentialParams}}.
+ 1. Return <a>success</a> with the array of {{CredentialParams}}.
+
+## <dfn>Remove Credentials</dfn> ## {#sctn-automation-remove-credentials}
+
+The <a>Remove Credentials</a> <a>extension command</a> removes all <a>Credential Key Pairs</a> stored on a <a>Virtual Authenticator</a>.
+The <a>extension command</a> is defined as follows:
+
+<figure id="table-removeCredentials" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>DELETE</td>
+                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/credentials`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <a>remote end steps</a> are:
+
+ 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
+     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Remove all <a>Credential Key Pairs</a> from the <a>Virtual Authenticator</a>'s database.
+ 1. Return <a>success</a>.
+
+## <dfn>Set User Verified</dfn> ## {#sctn-automation-set-user-verified}
+
+The <a>Set User Verified</a> <a>extension command</a> sets the |isUserVerified| property on the <a>Virtual Authenticator</a>.
+
+The <a>extension command</a> is defined as follows:
+
+    <xmp class="idl">
+    dictionary UserVerifiedParams {
+        required boolean isUserVerified;
+    };
+    </xmp>
+
+<figure id="table-setUserVerified" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>POST</td>
+                <td>`/session/{session id}/webauthn/authenticator/:authenticatorId/uv`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <a>remote end steps</a> are:
+
+ 1. If |authenticatorId| does not match any <a>Virtual Authenticator</a> stored in the <a>Virtual Authenticator
+     Database</a>, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
+ 1. Set the <a>Virtual Authenticator</a>'s |isUserVerified| flag to {{UserVerifiedParams/isUserVerified}}.
  1. Return <a>success</a>.
 
 # IANA Considerations # {#sctn-IANA}

--- a/index.bs
+++ b/index.bs
@@ -5752,8 +5752,8 @@ The [=remote end steps=] are:
  1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameters|' |privateKey| property.
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single private key per [[RFC5958]],
-     return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single ECDSA private key on the P-256
+     curve per [[RFC5958]], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. If the |parameters|' |userHandle| property is defined:
      1. Let |userHandle| be the result of decoding [=Base64url Encoding=] on the |parameters|' |userHandle| property.
      1. If |userHandle| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -234,6 +234,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
         text: WebDriver error code; url: dfn-error-code
         text: extension command; url: dfn-extension-command
         text: extension command name; url: dfn-extension-command-name
+        text: getting a property; url: dfn-getting-properties
         text: prefix; url: dfn-url-prefix
         text: invalid argument; url: dfn-invalid-argument
         text: local end; url: dfn-local-end
@@ -5497,29 +5498,27 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 :: None.
 
 
-# Automation # {#sctn-automation}
+# User Agent Automation # {#sctn-automation}
 
-For the purposes of user-agent automation and application testing, this document defines a number of [=extension
-commands=] for the [[WebDriver]] specification. 
+For the purposes of user agent automation and [=web application=] testing, this document defines a number of [[WebDriver]] [=extension commands=].
 
 ## <dfn>Virtual Authenticators</dfn> ## {#sctn-automation-virtual-authenticators}
 
-These [=extension commands=] create and interact with [=Virtual Authenticators=]: software implementations of the
-<a>Authenticator Model</a>. <a>Virtual Authenticators</a> are stored in a <dfn>Virtual Authenticator Database</dfn> and
+These WebDriver [=extension commands=] create and interact with [=Virtual Authenticators=]: software implementations of the
+<a>Authenticator Model</a>. <a>Virtual Authenticators</a> are stored in a <dfn>Virtual Authenticator Database</dfn>.
 have the following properties:
 
 : |authenticatorId|
 :: An arbitrary non-null string that uniquely identifies the [=Virtual Authenticator=].
 : |protocol|
 :: The protocol the [=Virtual Authenticator=] uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
-    or `u2f` for the [[FIDO-U2F-Message-Formats]].
 : |transport|
 :: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
     authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].
 : |hasResidentKey|
-:: If set to `true`, the authenticator will support [=resident credentials=].
+:: If set to [TRUE] the authenticator will support [=resident credentials=].
 : |hasUserVerification|
-:: If set to `true`, the authenticator will support [=user verification=].
+:: If set to [TRUE], the authenticator supports [=user verification=].
 : |isUserVerified|
 :: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to `true`,
     [=User Verification=] will always succeed. If set to `false`, it will fail. This property has no effect if
@@ -5528,7 +5527,7 @@ have the following properties:
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
 The [=Add Virtual Authenticator=] [=extension command=] creates a software [=Virtual Authenticator=]. The
-[=extension command=] is defined as follows:
+WebDriver [=extension command=] is defined as follows:
 
     <xmp class="idl">
     enum AuthenticatorProtocol {
@@ -5576,11 +5575,11 @@ The [=remote end steps=] are:
  1. Create a new [=Virtual Authenticator=] with the fields |authenticatorId|, |protocol|, |transport|,
     |hasResidentKey|, |hasUserVerification|, and |isUserVerified|.
  1. Store the authenticator in the [=Virtual Authenticator Database=].
- 1. Return [=success=] with |authenticatorId|.
+ 1. Return [=success=] with data |authenticatorId|.
 
 ## <dfn>Remove Virtual Authenticator</dfn> ## {#sctn-automation-remove-virtual-authenticator}
 
-The [=Remove Virtual Authenticator=] [=extension command=] removes a previously created [=Virtual Authenticator=].
+The [=Remove Virtual Authenticator=] WebDriver [=extension command=] removes a previously created [=Virtual Authenticator=].
 The [=extension command=] is defined as follows:
 
 <figure id="table-removeVirtualAuthenticator" class="table">
@@ -5609,7 +5608,7 @@ The [=remote end steps=] are:
 
 ## <dfn>Add Credential</dfn> ## {#sctn-automation-add-credential}
 
-The [=Add Credential=] [=extension command=] injects a [=Credential Key Pair=] and associated [=Authenticator Data=]
+The [=Add Credential=] WebDriver [=extension command=] injects a [=Credential Key Pair=] and associated [=Authenticator Data=]
 into an existing [=Virtual Authenticator=]. The [=extension command=] is defined as follows:
 
     <xmp class="idl">
@@ -5655,7 +5654,7 @@ The [=remote end steps=] are:
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. If |privateKey| is not a valid PKCS #8 encoded private key [[RFC5958]], return a [=WebDriver error=] with
+ 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single private key per [[RFC5958]], return a [=WebDriver error=] with
      [=WebDriver error code=] [=invalid argument=].
  1. Create a [=Credential Key Pair=] from |privateKey| identified by |credentialId| and an [=Authenticator Data=]
      structure from |rpIdHash| and |signCount|, and store them in the database of the [=Virtual Authenticator=]
@@ -5664,7 +5663,7 @@ The [=remote end steps=] are:
 
 ## <dfn>Get Credentials</dfn> ## {#sctn-automation-get-credentials}
 
-The [=Get Credentials=] [=extension command=] returns one {{CredentialParams}} for every [=Credential Key Pair=]
+The [=Get Credentials=] WebDriver [=extension command=] returns one {{CredentialParams}} for every [=Credential Key Pair=]
 and associated [=Authenticator Data=] stored in a [=Virtual Authenticator=], regardless of whether they were
 stored using [=Add Credential=] or {{CredentialsContainer/create()|navigator.credentials.create()}}. The [=extension command=]
 is defined as follows:
@@ -5691,11 +5690,11 @@ The [=remote end steps=] are:
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. For every [=Credential Key Pair=], construct a corresponding {{CredentialParams}}.
- 1. Return [=success=] with the array of {{CredentialParams}}.
+ 1. Return [=success=] with data containing |credentialsArray|.
 
 ## <dfn>Remove Credentials</dfn> ## {#sctn-automation-remove-credentials}
 
-The [=Remove Credentials=] [=extension command=] removes all [=Credential Key Pairs=] stored on a [=Virtual Authenticator=].
+The [=Remove Credentials=] WebDriver [=extension command=] removes all [=Credential Key Pairs=] stored on a [=Virtual Authenticator=].
 The [=extension command=] is defined as follows:
 
 <figure id="table-removeCredentials" class="table">

--- a/index.bs
+++ b/index.bs
@@ -5173,9 +5173,8 @@ have the following properties:
 :: The protocol the <a>Virtual Authenticator</a> uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
     or `u2f` for the [[FIDO-U2F-Message-Formats]].
 : |transport|
-:: The {{AuthenticatorTransport}} simulated.
-: |attachment|
-:: The {{AuthenticatorAttachment}} simulated.
+:: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
+    authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].
 : |hasResidentKey|
 :: If set to `true`, the authenticator will support [=resident credentials=].
 : |hasUserVerification|
@@ -5199,7 +5198,6 @@ The <a>Add Virtual Authenticator</a> <a>extension command</a> creates a software
     dictionary AddVirtualAuthenticatorParameters {
         required AuthenticatorProtocol protocol;
         required AuthenticatorTransport transport;
-        required AuthenticatorAttachment attachment;
         boolean hasResidentKey = false;
         boolean hasUserVerification = false;
         boolean isUserVerified = true;
@@ -5233,11 +5231,8 @@ The <a>remote end steps</a> are:
  1. Let |transport| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/transport}}
     property.
  1. If |transport| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
- 1. Let |attachment| be the result of <a>trying</a> to get the |parameter|'s {{AddVirtualAuthenticatorParameters/attachment}}
-    property.
- 1. If |attachment| is null, return a <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid argument</a>.
  1. Generate an arbitrary and unique string |authenticatorId|.
- 1. Create a new <a>Virtual Authenticator</a> with the fields |authenticatorId|, |protocol|, |transport|, |attachment|,
+ 1. Create a new <a>Virtual Authenticator</a> with the fields |authenticatorId|, |protocol|, |transport|,
     |hasResidentKey|, |hasUserVerification|, and |isUserVerified|.
  1. Store the authenticator in the <a>Virtual Authenticator Database</a>.
  1. Return <a>success</a> with |authenticatorId|.

--- a/index.bs
+++ b/index.bs
@@ -5516,7 +5516,7 @@ Each stored [=virtual authenticator=] has the following properties:
         Note: This string can be a UUID [[RFC4122]].
     </div>
 : |protocol|
-:: The protocol the [=Virtual Authenticator=] uses to encode its messages. Either `ctap2` for the [[FIDO-CTAP]] format
+:: The protocol the [=Virtual Authenticator=] speaks: either `ctap2` or `ctap1-u2f` [[FIDO-CTAP]].
 : |transport|
 :: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
     authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].
@@ -5554,7 +5554,7 @@ defined as follows:
     </table>
 </figure>
 
-The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] containing the following parameters:
+The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|. It contains the following |key| and |value| pairs:
 
 <figure id="table-authenticatorConfiguration" class="table">
     <table class="data">
@@ -5570,7 +5570,7 @@ The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] containing the f
             <tr>
                 <td>|protocol|</td>
                 <td>string</td>
-                <td>`"u2f"`, `"ctap2"`</td>
+                <td>`"ctap1/u2f"`, `"ctap2"`</td>
                 <td>None</td>
             </tr>
             <tr>

--- a/index.bs
+++ b/index.bs
@@ -5597,7 +5597,7 @@ The [=extension command=] is defined as follows:
         <tbody>
             <tr>
                 <td>DELETE</td>
-                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}`</td>
             </tr>
         </tbody>
     </table>

--- a/index.bs
+++ b/index.bs
@@ -5701,6 +5701,14 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>string</td>
             </tr>
             <tr>
+                <td>|isResidentCredential|</td>
+                <td>
+                    If set to [TRUE], a [=resident credential=] is created. If set to [FALSE], a [=non-resident credential=]
+                    is created instead.
+                </td>
+                <td>boolean</td>
+            </tr>
+            <tr>
                 <td>|rpId|</td>
                 <td>The [=public key credential source/rpId|Relying Party ID=] the credential is scoped to.</td>
                 <td>string</td>
@@ -5738,7 +5746,9 @@ The [=remote end steps=] are:
      Note: |parameters| is a [=Credential Parameters=] object.
  1. Let |credentialId| be the result of decoding [=Base64url Encoding=] on the |parameters|' |credentialId| property.
  1. If |credentialId| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |rpId| be the the |parameters|' |rpId| property.
+ 1. Let |isResidentCredential| be the |parameters|' |isResidentCredential| property.
+ 1. If |isResidentCredential| is not defined, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |rpId| be the |parameters|' |rpId| property.
  1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameters|' |privateKey| property.
  1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
@@ -5751,7 +5761,8 @@ The [=remote end steps=] are:
     1. Let |userHandle| be `null`.
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |credential| be a new [=Public Key Credential Source=] whose items are:
+ 1. Let |credential| be a new [=Client-side-resident Public Key Credential Source=] if |isResidentCredential| is [TRUE]
+     or a [=Server-side-resident Public Key Credential Source=] otherwise whose items are:
     : [=public key credential source/type=]
     :: {{public-key}}
     : [=public key credential source/id=]


### PR DESCRIPTION
This change introduces a [WebDriver Extension](https://w3c.github.io/webdriver/#dfn-extension-command) that lets clients create and manipulate virtual authenticators. This API can be used by web developers to write tests against the WebAuthn API and it's also possible to leverage it on [WPTs](https://github.com/web-platform-tests/wpt/tree/master/webauthn) through [testdriver.js](https://web-platform-tests.org/writing-tests/testdriver-tutorial.html). Being able to instantiate virtual authenticators on WPTs would be a major step towards enabling testing a larger surface area of the API across multiple browsers.

Fixes #1236


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nsatragno/webauthn/pull/1256.html" title="Last updated on Jul 30, 2019, 6:30 PM UTC (9be5c17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1256/126223e...nsatragno:9be5c17.html" title="Last updated on Jul 30, 2019, 6:30 PM UTC (9be5c17)">Diff</a>