### PR TITLE
(Deja vu) webauthn => publickey-credentials

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2920,7 +2920,7 @@ Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual fe
 ## Using Web Authentication within <code>iframe</code> elements ## {#sctn-iframe-guidance}
 
 The [=Web Authentication API=] is disabled by default in cross-origin <{iframe}>s.
-To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=], specify the <{iframe/allow}> attribute on the <{iframe}> element and include the `webauthn` feature policy token in the <{iframe/allow}> attribute's value.
+To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=], specify the <{iframe/allow}> attribute on the <{iframe}> element and include the `publickey-credentials` feature policy token in the <{iframe/allow}> attribute's value.
 
 
 


### PR DESCRIPTION
Missed one occurrence of the `webauthn` feature-identifier in https://github.com/w3c/webauthn/pull/1284!

/cc @equalsJeffH 😄


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Malvoz/webauthn/pull/1295.html" title="Last updated on Sep 7, 2019, 12:37 AM UTC (c48c92f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1295/8667dbe...Malvoz:c48c92f.html" title="Last updated on Sep 7, 2019, 12:37 AM UTC (c48c92f)">Diff</a>