### PR TITLE
revise draft-hodges-webauthn-registries per AD review and initiate work on rev -03

### DIFF
--- a/draft-hodges-webauthn-registries.html
+++ b/draft-hodges-webauthn-registries.html
@@ -1,7 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<!-- saved from url=(0050)https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi -->
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"><head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/"><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
 
   <title>Registries for Web Authentication (WebAuthn)</title>
 
@@ -386,16 +388,16 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.32.0 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Hodges, J., Mandyam, G., and M. Jones" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-hodges-webauthn-registries-02" />
-  <meta name="dct.issued" scheme="ISO8601" content="2019-03-11" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-hodges-webauthn-registries-03" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-17" />
   <meta name="dct.abstract" content="This specification defines IANA registries for W3C Web Authentication attestation statement format identifiers and extension identifiers.  " />
   <meta name="description" content="This specification defines IANA registries for W3C Web Authentication attestation statement format identifiers and extension identifiers.  " />
 
-<style>@media print {#ghostery-purple-box {display:none !important}}</style></head>
+</head>
 
 <body>
 
@@ -415,7 +417,7 @@
 <td class="right">G. Mandyam</td>
 </tr>
 <tr>
-<td class="left">Expires: September 12, 2019</td>
+<td class="left">Expires: April 19, 2020</td>
 <td class="right">Qualcomm Technologies Inc.</td>
 </tr>
 <tr>
@@ -428,7 +430,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">March 11, 2019</td>
+<td class="right">Oct 17, 2019</td>
 </tr>
 
     	
@@ -436,7 +438,7 @@
   </table>
 
   <p class="title">Registries for Web Authentication (WebAuthn)<br />
-  <span class="filename">draft-hodges-webauthn-registries-02</span></p>
+  <span class="filename">draft-hodges-webauthn-registries-03</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This specification defines IANA registries for W3C Web Authentication attestation statement format identifiers and extension identifiers.  </p>
@@ -444,22 +446,19 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-
-<p>This Internet-Draft will expire on September 12, 2019.</p>
+<p>This Internet-Draft will expire on April 19, 2020.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
-  <hr class="noprint">
-  <h1 class="np" id="rfc.toc"><a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.toc">Table of Contents</a></h1>
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
   <ul class="toc">
 
-  	<li>1.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.1">Introduction</a>
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
 </li>
-<li>2.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.2">WebAuthn Attestation Statement Format Identifier Registry</a>
-</li>
-<ul><li>2.1.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.2.1">Initial WebAuthn Attestation Statement Format Identifier Registry Values</a>
+<li>2.   <a href="#rfc.section.2">WebAuthn Attestation Statement Format Identifier Registry</a>
 </li>
 <ul><li>2.1.   <a href="#rfc.section.2.1">Initial WebAuthn Attestation Statement Format Identifier Registry Values</a>
 </li>
@@ -469,38 +468,36 @@
 </li>
 </ul><li>4.   <a href="#rfc.section.4">IANA Considerations</a>
 </li>
-</ul><li>4.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.4">IANA Considerations</a>
+<ul><li>4.1.   <a href="#rfc.section.4.1">WebAuthn Attestation Statement Format Identifier and Extension Identifiers Registries</a>
 </li>
-<ul><li>4.1.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.4.1">WebAuthn Attestation Statement Format Identifier and Extension Identifiers Registries</a>
+</ul><li>5.   <a href="#rfc.section.5">Security Considerations</a>
 </li>
-</ul><li>5.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.5">Security Considerations</a>
+<li>6.   <a href="#rfc.section.6">Acknowledgements</a>
 </li>
-<li>6.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.6">Acknowledgements</a>
+<li>7.   <a href="#rfc.section.7">Document History</a>
 </li>
-<li>7.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.7">Document History</a>
+<li>8.   <a href="#rfc.references">Normative References</a>
 </li>
-<li>8.   <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.references">Normative References</a>
-</li>
-<li><a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.authors">Authors' Addresses</a>
+<li><a href="#rfc.authors">Authors' Addresses</a>
 </li>
 
 
   </ul>
 
   <h1 id="rfc.section.1">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.1">1.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#Introduction" id="Introduction">Introduction</a>
+<a href="#rfc.section.1">1.</a> <a href="#Introduction" id="Introduction">Introduction</a>
 </h1>
 <p id="rfc.section.1.p.1">This specification establishes IANA registries for W3C Web Authentication <a href="#WebAuthn" class="xref">[WebAuthn]</a> attestation statement format identifiers and extension identifiers.  The initial values for these registries are in the IANA Considerations section of the <a href="#WebAuthn" class="xref">[WebAuthn]</a> specification.  </p>
 <h1 id="rfc.section.2">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.2">2.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#sctn-reg-new-attstn-format" id="sctn-reg-new-attstn-format">WebAuthn Attestation Statement Format Identifier Registry</a>
+<a href="#rfc.section.2">2.</a> <a href="#sctn-reg-new-attstn-format" id="sctn-reg-new-attstn-format">WebAuthn Attestation Statement Format Identifier Registry</a>
 </h1>
 <p id="rfc.section.2.p.1">WebAuthn attestation statement format identifiers are strings whose semantic, syntactic, and string-matching criteria are specified in <a href="#WebAuthn" class="xref">[WebAuthn]</a> <a href="https://www.w3.org/TR/webauthn/#sctn-attstn-fmt-ids">Section 8.1 "Attestation Statement Format Identifiers" </a>, along with the concepts of attestation and attestation statement formats.  </p>
-<p id="rfc.section.2.p.2">WebAuthn attestation statement format identifiers are registered on the advice of a Designated Expert (appointed by the IESG or their delegate), with a Specification Required (per <a href="#RFC5226" class="xref">[RFC5226]</a>).  </p>
+<p id="rfc.section.2.p.2">WebAuthn attestation statement format identifiers are registered on the advice of a Designated Expert (appointed by the IESG or their delegate), with a Specification Required (per <a href="#RFC8126" class="xref">[RFC8126]</a>).  </p>
 <p id="rfc.section.2.p.3">The Expert(s) will establish procedures for requesting registrations, and make them available from the registry page.  </p>
 <p id="rfc.section.2.p.4">Registration requests consist of at least the following information: </p>
 
 <ul>
-<li>WebAuthn Attestation Statement Format Identifier: This identifier  MUST be a maximum of 32 octets in length and MUST consist only of printable USASCII characters, excluding backslash and doublequote.  This name is case sensitive.  Names may not match other registered names in a case-insensitive manner unless the Designated Experts state that there is a compelling reason to allow an exception.  </li>
+<li>WebAuthn Attestation Statement Format Identifier: This identifier  MUST be a maximum of 32 octets in length and MUST consist only of printable USASCII characters, excluding backslash and doublequote, i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.  This name is case sensitive.  Names may not match other registered names in a case-insensitive manner unless the Designated Experts state that there is a compelling reason to allow an exception.  </li>
 <li>Description: A relatively short description of the attestation format.  </li>
 <li>Specification Document: Reference to the specification of the attestation statement format.  </li>
 <li>Notes: [optional]</li>
@@ -509,21 +506,22 @@
 <p> </p>
 <p id="rfc.section.2.p.5">The Expert(s) MAY define additional fields to be collected in the registry.  Each attestation statement format identifier added to this registry MUST be unique amongst the set of registered attestation statement format identifiers.  The Experts(s) MAY also designate attestation statement formats as proprietary if they lack complete specifications, and will assign a prefix indicating as such to the identifier.  </p>
 <p id="rfc.section.2.p.6">Registrations MUST reference a freely available specification, e.g., as described in <a href="#RFC2026" class="xref">[RFC2026]</a> Section 7.  </p>
-<p id="rfc.section.2.p.7">Note that WebAuthn attestation statement format identifiers can be registered by third parties, if the Expert(s) determine that an unregistered attestation statement format is widely deployed and not likely to be registered in a timely manner.  </p>
+<p id="rfc.section.2.p.7">Note that WebAuthn attestation statement format identifiers can be registered by third parties (e.g., the Expert(s) themselves), if the Expert(s) determine that an unregistered attestation statement format is widely deployed and not likely to be registered in a timely manner.  </p>
 <p id="rfc.section.2.p.8">Decisions (or lack thereof) made by the Designated Expert can be first appealed to Application Area Directors (contactable using app-ads@tools.ietf.org email address or directly by looking up their email addresses on http://www.iesg.org/ website) and, if the appellant is not satisfied with the response, to the full IESG (using the iesg@iesg.org mailing list).  </p>
 <h1 id="rfc.section.2.1">
 <a href="#rfc.section.2.1">2.1.</a> <a href="#sctn-reg-new-attstn-format-values" id="sctn-reg-new-attstn-format-values">Initial WebAuthn Attestation Statement Format Identifier Registry Values</a>
 </h1>
-<p id="rfc.section.2.1.p.1">The initial values for the WebAuthn Attestation Statement Format Identifier Registry are to be populated from the values listed in <a href="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-att-fmt-reg">Section 11.1 "WebAuthn Attestation Statement Format Identifier Registrations"</a> of <a href="#WebAuthn" class="xref">[WebAuthn]</a>.  </p><h1 id="rfc.section.3">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.3">3.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#sctn-reg-new-extn-id" id="sctn-reg-new-extn-id">WebAuthn Extension Identifier Registry</a>
+<p id="rfc.section.2.1.p.1">The initial values for the WebAuthn Attestation Statement Format Identifier Registry are to be populated from the values listed in <a href="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-att-fmt-reg">Section 11.1 "WebAuthn Attestation Statement Format Identifier Registrations"</a> of <a href="#WebAuthn" class="xref">[WebAuthn]</a>.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#sctn-reg-new-extn-id" id="sctn-reg-new-extn-id">WebAuthn Extension Identifier Registry</a>
 </h1>
 <p id="rfc.section.3.p.1">WebAuthn extension identifiers are strings whose semantic, syntactic, and string-matching criteria are specified in <a href="#WebAuthn" class="xref">[WebAuthn]</a> <a href="https://www.w3.org/TR/webauthn/#sctn-extension-id">Section 9.1 "Extension Identifiers" </a>.  </p>
-<p id="rfc.section.3.p.2">WebAuthn extension identifiers are registered on the advice of a Designated Expert (appointed by the IESG or their delegate), with a Specification Required (per <a href="#RFC5226" class="xref">[RFC5226]</a>).  </p>
+<p id="rfc.section.3.p.2">WebAuthn extension identifiers are registered on the advice of a Designated Expert (appointed by the IESG or their delegate), with a Specification Required (per <a href="#RFC8126" class="xref">[RFC8126]</a>).  </p>
 <p id="rfc.section.3.p.3">The Expert(s) will establish procedures for requesting registrations, and make them available from the registry page.  </p>
 <p id="rfc.section.3.p.4">Registration requests consist of at least the following information: </p>
 
 <ul>
-<li>WebAuthn Extension Identifier: This identifier  MUST be a maximum of 32 octets in length and MUST consist only of printable USASCII characters, excluding backslash and doublequote.  This name is case sensitive.  Names may not match other registered names in a case-insensitive manner unless the Designated Experts state that there is a compelling reason to allow an exception.  </li>
+<li>WebAuthn Extension Identifier: This identifier  MUST be a maximum of 32 octets in length and MUST consist only of printable USASCII characters, excluding backslash and doublequote, i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.  This name is case sensitive.  Names may not match other registered names in a case-insensitive manner unless the Designated Experts state that there is a compelling reason to allow an exception.  </li>
 <li>Description: A relatively short description of the extension.</li>
 <li>Specification Document: Reference to the specification of the extension.  </li>
 <li>Notes: [optional]</li>
@@ -531,29 +529,29 @@
 
 <p> </p>
 <p id="rfc.section.3.p.5">The Expert(s) MAY define additional fields to be collected in the registry.  Each extension identifier added to this registry MUST be unique amongst the set of registered extension identifiers.  </p>
-<p id="rfc.section.3.p.6">Registrations MUST reference a freely available specification, e.g., as described in <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#RFC2026" class="xref">[RFC2026]</a> Section 7.  </p>
-<p id="rfc.section.3.p.7">Note that WebAuthn extensions can be registered by third parties, if the Expert(s) determine that an unregistered extension is widely deployed and not likely to be registered in a timely manner.  </p>
+<p id="rfc.section.3.p.6">Registrations MUST reference a freely available specification, e.g., as described in <a href="#RFC2026" class="xref">[RFC2026]</a> Section 7.  </p>
+<p id="rfc.section.3.p.7">Note that WebAuthn extensions can be registered by third parties (e.g., the Expert(s) themselves), if the Expert(s) determine that an unregistered extension is widely deployed and not likely to be registered in a timely manner.  </p>
 <p id="rfc.section.3.p.8">Decisions (or lack thereof) made by the Designated Expert can be first appealed to Application Area Directors (contactable using app-ads@tools.ietf.org email address or directly by looking up their email addresses on http://www.iesg.org/ website) and, if the appellant is not satisfied with the response, to the full IESG (using the iesg@iesg.org mailing list).  </p>
 <h1 id="rfc.section.3.1">
 <a href="#rfc.section.3.1">3.1.</a> <a href="#sctn-reg-new-extn-id-values" id="sctn-reg-new-extn-id-values">Initial WebAuthn Extension Identifier Registry Values</a>
 </h1>
 <p id="rfc.section.3.1.p.1">The initial values for the WebAuthn Extension Identifier Registry are to be populated from the values listed in <a href="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-extensions-reg">Section 11.2 "WebAuthn Extension Identifier Registrations"</a> of <a href="#WebAuthn" class="xref">[WebAuthn]</a>.  </p>
 <h1 id="rfc.section.4">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.4">4.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#sctn-iana-cons" id="sctn-iana-cons">IANA Considerations</a>
+<a href="#rfc.section.4">4.</a> <a href="#sctn-iana-cons" id="sctn-iana-cons">IANA Considerations</a>
 </h1>
 <h1 id="rfc.section.4.1">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.4.1">4.1.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#sctn-attstn-extn-regs" id="sctn-attstn-extn-regs">WebAuthn Attestation Statement Format Identifier and Extension Identifiers Registries</a>
+<a href="#rfc.section.4.1">4.1.</a> <a href="#sctn-attstn-extn-regs" id="sctn-attstn-extn-regs">WebAuthn Attestation Statement Format Identifier and Extension Identifiers Registries</a>
 </h1>
 <p id="rfc.section.4.1.p.1">This specification establishes two registries: </p>
 
 <ul>
-<li>the "WebAuthn Attestation Statement Format Identifier" registry; see <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#sctn-reg-new-attstn-format" class="xref">Section 2</a>.  </li>
-<li>the "WebAuthn Extension Identifier" registry; see <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#sctn-reg-new-extn-id" class="xref">Section 3</a>.  </li>
+<li>the "WebAuthn Attestation Statement Format Identifier" registry; see <a href="#sctn-reg-new-attstn-format" class="xref">Section 2</a>.  </li>
+<li>the "WebAuthn Extension Identifier" registry; see <a href="#sctn-reg-new-extn-id" class="xref">Section 3</a>.  </li>
 </ul>
 
 <p> For both registries, the Expert(s) and IANA will interact as outlined below: </p>
 <p id="rfc.section.4.1.p.2">IANA will direct any incoming requests regarding the registry to the processes established by the Expert(s); typically, this will mean referring them to the registry HTML page.  </p>
-<p id="rfc.section.4.1.p.3">The Expert(s) will provide registry data to IANA in an agreed form (e.g., a specific XML format). IANA will publish: </p>
+<p id="rfc.section.4.1.p.3">The Expert(s) will provide registry data to IANA in an agreed form (e.g., a specific format). IANA will publish: </p>
 
 <ul>
 <li>The raw registry data</li>
@@ -573,15 +571,15 @@
 <p> </p>
 <p id="rfc.section.4.1.p.6">All registry data documents MUST include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions (<span>&lt;</span><a href="http://trustee.ietf.org/license-info">http://trustee.ietf.org/license-info</a><span>&gt;</span>).  </p>
 <h1 id="rfc.section.5">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.5">5.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#Security" id="Security">Security Considerations</a>
+<a href="#rfc.section.5">5.</a> <a href="#Security" id="Security">Security Considerations</a>
 </h1>
-<p id="rfc.section.5.p.1">See <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#WebAuthn" class="xref">[WebAuthn]</a> for relevant security considerations.  </p>
+<p id="rfc.section.5.p.1">See <a href="#WebAuthn" class="xref">[WebAuthn]</a> for relevant security considerations.  </p>
 <h1 id="rfc.section.6">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.6">6.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
+<a href="#rfc.section.6">6.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
 <p id="rfc.section.6.p.1">Thanks to Mark Nottingham for valuable comments and suggestions.  Thanks to Kathleen Moriarty and Benjamin Kaduk for their Area Director sponsorship of this specification.  </p>
 <h1 id="rfc.section.7">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.section.7">7.</a> <a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#sctn-history" id="sctn-history">Document History</a>
+<a href="#rfc.section.7">7.</a> <a href="#sctn-history" id="sctn-history">Document History</a>
 </h1>
 <p id="rfc.section.7.p.1">[[ to be removed by the RFC Editor before publication as an RFC ]]</p>
 <p id="rfc.section.7.p.2">-02 </p>
@@ -600,7 +598,7 @@
 
 <p> </p>
 <h1 id="rfc.references">
-<a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.references">8.</a> Normative References</h1>
+<a href="#rfc.references">8.</a> Normative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="RFC2026">[RFC2026]</b></td>
@@ -608,9 +606,9 @@
 <a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2026">The Internet Standards Process -- Revision 3</a>", BCP 9, RFC 2026, DOI 10.17487/RFC2026, October 1996.</td>
 </tr>
 <tr>
-<td class="reference"><b id="RFC5226">[RFC5226]</b></td>
+<td class="reference"><b id="RFC8126">[RFC8126]</b></td>
 <td class="top">
-<a>Narten, T.</a> and <a>H. Alvestrand</a>, "<a href="https://tools.ietf.org/html/rfc5226">Guidelines for Writing an IANA Considerations Section in RFCs</a>", RFC 5226, DOI 10.17487/RFC5226, May 2008.</td>
+<a>Cotton, M.</a>, <a>Leiba, B.</a> and <a>T. Narten</a>, "<a href="https://tools.ietf.org/html/rfc8126">Guidelines for Writing an IANA Considerations Section in RFCs</a>", BCP 26, RFC 8126, DOI 10.17487/RFC8126, June 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="WebAuthn">[WebAuthn]</b></td>
@@ -618,7 +616,7 @@
 <a href="mailto:balfanz@google.com" title="Google">Balfanz, D.</a>, <a href="mailto:aczeskis@google.com" title="Google">Czeskis, A.</a>, <a href="mailto:jdhodges@google.com" title="PayPal">Hodges, J.</a>, <a href="mailto:jc@mozilla.com" title="Mozilla">Jones, J.</a>, <a href="mailto:mbj@microsoft.com" title="Microsoft">Jones, M.</a>, <a href="mailto:akshayku@microsoft.com" title="Microsoft">Kumar, A.</a>, <a href="mailto:huliao@microsoft.com" title="Microsoft">Liao, A.</a>, <a href="mailto:rolf@noknok.com" title="Nok Nok Labs">Lindemann, R.</a> and <a href="mailto:emil@yubico.com" title="Yubico">E. Lundberg</a>, "<a href="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/">Web Authentication: An API for accessing Public Key Credentials</a>", World Wide Web Consortium (W3C) Recommendation, March 2019.</td>
 </tr>
 </tbody></table>
-<h1 id="rfc.authors"><a href="https://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi#rfc.authors">Authors' Addresses</a></h1>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
 <div class="avoidbreak">
   <address class="vcard">
 	<span class="vcardline">
@@ -692,6 +690,5 @@
   </address>
 </div>
 
-
-
-</body></html>
+</body>
+</html>

--- a/draft-hodges-webauthn-registries.txt
+++ b/draft-hodges-webauthn-registries.txt
@@ -5,14 +5,14 @@
 W3C WebAuthn Working Group                                     J. Hodges
 Internet-Draft                                                    Google
 Intended status: Informational                                G. Mandyam
-Expires: September 12, 2019                   Qualcomm Technologies Inc.
+Expires: April 19, 2020                       Qualcomm Technologies Inc.
                                                                 M. Jones
                                                                Microsoft
-                                                          March 11, 2019
+                                                            Oct 17, 2019
 
 
               Registries for Web Authentication (WebAuthn)
-                  draft-hodges-webauthn-registries-02
+                  draft-hodges-webauthn-registries-03
 
 Abstract
 
@@ -34,7 +34,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 12, 2019.
+   This Internet-Draft will expire on April 19, 2020.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Hodges, et al.         Expires September 12, 2019               [Page 1]
+Hodges, et al.           Expires April 19, 2020                 [Page 1]
 
-Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
+Internet-DraftRegistries for Web Authentication (WebAuthn)      Oct 2019
 
 
 Table of Contents
@@ -66,15 +66,15 @@ Table of Contents
            Registry Values . . . . . . . . . . . . . . . . . . . . .   3
    3.  WebAuthn Extension Identifier Registry  . . . . . . . . . . .   3
      3.1.  Initial WebAuthn Extension Identifier Registry Values . .   4
-   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   4
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   5
      4.1.  WebAuthn Attestation Statement Format Identifier and
-           Extension Identifiers Registries  . . . . . . . . . . . .   4
+           Extension Identifiers Registries  . . . . . . . . . . . .   5
    5.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
-   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   5
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
    7.  Document History  . . . . . . . . . . . . . . . . . . . . . .   6
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .   6
-     8.2.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .   6
+     8.2.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .   7
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   7
 
 1.  Introduction
@@ -95,7 +95,7 @@ Table of Contents
 
    WebAuthn attestation statement format identifiers are registered on
    the advice of a Designated Expert (appointed by the IESG or their
-   delegate), with a Specification Required (per [RFC5226]).
+   delegate), with a Specification Required (per [RFC8126]).
 
    The Expert(s) will establish procedures for requesting registrations,
    and make them available from the registry page.
@@ -104,16 +104,17 @@ Table of Contents
 
    o  WebAuthn Attestation Statement Format Identifier: This identifier
       MUST be a maximum of 32 octets in length and MUST consist only of
-      printable USASCII characters, excluding backslash and doublequote.
-      This name is case sensitive.  Names may not match other registered
+      printable USASCII characters, excluding backslash and doublequote,
+      i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.
 
 
 
-Hodges, et al.         Expires September 12, 2019               [Page 2]
+Hodges, et al.           Expires April 19, 2020                 [Page 2]
 
-Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
+Internet-DraftRegistries for Web Authentication (WebAuthn)      Oct 2019
 
 
+      This name is case sensitive.  Names may not match other registered
       names in a case-insensitive manner unless the Designated Experts
       state that there is a compelling reason to allow an exception.
    o  Description: A relatively short description of the attestation
@@ -134,9 +135,10 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
    as described in [RFC2026] Section 7.
 
    Note that WebAuthn attestation statement format identifiers can be
-   registered by third parties, if the Expert(s) determine that an
-   unregistered attestation statement format is widely deployed and not
-   likely to be registered in a timely manner.
+   registered by third parties (e.g., the Expert(s) themselves), if the
+   Expert(s) determine that an unregistered attestation statement format
+   is widely deployed and not likely to be registered in a timely
+   manner.
 
    Decisions (or lack thereof) made by the Designated Expert can be
    first appealed to Application Area Directors (contactable using app-
@@ -159,16 +161,18 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
    and string-matching criteria are specified in [WebAuthn] Section 9.1
    "Extension Identifiers" [3].
 
+
+
+
+
+Hodges, et al.           Expires April 19, 2020                 [Page 3]
+
+Internet-DraftRegistries for Web Authentication (WebAuthn)      Oct 2019
+
+
    WebAuthn extension identifiers are registered on the advice of a
    Designated Expert (appointed by the IESG or their delegate), with a
-   Specification Required (per [RFC5226]).
-
-
-
-Hodges, et al.         Expires September 12, 2019               [Page 3]
-
-Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
-
+   Specification Required (per [RFC8126]).
 
    The Expert(s) will establish procedures for requesting registrations,
    and make them available from the registry page.
@@ -177,7 +181,8 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
 
    o  WebAuthn Extension Identifier: This identifier MUST be a maximum
       of 32 octets in length and MUST consist only of printable USASCII
-      characters, excluding backslash and doublequote.  This name is
+      characters, excluding backslash and doublequote, i.e., VCHAR as
+      defined in [[!RFC5234]] but without %x22 and %x5c.  This name is
       case sensitive.  Names may not match other registered names in a
       case-insensitive manner unless the Designated Experts state that
       there is a compelling reason to allow an exception.
@@ -193,9 +198,10 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
    Registrations MUST reference a freely available specification, e.g.,
    as described in [RFC2026] Section 7.
 
-   Note that WebAuthn extensions can be registered by third parties, if
-   the Expert(s) determine that an unregistered extension is widely
-   deployed and not likely to be registered in a timely manner.
+   Note that WebAuthn extensions can be registered by third parties
+   (e.g., the Expert(s) themselves), if the Expert(s) determine that an
+   unregistered extension is widely deployed and not likely to be
+   registered in a timely manner.
 
    Decisions (or lack thereof) made by the Designated Expert can be
    first appealed to Application Area Directors (contactable using app-
@@ -210,21 +216,22 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
    to be populated from the values listed in Section 11.2 "WebAuthn
    Extension Identifier Registrations" [4] of [WebAuthn].
 
+
+
+
+
+
+Hodges, et al.           Expires April 19, 2020                 [Page 4]
+
+Internet-DraftRegistries for Web Authentication (WebAuthn)      Oct 2019
+
+
 4.  IANA Considerations
 
 4.1.  WebAuthn Attestation Statement Format Identifier and Extension
       Identifiers Registries
 
    This specification establishes two registries:
-
-
-
-
-
-Hodges, et al.         Expires September 12, 2019               [Page 4]
-
-Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
-
 
    o  the "WebAuthn Attestation Statement Format Identifier" registry;
       see Section 2.
@@ -238,7 +245,7 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
    referring them to the registry HTML page.
 
    The Expert(s) will provide registry data to IANA in an agreed form
-   (e.g., a specific XML format).  IANA will publish:
+   (e.g., a specific format).  IANA will publish:
 
    o  The raw registry data
    o  The registry data, transformed into HTML
@@ -264,23 +271,22 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
 
    See [WebAuthn] for relevant security considerations.
 
+
+
+
+
+
+
+Hodges, et al.           Expires April 19, 2020                 [Page 5]
+
+Internet-DraftRegistries for Web Authentication (WebAuthn)      Oct 2019
+
+
 6.  Acknowledgements
 
    Thanks to Mark Nottingham for valuable comments and suggestions.
    Thanks to Kathleen Moriarty and Benjamin Kaduk for their Area
    Director sponsorship of this specification.
-
-
-
-
-
-
-
-
-Hodges, et al.         Expires September 12, 2019               [Page 5]
-
-Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
-
 
 7.  Document History
 
@@ -308,10 +314,10 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
               3", BCP 9, RFC 2026, DOI 10.17487/RFC2026, October 1996,
               <https://www.rfc-editor.org/info/rfc2026>.
 
-   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
-              IANA Considerations Section in RFCs", RFC 5226,
-              DOI 10.17487/RFC5226, May 2008,
-              <https://www.rfc-editor.org/info/rfc5226>.
+   [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
+              Writing an IANA Considerations Section in RFCs", BCP 26,
+              RFC 8126, DOI 10.17487/RFC8126, June 2017,
+              <https://www.rfc-editor.org/info/rfc8126>.
 
    [WebAuthn]
               Balfanz, D., Czeskis, A., Hodges, J., Jones, J., Jones,
@@ -321,6 +327,17 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
               (W3C) Recommendation, March 2019,
               <https://www.w3.org/TR/2019/REC-webauthn-1-20190304/>.
 
+
+
+
+
+
+
+Hodges, et al.           Expires April 19, 2020                 [Page 6]
+
+Internet-DraftRegistries for Web Authentication (WebAuthn)      Oct 2019
+
+
 8.2.  URIs
 
    [1] https://www.w3.org/TR/webauthn/#sctn-attstn-fmt-ids
@@ -329,14 +346,6 @@ Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
        reg
 
    [3] https://www.w3.org/TR/webauthn/#sctn-extension-id
-
-
-
-
-Hodges, et al.         Expires September 12, 2019               [Page 6]
-
-Internet-DraftRegistries for Web Authentication (WebAuthn)    March 2019
-
 
    [4] https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-
        extensions-reg
@@ -380,13 +389,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-Hodges, et al.         Expires September 12, 2019               [Page 7]
+Hodges, et al.           Expires April 19, 2020                 [Page 7]

--- a/draft-hodges-webauthn-registries.xml
+++ b/draft-hodges-webauthn-registries.xml
@@ -90,93 +90,93 @@
       <t>
         This specification establishes IANA registries for W3C Web Authentication <xref
         target="WebAuthn"/> attestation statement format identifiers and extension identifiers.
-	The initial values for these registries are in the IANA Considerations
-	section of the <xref target="WebAuthn"/> specification.
+        The initial values for these registries are in the IANA Considerations
+        section of the <xref target="WebAuthn"/> specification.
       </t>
     </section>
 
 
     <section title="WebAuthn Attestation Statement Format Identifier Registry"
-      anchor="sctn-reg-new-attstn-format">
+      anchor="sctn-attstn-format-registry">
 
       <t>
         WebAuthn attestation statement format identifiers are strings whose semantic, syntactic,
         and string-matching criteria are specified in <xref target="WebAuthn"/>
-	<eref target="https://www.w3.org/TR/webauthn/#sctn-attstn-fmt-ids">
-	Section 8.1 "Attestation Statement Format Identifiers" </eref>,
+        <eref target="https://www.w3.org/TR/webauthn/#sctn-attstn-fmt-ids">
+        "Attestation Statement Format Identifiers" </eref>,
         along with the concepts of attestation and attestation statement formats.
       </t>
-      <t>
-        WebAuthn attestation statement format identifiers are registered on the
-	advice of a Designated Expert
-        (appointed by the IESG or their delegate), with a Specification Required (per <xref
-            target="RFC8126"/>).
-      </t>
-      <t>
-        The Expert(s) will establish procedures for requesting registrations,
-        and make them available from the registry page.
-      </t>
-      <t>
-        Registration requests consist of at least the following information:
-        <list style="symbols" >
-          <t>
-	    WebAuthn Attestation Statement Format Identifier:
-	    This identifier  MUST be a maximum of 32 octets in length and MUST
-	    consist only of printable USASCII characters, excluding backslash and doublequote,
-	    i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.
-	    This name is case sensitive.
-	    Names may not match other registered names in a case-insensitive manner
-	    unless the Designated Experts state that there is a compelling reason
-	    to allow an exception.
-	  </t>
-          <t>
-            Description: A relatively short description of the attestation
-            format.
-          </t>
-          <t>
-            Specification Document: Reference to the specification of the
-            attestation statement format.
-          </t>
-          <t>Notes: [optional]</t>
-        </list>
-      </t>
-      <t>
-        The Expert(s) MAY define additional fields to be collected in the registry.
-        Each attestation statement format identifier added to this registry MUST be unique
-        amongst the set of registered attestation statement format identifiers.  The Experts(s) MAY
-        also designate attestation statement formats as proprietary if they lack complete specifications,
-        and will assign a prefix indicating as such to the identifier.
-      </t>
-      <t>
-        Registrations MUST reference a freely available specification, e.g., as
-        described in <xref target="RFC2026"/> Section 7.
-      </t>
-      <t>
-        Note that WebAuthn attestation statement format identifiers
-        can be registered by third parties (e.g., the Expert(s) themselves),
-        if the
-        Expert(s) determine that an unregistered attestation statement format
-	    is widely deployed and not
-        likely to be registered in a timely manner.
-      </t>
-      <t>
-        Decisions (or lack thereof) made by the Designated Expert can be
-        first appealed to Application Area Directors (contactable using
-        app-ads@tools.ietf.org email address or directly by looking up their
-        email addresses on http://www.iesg.org/ website) and, if the
-        appellant is not satisfied with the response, to the full IESG (using
-        the iesg@iesg.org mailing list).
-      </t>
+      <section title="Registering Attestation Statement Format Identifiers"
+        anchor="sctn-registering-attstn-format-idents">
+        <t>
+          WebAuthn attestation statement format identifiers are registered on the advice of a
+          Designated Expert (appointed by the IESG or their delegate), with a Specification Required
+          (per <xref target="RFC8126"/>).
+        </t>
+        <t>
+          The Expert(s) will establish procedures for requesting registrations,
+          and make them available from the registry page.
+        </t>
+        <t>
+          Registration requests consist of at least the following information:
+          <list style="symbols" >
+            <t>
+              WebAuthn Attestation Statement Format Identifier:
+              This identifier  MUST be a maximum of 32 octets in length and MUST
+              consist only of printable USASCII characters, excluding backslash and doublequote,
+              i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.
+              This name is case sensitive.
+              Names may not match other registered names in a case-insensitive manner
+              unless the Designated Experts state that there is a compelling reason
+              to allow an exception.
+            </t>
+            <t>
+              Description: A relatively short description of the attestation
+              format.
+            </t>
+            <t>
+              Specification Document: Reference to the specification of the
+              attestation statement format.
+            </t>
+            <t>Notes: [optional]</t>
+          </list>
+        </t>
+        <t>
+          The Expert(s) MAY define additional fields to be collected in the registry. Each
+          attestation statement format identifier added to this registry MUST be unique amongst the
+          set of registered attestation statement format identifiers. The Experts(s) MAY also
+          designate attestation statement formats as proprietary if they lack complete
+          specifications, and will assign a prefix indicating as such to the identifier.
+        </t>
+        <t>
+          Registrations MUST reference a freely available specification, e.g., as
+          described in <xref target="RFC2026"/> Section 7.
+        </t>
+        <t>
+          Note that WebAuthn attestation statement format identifiers can be registered by third
+          parties (e.g., the Expert(s) themselves), if the Expert(s) determine that an unregistered
+          attestation statement format is widely deployed and not likely to be registered in a
+          timely manner.
+        </t>
+        <t>
+          Decisions (or lack thereof) made by the Designated Expert can be
+          first appealed to Application Area Directors (contactable using
+          app-ads@tools.ietf.org email address or directly by looking up their
+          email addresses on http://www.iesg.org/ website) and, if the
+          appellant is not satisfied with the response, to the full IESG (using
+          the iesg@iesg.org mailing list).
+        </t>
+      </section>
 
       <section title="Initial WebAuthn Attestation Statement Format Identifier Registry Values"
-        anchor="sctn-reg-new-attstn-format-values">
+        anchor="sctn-attstn-format-registry-values">
 
         <t>
-	  The initial values for the WebAuthn Attestation Statement Format Identifier Registry are
-	  to be populated from the values listed in
-	  <eref target="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-att-fmt-reg">
-	  Section 11.1 "WebAuthn Attestation Statement Format Identifier
-	  Registrations"</eref> of <xref target="WebAuthn"/>.
+          The initial values for the WebAuthn Attestation Statement Format Identifier Registry are
+          to be populated from the values listed in
+          <eref target="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-att-fmt-reg">
+          Section 11.1 "WebAuthn Attestation Statement Format Identifier
+          Registrations"</eref> of <xref target="WebAuthn"/>.
         </t>
 
       </section>
@@ -190,8 +190,8 @@
       <t>
         WebAuthn extension identifiers are strings whose semantic, syntactic,
         and string-matching criteria are specified in <xref target="WebAuthn"/>
-	<eref target="https://www.w3.org/TR/webauthn/#sctn-extension-id">
-	Section 9.1 "Extension Identifiers" </eref>.
+        <eref target="https://www.w3.org/TR/webauthn/#sctn-extension-id">
+        Section 9.1 "Extension Identifiers" </eref>.
       </t>
       <t>
         WebAuthn extension identifiers are registered on the advice of a Designated Expert
@@ -206,15 +206,15 @@
         Registration requests consist of at least the following information:
         <list style="symbols" >
           <t>
-	    WebAuthn Extension Identifier:
-	    This identifier  MUST be a maximum of 32 octets in length and MUST
-	    consist only of printable USASCII characters, excluding backslash and doublequote,
-	    i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.
-	    This name is case sensitive.
-	    Names may not match other registered names in a case-insensitive manner
-	    unless the Designated Experts state that there is a compelling reason
-	    to allow an exception.
-	  </t>
+            WebAuthn Extension Identifier:
+            This identifier  MUST be a maximum of 32 octets in length and MUST
+            consist only of printable USASCII characters, excluding backslash and doublequote,
+            i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.
+            This name is case sensitive.
+            Names may not match other registered names in a case-insensitive manner
+            unless the Designated Experts state that there is a compelling reason
+            to allow an exception.
+          </t>
           <t>Description: A relatively short description of the extension.</t>
           <t>
             Specification Document: Reference to the specification of the
@@ -252,11 +252,11 @@
         anchor="sctn-reg-new-extn-id-values">
 
         <t>
-	  The initial values for the WebAuthn Extension Identifier Registry are
-	  to be populated from the values listed in
-	  <eref target="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-extensions-reg">
-	  Section 11.2 "WebAuthn Extension Identifier Registrations"</eref>
-	  of <xref target="WebAuthn"/>.
+        The initial values for the WebAuthn Extension Identifier Registry are
+        to be populated from the values listed in
+        <eref target="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#sctn-extensions-reg">
+        Section 11.2 "WebAuthn Extension Identifier Registrations"</eref>
+        of <xref target="WebAuthn"/>.
         </t>
 
       </section>
@@ -272,10 +272,12 @@
           This specification establishes two registries:
           <list style="symbols">
             <t>
-              the "WebAuthn Attestation Statement Format Identifier" registry; see <xref target="sctn-reg-new-attstn-format"/>.
+              the "WebAuthn Attestation Statement Format Identifier" registry; see
+              <xref target="sctn-attstn-format-registry"/>.
             </t>
             <t>
-              the "WebAuthn Extension Identifier" registry; see <xref target="sctn-reg-new-extn-id" />.
+              the "WebAuthn Extension Identifier" registry;
+              see <xref target="sctn-reg-new-extn-id" />.
             </t>
           </list>
           For both registries, the Expert(s) and IANA will interact as outlined below:
@@ -305,9 +307,8 @@
               text and markup.
             </t>
             <t>
-              Include a stable HTML fragment identifier for each registered
-	      attestation statement format identifier or
-              extension identifier.
+              Include a stable HTML fragment identifier for each registered attestation statement
+              format identifier or extension identifier.
             </t>
           </list>
         </t>
@@ -332,7 +333,8 @@
       <t>
         Thanks to Mark Nottingham
         for valuable comments and suggestions.
-	Thanks to Kathleen Moriarty and Benjamin Kaduk for their Area Director sponsorship of this specification.
+        Thanks to Kathleen Moriarty and Benjamin Kaduk for their Area Director sponsorship
+        of this specification.
       </t>
     </section>
 
@@ -340,31 +342,31 @@
       <t>[[ to be removed by the RFC Editor before publication as an RFC ]]</t>
 
       <t>
-	-02
+        -02
         <list style="symbols">
-	  <t>
-	    Refresh now that the WebAuthn spec is at Recommendation (REC) maturity level.
-	  </t>
-	</list>
+          <t>
+            Refresh now that the WebAuthn spec is at Recommendation (REC) maturity level.
+          </t>
+        </list>
       </t>
 
 
       <t>
-	-01
+        -01
         <list style="symbols">
-	  <t>
-	    Refresh now that the WebAuthn Committee Recommendation (CR) draft is pending.
-	  </t>
-	</list>
+          <t>
+            Refresh now that the WebAuthn Committee Recommendation (CR) draft is pending.
+          </t>
+        </list>
       </t>
 
       <t>
-	-00
+	    -00
         <list style="symbols">
-	  <t>
-	    Initial version.
-	  </t>
-	</list>
+          <t>
+            Initial version.
+          </t>
+        </list>
       </t>
 
     </section>

--- a/draft-hodges-webauthn-registries.xml
+++ b/draft-hodges-webauthn-registries.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rfc SYSTEM "http://xml2rfc.tools.ietf.org/authoring/rfc2629.dtd" [
   <!ENTITY rfc2026 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2026.xml">
-  <!ENTITY rfc5226 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5226.xml">
+  <!ENTITY rfc8126 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8126.xml">
 ]>
 
 <?xml-stylesheet type="text/xsl" href="http://xml2rfc.tools.ietf.org/authoring/rfc2629.xslt" ?>
@@ -21,7 +21,7 @@
   -00d: Let initial values be in the [WebAuthn] spec, rather than here.
 -->
 
-<rfc category="info" ipr="trust200902" docName="draft-hodges-webauthn-registries-02">
+<rfc category="info" ipr="trust200902" docName="draft-hodges-webauthn-registries-03">
   <front>
     <title>Registries for Web Authentication (WebAuthn)</title>
 
@@ -66,7 +66,7 @@
       </address>
     </author>
 
-    <date month="March" year="2019" />
+    <date month="Oct" year="2019" />
 
     <area>Security</area>
     <workgroup>W3C WebAuthn Working Group</workgroup>
@@ -110,7 +110,7 @@
         WebAuthn attestation statement format identifiers are registered on the
 	advice of a Designated Expert
         (appointed by the IESG or their delegate), with a Specification Required (per <xref
-            target="RFC5226"/>).
+            target="RFC8126"/>).
       </t>
       <t>
         The Expert(s) will establish procedures for requesting registrations,
@@ -122,7 +122,8 @@
           <t>
 	    WebAuthn Attestation Statement Format Identifier:
 	    This identifier  MUST be a maximum of 32 octets in length and MUST
-	    consist only of printable USASCII characters, excluding backslash and doublequote.
+	    consist only of printable USASCII characters, excluding backslash and doublequote,
+	    i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.
 	    This name is case sensitive.
 	    Names may not match other registered names in a case-insensitive manner
 	    unless the Designated Experts state that there is a compelling reason
@@ -152,9 +153,10 @@
       </t>
       <t>
         Note that WebAuthn attestation statement format identifiers
-        can be registered by third parties, if the
+        can be registered by third parties (e.g., the Expert(s) themselves),
+        if the
         Expert(s) determine that an unregistered attestation statement format
-	is widely deployed and not
+	    is widely deployed and not
         likely to be registered in a timely manner.
       </t>
       <t>
@@ -194,7 +196,7 @@
       <t>
         WebAuthn extension identifiers are registered on the advice of a Designated Expert
         (appointed by the IESG or their delegate), with a Specification Required (per <xref
-            target="RFC5226"/>).
+            target="RFC8126"/>).
       </t>
       <t>
         The Expert(s) will establish procedures for requesting registrations,
@@ -206,7 +208,8 @@
           <t>
 	    WebAuthn Extension Identifier:
 	    This identifier  MUST be a maximum of 32 octets in length and MUST
-	    consist only of printable USASCII characters, excluding backslash and doublequote.
+	    consist only of printable USASCII characters, excluding backslash and doublequote,
+	    i.e., VCHAR as defined in [[!RFC5234]] but without %x22 and %x5c.
 	    This name is case sensitive.
 	    Names may not match other registered names in a case-insensitive manner
 	    unless the Designated Experts state that there is a compelling reason
@@ -231,7 +234,8 @@
         described in <xref target="RFC2026"/> Section 7.
       </t>
       <t>
-        Note that WebAuthn extensions can be registered by third parties, if the Expert(s)
+        Note that WebAuthn extensions can be registered by third parties
+        (e.g., the Expert(s) themselves), if the Expert(s)
         determine that an unregistered extension is widely deployed and not likely to be
         registered in a timely manner.
       </t>
@@ -281,7 +285,7 @@
           by the Expert(s); typically, this will mean referring them to the registry HTML page.
         </t>
         <t>
-          The Expert(s) will provide registry data to IANA in an agreed form (e.g., a specific XML
+          The Expert(s) will provide registry data to IANA in an agreed form (e.g., a specific
           format). IANA will publish:
           <list style="symbols">
             <t>The raw registry data</t>
@@ -371,7 +375,7 @@
   <back>
     <references title="Normative References">
       &rfc2026;
-      &rfc5226;
+      &rfc8126;
 
       <reference anchor="WebAuthn" target="https://www.w3.org/TR/2019/REC-webauthn-1-20190304/">
         <front>


### PR DESCRIPTION
This set of commits represent updates to draft-hodges-webauthn-registries per AD Ben Kaduk's review. the new target published revision number is -03 (the presently-published rev is -02), so this set of commits is referred to as -03a.  Target publication date for -03 is by 4-Nov-2019 (which is the Internet-Draft cut-off for IETF-106)