### PR TITLE
Add note about use of floating point in extensions passed through that clients do not recognize

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4827,7 +4827,7 @@ operation. Likewise, clients can choose to produce a [=client extension output=]
 understand by encoding the [=authenticator extension output=] value into JSON, provided that the CBOR output uses only types
 present in JSON.
 
-When clients choose to pass through extensions they do not recognize,
+When [=clients=] choose to pass through extensions they do not recognize,
 the JavaScript values in the [=client extension inputs=]
 are converted to [=CBOR=] values in the [=authenticator extension inputs=].
 When the JavaScript value is an [=%ArrayBuffer%=], it is converted to a [=CBOR=] byte array.
@@ -4835,6 +4835,12 @@ When the JavaScript value is a non-integer number, it is converted to a 64-bit C
 Otherwise, when the JavaScript type corresponds to a JSON type, the conversion is done
 using the rules defined in Section 4.2 of [[!RFC7049]] (Converting from JSON to CBOR),
 but operating on inputs of JavaScript type values rather than inputs of JSON type values.
+Note that the numeric conversion rules have the consequence that
+when a client passes through an extension it does not recognize,
+if the extension uses floating point values,
+[=authenticators=] need to be prepared to receive those values as [=CBOR=] integers
+when the floating point values used happen to be integers,
+should the [=authenticator=] want the extension to always work without actual [=client=] support for it.
 Once these conversions are done,
 canonicalization of the resulting [=CBOR=] MUST be performed using the [=CTAP2 canonical CBOR encoding form=].
 

--- a/index.bs
+++ b/index.bs
@@ -4835,14 +4835,15 @@ When the JavaScript value is a non-integer number, it is converted to a 64-bit C
 Otherwise, when the JavaScript type corresponds to a JSON type, the conversion is done
 using the rules defined in Section 4.2 of [[!RFC7049]] (Converting from JSON to CBOR),
 but operating on inputs of JavaScript type values rather than inputs of JSON type values.
-Note that the numeric conversion rules have the consequence that
-when a client passes through an extension it does not recognize,
-if the extension uses floating point values,
-[=authenticators=] need to be prepared to receive those values as [=CBOR=] integers
-when the floating point values used happen to be integers,
-should the [=authenticator=] want the extension to always work without actual [=client=] support for it.
 Once these conversions are done,
 canonicalization of the resulting [=CBOR=] MUST be performed using the [=CTAP2 canonical CBOR encoding form=].
+
+Note that the JavaScript numeric conversion rules have the consequence that
+when a client passes through an extension it does not recognize,
+if the extension uses floating point values,
+[=authenticators=] need to be prepared to receive those values as [=CBOR=] integers,
+should the [=authenticator=] want the extension to always work without actual [=client=] support for it.
+This will happen when the floating point values used happen to be integers.
 
 Likewise, when clients receive outputs from extensions they have passed through that they do not recognize,
 the [=CBOR=] values in the [=authenticator extension outputs=]


### PR DESCRIPTION
Fixes #1273


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/1307.html" title="Last updated on Oct 9, 2019, 7:41 PM UTC (d1dc052)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1307/2b435a7...selfissued:d1dc052.html" title="Last updated on Oct 9, 2019, 7:41 PM UTC (d1dc052)">Diff</a>