### PR TITLE
Type transport strings as DOMStrings.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -246,6 +246,7 @@ spec:infra; type:dfn; for:map-exists; text:exists
 spec:url; type:dfn; text:domain
 spec:url; type:dfn; for:url; text:host
 spec:url; type:dfn; text:valid domain;
+spec:webidl; type:dfn; text:DOMString
 spec:webidl; type:interface; text:Promise
 </pre>
 
@@ -1679,7 +1680,7 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                         ::  |attestationObject|
 
                         :   {{AuthenticatorAttestationResponse/[[transports]]}}
-                        ::  A sequence of zero or more unique {{AuthenticatorTransport}} values, in lexicographical order, that the |authenticator| is believed to support.
+                        ::  A sequence of zero or more unique {{DOMString}}s, in lexicographical order, that the |authenticator| is believed to support. The values SHOULD be members of {{AuthenticatorTransport}}.
 
                             If a user agent does not wish to divulge this information it MAY substitute an arbitrary sequence designed to preserve privacy. This sequence MUST still be valid, i.e. lexicographically sorted and free of duplicates. For example, it may use the empty sequence. Either way, in this case the user agent takes the risk that [=[RP]=] behavior may be suboptimal.
 
@@ -2166,7 +2167,7 @@ during registration.
     [SecureContext, Exposed=Window]
     interface AuthenticatorAttestationResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      attestationObject;
-        sequence<AuthenticatorTransport>                 getTransports();
+        sequence<DOMString>                              getTransports();
     };
 </xmp>
 <div dfn-type="attribute" dfn-for="AuthenticatorAttestationResponse">
@@ -2190,7 +2191,7 @@ during registration.
     ::  This operation returns the value of {{AuthenticatorAttestationResponse/[[transports]]}}.
 
     :   <dfn>\[[transports]]</dfn>
-    ::  This [=internal slot=] contains a sequence of zero or more unique {{AuthenticatorTransport}} values in lexicographical order. These values are the transports that the [=authenticator=] is believed to support, or an empty sequence if the information is unavailable.
+    ::  This [=internal slot=] contains a sequence of zero or more unique {{DOMString}}s in lexicographical order. These values are the transports that the [=authenticator=] is believed to support, or an empty sequence if the information is unavailable. The values SHOULD be members of {{AuthenticatorTransport}} but [=[RPS]=] MUST support unknown values.
 </div>
 
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}
@@ -2795,7 +2796,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     dictionary PublicKeyCredentialDescriptor {
         required PublicKeyCredentialType      type;
         required BufferSource                 id;
-        sequence<AuthenticatorTransport>      transports;
+        sequence<DOMString>                   transports;
     };
 </xmp>
 
@@ -2812,7 +2813,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
     :   <dfn>transports</dfn>
     ::  This OPTIONAL member contains a hint as to how the [=client=] might communicate with the [=managing authenticator=] of the
-        [=public key credential=] the caller is referring to.
+        [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [[=client platforms=]] MUST ignore unknown values.
 </div>
 
 
@@ -2831,8 +2832,10 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     [=Authenticators=] may implement various [[#enum-transport|transports]] for communicating with [=clients=]. This enumeration
     defines hints as to how clients might communicate with a particular authenticator in order to obtain an assertion for a
     specific credential. Note that these hints represent the [=[WRP]=]'s best belief as to how an authenticator may be reached. A
-    [=[RP]=] may obtain a list of transports hints from some [=attestation statement formats=] or via some out-of-band mechanism;
-    it is outside the scope of this specification to define that mechanism.
+    [=[RP]=] will typically learn of the supported transports for a [=public key credential=] via
+    {{AuthenticatorAttestationResponse/getTransports()}}.
+
+    This enumeration is not referenced by other parts of the IDL because that would preclude other values from being used. But it is important for backwards compatibility that [=client platforms=] and [=[RPS]=] handle unknown values. Therefore it exists here for documentation and as a registry. Where transports are represented elsewhere, they are typed as {{DOMString}}s.
 
     :   <dfn>usb</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over removable USB.


### PR DESCRIPTION
Currently transports are represented as an enum. However, WebIDL has
strict enums. (I.e. an RP which sent an unrecognised transport would
make the whole structure unparsable.) This means that every time we add
a transport, we break all existing browsers.

In order to address this, this change retypes transports as plain
DOMStrings. The AuthenticatorTransport enum still exists, but now only
as documentation and registry — not as a factor in type-checking.