### PR TITLE
rename feature-identifier token: webauthn -> publickey-credentials  (fix #1277)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2893,7 +2893,7 @@ needs.
 ## Feature Policy integration ## {#sctn-feature-policy}
 
 This specification defines a [=policy-controlled feature=] identified by
-the feature policy token "<code><dfn data-lt="webauthn-feature" export>webauthn</dfn></code>".
+the feature-identifier token "<code><dfn data-lt="webauthn-feature" export>publickey-credentials</dfn></code>".
 Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
 A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is allowed


### PR DESCRIPTION
fixes #1277

See also FP issue: https://github.com/w3c/webappsec-feature-policy/issues/335


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1284.html" title="Last updated on Aug 23, 2019, 5:52 PM UTC (0e4695a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1284/0cc6d70...0e4695a.html" title="Last updated on Aug 23, 2019, 5:52 PM UTC (0e4695a)">Diff</a>