### PR TITLE
make UV requirement default 'discouraged'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2434,7 +2434,7 @@ attributes.
         AuthenticatorAttachment      authenticatorAttachment;
         boolean                      requireResidentKey = false;
         ResidentKeyRequirement       residentKey;
-        UserVerificationRequirement  userVerification = "preferred";
+        UserVerificationRequirement  userVerification = "discouraged";
     };
 </xmp>
 


### PR DESCRIPTION
fixes #1253 

see also: https://chromium.googlesource.com/chromium/src/+/master/content/browser/webauth/uv_preferred.md


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1259.html" title="Last updated on Jul 13, 2019, 12:51 AM UTC (5658427)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1259/d2a4543...5658427.html" title="Last updated on Jul 13, 2019, 12:51 AM UTC (5658427)">Diff</a>