### PR TITLE
Add note about decoding U2F keyhandles.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4930,7 +4930,7 @@ in order to allow users to [=authentication|authenticate=] using their registere
      of the {{CredentialsContainer/get()}} method:
 
      - Set the {{PublicKeyCredentialDescriptor/type}} members to {{PublicKeyCredentialType/public-key}}.
-     - Set the {{PublicKeyCredentialDescriptor/id}} members to the respective U2F key handles of the desired credentials.
+     - Set the {{PublicKeyCredentialDescriptor/id}} members to the respective U2F key handles of the desired credentials. Note that U2F key handles are commonly base64url encoded but must be decoded to their binary form when used in {{PublicKeyCredentialDescriptor/id}}.
 
      {{PublicKeyCredentialRequestOptions/allowCredentials}} MAY contain a mixture
      of both WebAuthn [=credential IDs=] and U2F key handles;
@@ -5011,7 +5011,8 @@ Instead, in step three, the comparison on the host is relaxed to accept hosts on
 
 This registration extension allows [=[WRPS]=] to exclude authenticators which contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
 
-During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a population of users with legacy credentials already registered. The [appid](#sctn-appid-extension) extension allows the sign-in flow to be transitioned smoothly but, when transitioning the registration flow, the [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) field will not be effective in excluding authenticators with legacy credentials because its contents are taken to be WebAuthn credentials. This extension directs [=client platforms=] to consider the contents of [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) as both WebAuthn and legacy FIDO credentials.
+During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a population of users with legacy credentials already registered. The [appid](#sctn-appid-extension) extension allows the sign-in flow to be transitioned smoothly but, when transitioning the registration flow, the [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) field will not be effective in excluding authenticators with legacy credentials because its contents are taken to be WebAuthn credentials. This extension directs [=client platforms=] to consider the contents of [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) as both WebAuthn and legacy FIDO credentials. Note that U2F key handles are commonly base64url encoded but must be decoded to their binary form when used in [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials).
+
 
 : Extension identifier
 :: `appidExclude`

--- a/index.bs
+++ b/index.bs
@@ -4930,7 +4930,7 @@ in order to allow users to [=authentication|authenticate=] using their registere
      of the {{CredentialsContainer/get()}} method:
 
      - Set the {{PublicKeyCredentialDescriptor/type}} members to {{PublicKeyCredentialType/public-key}}.
-     - Set the {{PublicKeyCredentialDescriptor/id}} members to the respective U2F key handles of the desired credentials. Note that U2F key handles are commonly base64url encoded but must be decoded to their binary form when used in {{PublicKeyCredentialDescriptor/id}}.
+     - Set the {{PublicKeyCredentialDescriptor/id}} members to the respective U2F key handles of the desired credentials. Note that U2F key handles commonly use [=base64url encoding=] but must be decoded to their binary form when used in {{PublicKeyCredentialDescriptor/id}}.
 
      {{PublicKeyCredentialRequestOptions/allowCredentials}} MAY contain a mixture
      of both WebAuthn [=credential IDs=] and U2F key handles;
@@ -5011,7 +5011,7 @@ Instead, in step three, the comparison on the host is relaxed to accept hosts on
 
 This registration extension allows [=[WRPS]=] to exclude authenticators which contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
 
-During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a population of users with legacy credentials already registered. The [appid](#sctn-appid-extension) extension allows the sign-in flow to be transitioned smoothly but, when transitioning the registration flow, the [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) field will not be effective in excluding authenticators with legacy credentials because its contents are taken to be WebAuthn credentials. This extension directs [=client platforms=] to consider the contents of [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) as both WebAuthn and legacy FIDO credentials. Note that U2F key handles are commonly base64url encoded but must be decoded to their binary form when used in [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials).
+During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a population of users with legacy credentials already registered. The [appid](#sctn-appid-extension) extension allows the sign-in flow to be transitioned smoothly but, when transitioning the registration flow, the [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) field will not be effective in excluding authenticators with legacy credentials because its contents are taken to be WebAuthn credentials. This extension directs [=client platforms=] to consider the contents of [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) as both WebAuthn and legacy FIDO credentials. Note that U2F key handles commonly use [=base64url encoding=] but must be decoded to their binary form when used in [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials).
 
 
 : Extension identifier


### PR DESCRIPTION
U2F key handles need to be base64url decoded before being used as
ArrayBuffers in WebAuthn calls. This isn't completely obvious so this
change adds a clarification to the appid and appidExclude extensions.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1272.html" title="Last updated on Aug 20, 2019, 10:13 PM UTC (cf05efe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1272/4561e48...agl:cf05efe.html" title="Last updated on Aug 20, 2019, 10:13 PM UTC (cf05efe)">Diff</a>