### PR TITLE
fix publickey-credentials feature identifier tag

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2903,7 +2903,7 @@ needs.
 ## Feature Policy integration ## {#sctn-feature-policy}
 
 This specification defines a [=policy-controlled feature=] identified by
-the feature-identifier token "<code><dfn data-lt="webauthn-feature" export>publickey-credentials</dfn></code>".
+the feature-identifier token "<code><dfn data-lt="publickey-credentials-feature" export>publickey-credentials</dfn></code>".
 Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
 A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is allowed


### PR DESCRIPTION
deja vu! (doh!) yet another loose-end in chaging from the feature-identifier token of `webauthn` to `publickey-credentials`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1301.html" title="Last updated on Sep 16, 2019, 8:20 AM UTC (0c76735)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1301/32c216c...0c76735.html" title="Last updated on Sep 16, 2019, 8:20 AM UTC (0c76735)">Diff</a>