### PR TITLE
feature policy integration: add link to "allowed to use"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2886,7 +2886,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
     :   <dfn>usb</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over removable USB.
-    
+
     :   <dfn>lightning</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over removable Lightning.
 
@@ -2949,8 +2949,8 @@ This specification defines a [=policy-controlled feature=] identified by
 the feature-identifier token "<code><dfn data-lt="publickey-credentials-feature" export>publickey-credentials</dfn></code>".
 Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
-A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is allowed
-to successfully invoke the [=Web Authentication API=], i.e., via
+A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
+[=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via
 <code><a idl for="CredentialsContainer" lt="create()">navigator.credentials.create({publicKey:..., ...})</a></code> and
 <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code>.
 If disabled in any document, no content in the document will be [=allowed to use=]
@@ -4078,18 +4078,18 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
     outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
     extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
-    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of 
+    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
     <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
     Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
     [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
-    [=client extension outputs=] that were not originally specified as part of 
-    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such 
-    situations, whether it be to ignore the unsolicited extensions or reject the attestation. The [=[RP]=] can make this 
+    [=client extension outputs=] that were not originally specified as part of
+    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
+    situations, whether it be to ignore the unsolicited extensions or reject the attestation. The [=[RP]=] can make this
     decision based on local policy and the extensions in use.
 
-    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be 
+    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be
     prepared to handle cases where none or not all of the requested extensions were acted upon.
 
 1. Determine the attestation statement format by performing a USASCII case-sensitive match on |fmt| against the set of
@@ -4230,18 +4230,18 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
     outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
     extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
-    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of 
+    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
     <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
     In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
     Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
     [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
-    [=client extension outputs=] that were not originally specified as part of 
-    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such 
-    situations, whether it be to ignore the unsolicited extensions or reject the assertion. The [=[RP]=] can make this 
+    [=client extension outputs=] that were not originally specified as part of
+    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
+    situations, whether it be to ignore the unsolicited extensions or reject the assertion. The [=[RP]=] can make this
     decision based on local policy and the extensions in use.
 
-    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be 
+    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be
     prepared to handle cases where none or not all of the requested extensions were acted upon.
 
 1. Let |hash| be the result of computing a hash over the |cData| using SHA-256.


### PR DESCRIPTION
I noticed, while explaining how this featpol stuff will work, that the featpol integration section laced a link to the magic & essential "allowed to use" alg in the happy-path sense (there's already one in the sad-path-it-didn't-work sense). this amazingly simple patch fixes this oversight. yay!  (see line 2953)

NOTE: as an added bonus, my text editor went ahead and deleted all trailing whitespace that had crept into `index.bs` since the last time we cleaned it up (it's not all that much).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1328.html" title="Last updated on Oct 18, 2019, 4:56 PM UTC (c6df5fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1328/b5c4001...c6df5fd.html" title="Last updated on Oct 18, 2019, 4:56 PM UTC (c6df5fd)">Diff</a>