### PR TITLE
Initial proposal to fix #1287 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3985,8 +3985,15 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
     <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
-    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST be prepared to
-    handle cases where none or not all of the requested extensions were acted upon.
+    Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
+    [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
+    [=client extension outputs=] that were not originally specified as part of 
+    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] should be aware of this and 
+    be able to handle such situations, whether it be to ignore the unsolicited extensions or reject the attestation. The
+    [=[RP]=] can make this decision based on local policy and the extensions in use.
+
+    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be 
+    prepared to handle cases where none or not all of the requested extensions were acted upon.
 
 1. Determine the attestation statement format by performing a USASCII case-sensitive match on |fmt| against the set of
     supported WebAuthn Attestation Statement Format Identifier values.
@@ -4109,11 +4116,18 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
     extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
     and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e. those that were not specified as part of 
-    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
+    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
-    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST be prepared to
-    handle cases where none or not all of the requested extensions were acted upon.
+    Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
+    [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
+    [=client extension outputs=] that were not originally specified as part of 
+    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] should be aware of this and 
+    be able to handle such situations, whether it be to ignore the unsolicited extensions or reject the assertion. The
+    [=[RP]=] can make this decision based on local policy and the extensions in use.
+
+    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be 
+    prepared to handle cases where none or not all of the requested extensions were acted upon.
 
 1. Let |hash| be the result of computing a hash over the |cData| using SHA-256.
 

--- a/index.bs
+++ b/index.bs
@@ -3981,7 +3981,7 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
     outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
     extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
-    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e. those that were not specified as part of 
+    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of 
     <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 

--- a/index.bs
+++ b/index.bs
@@ -3980,12 +3980,9 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
 
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
     outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
-    extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
-    In particular, any [=extension identifier=] values in the |clientExtensionResults| and
-    the <code>[=authdataextensions|extensions=]</code> in |authData|
-    MUST also be present as [=extension identifier=] values in
-    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>,
-    i.e., no extensions are present that were not requested.
+    extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
+    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e. those that were not specified as part of 
+    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
     Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST be prepared to
@@ -4110,12 +4107,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
     outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
-    extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
-    In particular, any [=extension identifier=] values in the |clientExtensionResults| and
-    the <code>[=authdataextensions|extensions=]</code> in |authData|
-    MUST also be present as [=extension identifier=] values in
-    the <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>,
-    i.e., no extensions are present that were not requested.
+    extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
+    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e. those that were not specified as part of 
+    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
     Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST be prepared to

--- a/index.bs
+++ b/index.bs
@@ -4115,7 +4115,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
     outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
     extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
-    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e. those that were not specified as part of 
+    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of 
     <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 

--- a/index.bs
+++ b/index.bs
@@ -3988,9 +3988,9 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
     Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
     [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
     [=client extension outputs=] that were not originally specified as part of 
-    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] should be aware of this and 
-    be able to handle such situations, whether it be to ignore the unsolicited extensions or reject the attestation. The
-    [=[RP]=] can make this decision based on local policy and the extensions in use.
+    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such 
+    situations, whether it be to ignore the unsolicited extensions or reject the attestation. The [=[RP]=] can make this 
+    decision based on local policy and the extensions in use.
 
     Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be 
     prepared to handle cases where none or not all of the requested extensions were acted upon.
@@ -4122,9 +4122,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
     [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
     [=client extension outputs=] that were not originally specified as part of 
-    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] should be aware of this and 
-    be able to handle such situations, whether it be to ignore the unsolicited extensions or reject the assertion. The
-    [=[RP]=] can make this decision based on local policy and the extensions in use.
+    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such 
+    situations, whether it be to ignore the unsolicited extensions or reject the assertion. The [=[RP]=] can make this 
+    decision based on local policy and the extensions in use.
 
     Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be 
     prepared to handle cases where none or not all of the requested extensions were acted upon.


### PR DESCRIPTION
Relax the requirement for RP's to reject responses containing unsolicited extensions

fix #1287


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sbweeden/webauthn/pull/1289.html" title="Last updated on Sep 10, 2019, 12:26 AM UTC (dc0378b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1289/30d3e9f...sbweeden:dc0378b.html" title="Last updated on Sep 10, 2019, 12:26 AM UTC (dc0378b)">Diff</a>