### PR TITLE
Use CSS numbering for table references too

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -86,7 +86,7 @@ figure.table figcaption {
     counter-increment: none;
 }
 figure.table figcaption:not(.no-marker)::before {
-    content: counter(table);
+    content: "Table " counter(table) " ";
 }
 figure.table .overlarge {
     max-width: 50em;

--- a/index.bs
+++ b/index.bs
@@ -101,6 +101,20 @@ figure.table .overlarge {
     counter-increment: figure -1;
     content: ""
 }
+
+.table-ref-previous::before {
+    content: "Table " counter(table)
+}
+
+.table-ref-following::before {
+    counter-increment: table;
+    content: "Table " counter(table)
+}
+
+.table-ref-following::after {
+    counter-increment: table -1;
+    content: ""
+}
 </style>
 
 
@@ -3049,7 +3063,9 @@ format, and uses its knowledge of the authenticator to make trust decisions.
 The [=authenticator data=] has a compact but extensible encoding. This is desired since authenticators can be devices with
 limited capabilities and low power requirements, with much simpler software stacks than the [=client platform=].
 
-The [=authenticator data=] structure is a byte array of 37 bytes or more, laid out as shown in [Table 1](#table-authData).
+The [=authenticator data=] structure is a byte array of 37 bytes or more,
+laid out as shown in <a href="#table-authData"><span class="table-ref-following"/></a>.
+
 
 <figure id="table-authData" class="table">
     <table class="complex data longlastcol">
@@ -3216,7 +3232,9 @@ The above examples illustrate the the primary <dfn>authenticator type</dfn> char
 - Whether the authenticator is [=resident credential capable=] &mdash; the [=credential storage modality=].
 
 These characteristics are independent and may in theory be combined in any way,
-but [Table 2](#table-authenticatorTypes) lists and names some [=authenticator types=] of particular interest.
+but <a href="#table-authenticatorTypes"><span class="table-ref-following"/></a>
+lists and names some [=authenticator types=] of particular interest.
+
 
 <figure id="table-authenticatorTypes" class="table">
     <table class="data">
@@ -3274,7 +3292,9 @@ typically a PIN or [=biometric recognition=].
 The [=authenticator=] can thus act as two kinds of [=authentication factor=],
 which enables [=multi-factor=] authentication while eliminating the need to share a password with the [=[RP]=].
 
-The four combinations not named in [Table 2](#table-authenticatorTypes) have less distinguished use cases:
+The four combinations not named in <a href="#table-authenticatorTypes"><span class="table-ref-previous"/></a>
+have less distinguished use cases:
+
 
 - The [=credential storage modality=] is less relevant for a [=platform authenticator=] than for a [=roaming authenticator=],
     since users using a [=platform authenticator=] can typically be identified by a session cookie or the like
@@ -3742,7 +3762,7 @@ understand the characteristics of the [=authenticators=] that they trust, based 
 ### Attested Credential Data ### {#sctn-attested-credential-data}
 
 <dfn>Attested credential data</dfn> is a variable-length byte array added to the [=authenticator data=] when generating an [=attestation
-object=] for a given credential. Its format is shown in [Table 3](#table-attestedCredentialData).
+object=] for a given credential. Its format is shown in <a href="#table-attestedCredentialData"><span class="table-ref-following"/></a>.
 
 <figure id="table-attestedCredentialData" class="table">
     <table class="complex data longlastcol">

--- a/index.bs
+++ b/index.bs
@@ -94,7 +94,7 @@ figure.table .overlarge {
 
 .figure-num-following::before {
     counter-increment: figure;
-    content: counter(figure)
+    content: "Figure " counter(figure)
 }
 
 .figure-num-following::after {
@@ -1199,7 +1199,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are [=managing authenticator|managed=] by a [=[WAA]=], with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
-browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration">Figure <span class="figure-num-following"/></a>, below.
+browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration"><span class="figure-num-following"/></a>, below.
 
 
 <figure id="fig-registration">
@@ -1209,7 +1209,7 @@ browser to create a new credential for future use by the [=[RP]=]. See <a href="
 
 
 Scripts can also request the user’s permission to perform
-[=authentication=] operations with an existing credential. See <a href="#fig-authentication">Figure <span class="figure-num-following"/></a>, below.
+[=authentication=] operations with an existing credential. See <a href="#fig-authentication"><span class="figure-num-following"/></a>, below.
 
 
 <figure id="fig-authentication">
@@ -3137,7 +3137,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 - If the authenticator does not include any [=authDataExtensions|extension data=], it MUST set the `ED` [=flag=] to zero, and to one if
     [=authDataExtensions|extension data=] is included.
 
-<a href="#fig-authData">Figure <span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
+<a href="#fig-authData"><span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
 
 <figure id="fig-authData">
     <img src="images/fido-signature-formats-figure1.svg"/>
@@ -3604,7 +3604,7 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     specified in [[#sctn-authenticator-data]] including |processedExtensions|, if any, as
     the <code>[=authDataExtensions|extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.
 1. Let |signature| be the [=assertion signature=] of the concatenation <code>|authenticatorData| || |hash|</code> using the
-    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature">Figure <span class="figure-num-following"/></a>, below. A simple,
+    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature"><span class="figure-num-following"/></a>, below. A simple,
     undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
     client data=] (which potentially has a variable length) is always the last element.
@@ -3661,7 +3661,7 @@ Authenticators may be required to store arbitrary strings chosen by a [=[RP]=], 
 
 If string value truncation is the chosen accommodation then authenticators MAY truncate in order to make the string fit within a length equal or greater than the specified minimum supported length. Such truncation MAY also respect UTF-8 sequence boundaries or [=grapheme cluster=] boundaries [[UTR29]]. This defines the maximum truncation permitted and authenticators MUST NOT truncate further.
 
-For example, in <a href="#fig-stringTruncation">figure <span class="figure-num-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
+For example, in <a href="#fig-stringTruncation"><span class="figure-num-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
 
 <figure id="fig-stringTruncation">
     <img src="images/string-truncation.svg"/>
@@ -3689,7 +3689,7 @@ MAY either perform [=self attestation=] of the [=credential public key=] with th
 or otherwise perform [=None|no attestation=]. All this
 information is returned by [=authenticators=] any time a new [=public key credential=] is generated, in the overall form of an
 <dfn>attestation object</dfn>. The relationship of the [=attestation object=] with [=authenticator data=] (containing
-[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs">figure <span class="figure-num-following"/></a>, below.
+[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs"><span class="figure-num-following"/></a>, below.
 
 If an [=authenticator=] employs [=self attestation=] or [=None|no attestation=], then no provenance information is provided
 for the [=[RP]=] to base a trust decision on.

--- a/index.bs
+++ b/index.bs
@@ -92,12 +92,12 @@ figure.table .overlarge {
     max-width: 50em;
 }
 
-.figure-ref-following::before {
+.figure-num-following::before {
     counter-increment: figure;
     content: "Figure " counter(figure)
 }
 
-.figure-ref-following::after {
+.figure-num-following::after {
     counter-increment: figure -1;
     content: ""
 }
@@ -1213,7 +1213,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are [=managing authenticator|managed=] by a [=[WAA]=], with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
-browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration"><span class="figure-ref-following"/></a>, below.
+browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration"><span class="figure-num-following"/></a>, below.
 
 
 <figure id="fig-registration">
@@ -1223,7 +1223,7 @@ browser to create a new credential for future use by the [=[RP]=]. See <a href="
 
 
 Scripts can also request the user’s permission to perform
-[=authentication=] operations with an existing credential. See <a href="#fig-authentication"><span class="figure-ref-following"/></a>, below.
+[=authentication=] operations with an existing credential. See <a href="#fig-authentication"><span class="figure-num-following"/></a>, below.
 
 
 <figure id="fig-authentication">
@@ -3153,7 +3153,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 - If the authenticator does not include any [=authDataExtensions|extension data=], it MUST set the `ED` [=flag=] to zero, and to one if
     [=authDataExtensions|extension data=] is included.
 
-<a href="#fig-authData"><span class="figure-ref-following"/></a> shows a visual representation of the [=authenticator data=] structure.
+<a href="#fig-authData"><span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
 
 <figure id="fig-authData">
     <img src="images/fido-signature-formats-figure1.svg"/>
@@ -3624,7 +3624,7 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     specified in [[#sctn-authenticator-data]] including |processedExtensions|, if any, as
     the <code>[=authDataExtensions|extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.
 1. Let |signature| be the [=assertion signature=] of the concatenation <code>|authenticatorData| || |hash|</code> using the
-    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature"><span class="figure-ref-following"/></a>, below. A simple,
+    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature"><span class="figure-num-following"/></a>, below. A simple,
     undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
     client data=] (which potentially has a variable length) is always the last element.
@@ -3681,7 +3681,7 @@ Authenticators may be required to store arbitrary strings chosen by a [=[RP]=], 
 
 If string value truncation is the chosen accommodation then authenticators MAY truncate in order to make the string fit within a length equal or greater than the specified minimum supported length. Such truncation MAY also respect UTF-8 sequence boundaries or [=grapheme cluster=] boundaries [[UTR29]]. This defines the maximum truncation permitted and authenticators MUST NOT truncate further.
 
-For example, in <a href="#fig-stringTruncation"><span class="figure-ref-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
+For example, in <a href="#fig-stringTruncation"><span class="figure-num-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
 
 <figure id="fig-stringTruncation">
     <img src="images/string-truncation.svg"/>
@@ -3709,7 +3709,7 @@ MAY either perform [=self attestation=] of the [=credential public key=] with th
 or otherwise perform [=None|no attestation=]. All this
 information is returned by [=authenticators=] any time a new [=public key credential=] is generated, in the overall form of an
 <dfn>attestation object</dfn>. The relationship of the [=attestation object=] with [=authenticator data=] (containing
-[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs"><span class="figure-ref-following"/></a>, below.
+[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs"><span class="figure-num-following"/></a>, below.
 
 If an [=authenticator=] employs [=self attestation=] or [=None|no attestation=], then no provenance information is provided
 for the [=[RP]=] to base a trust decision on.

--- a/index.bs
+++ b/index.bs
@@ -92,12 +92,12 @@ figure.table .overlarge {
     max-width: 50em;
 }
 
-.figure-num-following::before {
+.figure-ref-following::before {
     counter-increment: figure;
     content: "Figure " counter(figure)
 }
 
-.figure-num-following::after {
+.figure-ref-following::after {
     counter-increment: figure -1;
     content: ""
 }
@@ -1199,7 +1199,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are [=managing authenticator|managed=] by a [=[WAA]=], with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
-browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration"><span class="figure-num-following"/></a>, below.
+browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration"><span class="figure-ref-following"/></a>, below.
 
 
 <figure id="fig-registration">
@@ -1209,7 +1209,7 @@ browser to create a new credential for future use by the [=[RP]=]. See <a href="
 
 
 Scripts can also request the user’s permission to perform
-[=authentication=] operations with an existing credential. See <a href="#fig-authentication"><span class="figure-num-following"/></a>, below.
+[=authentication=] operations with an existing credential. See <a href="#fig-authentication"><span class="figure-ref-following"/></a>, below.
 
 
 <figure id="fig-authentication">
@@ -3137,7 +3137,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 - If the authenticator does not include any [=authDataExtensions|extension data=], it MUST set the `ED` [=flag=] to zero, and to one if
     [=authDataExtensions|extension data=] is included.
 
-<a href="#fig-authData"><span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
+<a href="#fig-authData"><span class="figure-ref-following"/></a> shows a visual representation of the [=authenticator data=] structure.
 
 <figure id="fig-authData">
     <img src="images/fido-signature-formats-figure1.svg"/>
@@ -3604,7 +3604,7 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     specified in [[#sctn-authenticator-data]] including |processedExtensions|, if any, as
     the <code>[=authDataExtensions|extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.
 1. Let |signature| be the [=assertion signature=] of the concatenation <code>|authenticatorData| || |hash|</code> using the
-    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature"><span class="figure-num-following"/></a>, below. A simple,
+    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature"><span class="figure-ref-following"/></a>, below. A simple,
     undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
     client data=] (which potentially has a variable length) is always the last element.
@@ -3661,7 +3661,7 @@ Authenticators may be required to store arbitrary strings chosen by a [=[RP]=], 
 
 If string value truncation is the chosen accommodation then authenticators MAY truncate in order to make the string fit within a length equal or greater than the specified minimum supported length. Such truncation MAY also respect UTF-8 sequence boundaries or [=grapheme cluster=] boundaries [[UTR29]]. This defines the maximum truncation permitted and authenticators MUST NOT truncate further.
 
-For example, in <a href="#fig-stringTruncation"><span class="figure-num-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
+For example, in <a href="#fig-stringTruncation"><span class="figure-ref-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
 
 <figure id="fig-stringTruncation">
     <img src="images/string-truncation.svg"/>
@@ -3689,7 +3689,7 @@ MAY either perform [=self attestation=] of the [=credential public key=] with th
 or otherwise perform [=None|no attestation=]. All this
 information is returned by [=authenticators=] any time a new [=public key credential=] is generated, in the overall form of an
 <dfn>attestation object</dfn>. The relationship of the [=attestation object=] with [=authenticator data=] (containing
-[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs"><span class="figure-num-following"/></a>, below.
+[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs"><span class="figure-ref-following"/></a>, below.
 
 If an [=authenticator=] employs [=self attestation=] or [=None|no attestation=], then no provenance information is provided
 for the [=[RP]=] to base a trust decision on.

--- a/index.bs
+++ b/index.bs
@@ -94,7 +94,7 @@ figure.table .overlarge {
 
 .figure-num-following::before {
     counter-increment: figure;
-    content: "Figure " counter(figure)
+    content: counter(figure)
 }
 
 .figure-num-following::after {
@@ -1213,7 +1213,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are [=managing authenticator|managed=] by a [=[WAA]=], with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
-browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration"><span class="figure-num-following"/></a>, below.
+browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration">Figure <span class="figure-num-following"/></a>, below.
 
 
 <figure id="fig-registration">
@@ -1223,7 +1223,7 @@ browser to create a new credential for future use by the [=[RP]=]. See <a href="
 
 
 Scripts can also request the user’s permission to perform
-[=authentication=] operations with an existing credential. See <a href="#fig-authentication"><span class="figure-num-following"/></a>, below.
+[=authentication=] operations with an existing credential. See <a href="#fig-authentication">Figure <span class="figure-num-following"/></a>, below.
 
 
 <figure id="fig-authentication">
@@ -3153,7 +3153,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 - If the authenticator does not include any [=authDataExtensions|extension data=], it MUST set the `ED` [=flag=] to zero, and to one if
     [=authDataExtensions|extension data=] is included.
 
-<a href="#fig-authData"><span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
+<a href="#fig-authData">Figure <span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
 
 <figure id="fig-authData">
     <img src="images/fido-signature-formats-figure1.svg"/>
@@ -3624,7 +3624,7 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     specified in [[#sctn-authenticator-data]] including |processedExtensions|, if any, as
     the <code>[=authDataExtensions|extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.
 1. Let |signature| be the [=assertion signature=] of the concatenation <code>|authenticatorData| || |hash|</code> using the
-    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature"><span class="figure-num-following"/></a>, below. A simple,
+    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature">Figure <span class="figure-num-following"/></a>, below. A simple,
     undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
     client data=] (which potentially has a variable length) is always the last element.
@@ -3681,7 +3681,7 @@ Authenticators may be required to store arbitrary strings chosen by a [=[RP]=], 
 
 If string value truncation is the chosen accommodation then authenticators MAY truncate in order to make the string fit within a length equal or greater than the specified minimum supported length. Such truncation MAY also respect UTF-8 sequence boundaries or [=grapheme cluster=] boundaries [[UTR29]]. This defines the maximum truncation permitted and authenticators MUST NOT truncate further.
 
-For example, in <a href="#fig-stringTruncation"><span class="figure-num-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
+For example, in <a href="#fig-stringTruncation">figure <span class="figure-num-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
 
 <figure id="fig-stringTruncation">
     <img src="images/string-truncation.svg"/>
@@ -3709,7 +3709,7 @@ MAY either perform [=self attestation=] of the [=credential public key=] with th
 or otherwise perform [=None|no attestation=]. All this
 information is returned by [=authenticators=] any time a new [=public key credential=] is generated, in the overall form of an
 <dfn>attestation object</dfn>. The relationship of the [=attestation object=] with [=authenticator data=] (containing
-[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs"><span class="figure-num-following"/></a>, below.
+[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs">figure <span class="figure-num-following"/></a>, below.
 
 If an [=authenticator=] employs [=self attestation=] or [=None|no attestation=], then no provenance information is provided
 for the [=[RP]=] to base a trust decision on.

--- a/index.bs
+++ b/index.bs
@@ -86,7 +86,7 @@ figure.table figcaption {
     counter-increment: none;
 }
 figure.table figcaption:not(.no-marker)::before {
-    content: "Table " counter(table) " ";
+    content: counter(table);
 }
 figure.table .overlarge {
     max-width: 50em;
@@ -103,17 +103,17 @@ figure.table .overlarge {
 }
 
 .table-ref-previous::before {
-    content: "Table " counter(table)
+    content: counter(table);
 }
 
 .table-ref-following::before {
     counter-increment: table;
-    content: "Table " counter(table)
+    content: counter(table);
 }
 
 .table-ref-following::after {
     counter-increment: table -1;
-    content: ""
+    content: "";
 }
 </style>
 
@@ -3064,7 +3064,7 @@ The [=authenticator data=] has a compact but extensible encoding. This is desire
 limited capabilities and low power requirements, with much simpler software stacks than the [=client platform=].
 
 The [=authenticator data=] structure is a byte array of 37 bytes or more,
-laid out as shown in <a href="#table-authData"><span class="table-ref-following"/></a>.
+laid out as shown in <a href="#table-authData">Table <span class="table-ref-following"/></a>.
 
 
 <figure id="table-authData" class="table">
@@ -3232,7 +3232,7 @@ The above examples illustrate the the primary <dfn>authenticator type</dfn> char
 - Whether the authenticator is [=resident credential capable=] &mdash; the [=credential storage modality=].
 
 These characteristics are independent and may in theory be combined in any way,
-but <a href="#table-authenticatorTypes"><span class="table-ref-following"/></a>
+but <a href="#table-authenticatorTypes">Table <span class="table-ref-following"/></a>
 lists and names some [=authenticator types=] of particular interest.
 
 
@@ -3292,7 +3292,7 @@ typically a PIN or [=biometric recognition=].
 The [=authenticator=] can thus act as two kinds of [=authentication factor=],
 which enables [=multi-factor=] authentication while eliminating the need to share a password with the [=[RP]=].
 
-The four combinations not named in <a href="#table-authenticatorTypes"><span class="table-ref-previous"/></a>
+The four combinations not named in <a href="#table-authenticatorTypes">Table <span class="table-ref-previous"/></a>
 have less distinguished use cases:
 
 
@@ -3762,7 +3762,7 @@ understand the characteristics of the [=authenticators=] that they trust, based 
 ### Attested Credential Data ### {#sctn-attested-credential-data}
 
 <dfn>Attested credential data</dfn> is a variable-length byte array added to the [=authenticator data=] when generating an [=attestation
-object=] for a given credential. Its format is shown in <a href="#table-attestedCredentialData"><span class="table-ref-following"/></a>.
+object=] for a given credential. Its format is shown in <a href="#table-attestedCredentialData">Table <span class="table-ref-following"/></a>.
 
 <figure id="table-attestedCredentialData" class="table">
     <table class="complex data longlastcol">


### PR DESCRIPTION
This would merge into PR #1323.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1324.html" title="Last updated on Oct 23, 2019, 7:36 PM UTC (847ae92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1324/3f1f35a...847ae92.html" title="Last updated on Oct 23, 2019, 7:36 PM UTC (847ae92)">Diff</a>