### PR TITLE
Reduce duplicated terminology

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3864,13 +3864,13 @@ calling {{CredentialsContainer/create()|navigator.credentials.create()}} they se
 
 : <dfn>Basic Attestation</dfn> (<dfn>Basic</dfn>)
 :: In the case of basic attestation [[UAFProtocol]], the authenticator's [=attestation key pair=] is specific to an
-    authenticator model.  Thus, authenticators of the same model often share the same attestation key pair. See
+    authenticator model.  Thus, authenticators of the same model often share the same [=attestation key pair=]. See
     [[#sctn-attestation-privacy]] for further information.
 
 : <dfn>Self Attestation</dfn> (<dfn>Self</dfn>)
 :: In the case of [=self attestation=], also known as surrogate basic attestation [[UAFProtocol]], the Authenticator does not have
-    any specific attestation key. Instead it uses the credential private key to create the attestation signature.
-    Authenticators without meaningful protection measures for an attestation private key typically use this attestation type.
+    any specific [=attestation key pair=]. Instead it uses the [=credential private key=] to create the attestation signature.
+    Authenticators without meaningful protection measures for an [=attestation private key=] typically use this attestation type.
 
 : <dfn>Attestation CA</dfn> (<dfn>AttCA</dfn>)
 :: In this case, an [=authenticator=] is based on a Trusted Platform Module (TPM) and holds an authenticator-specific
@@ -5799,18 +5799,19 @@ SHOULD be specified in the attestation certificate itself, so that it can be ver
 ### Attestation Certificate and Attestation Certificate CA Compromise ### {#sctn-ca-compromise}
 
 When an intermediate CA or a root CA used for issuing attestation certificates is compromised, [=[WAA]=]
-attestation keys are still safe although their certificates can no longer be trusted. A [=[WAA]=] manufacturer that
-has recorded the public attestation keys for their [=authenticator=] models can issue new attestation certificates for these keys from a new
+[=attestation key pairs=] are still safe although their certificates can no longer be trusted. A [=[WAA]=] manufacturer that
+has recorded the [=attestation public keys=] for their [=authenticator=] models can issue new [=attestation certificates=] for these keys from a new
 intermediate CA or from a new root CA. If the root CA changes, the [=[WRPS]=]  MUST update their trusted root certificates
 accordingly.
 
-A [=[WAA]=] attestation certificate MUST be revoked by the issuing CA if its key has been compromised. A WebAuthn
-Authenticator manufacturer may need to ship a firmware update and inject new attestation keys and certificates into already
+A [=[WAA]=] [=attestation certificate=] MUST be revoked by the issuing CA if its [=attestation private key|private key=] has been compromised. A WebAuthn
+Authenticator manufacturer may need to ship a firmware update and inject new [=attestation private keys=]
+and [=attestation certificate|certificates=] into already
 manufactured [=[WAA]s=], if the exposure was due to a firmware flaw. (The process by which this happens is out of
 scope for this specification.) If the [=[WAA]=] manufacturer does not have this capability, then it may not be
-possible for [=[RPS]=] to trust any further attestation statements from the affected [=[WAA]s=].
+possible for [=[RPS]=] to trust any further [=attestation statements=] from the affected [=[WAA]s=].
 
-If an [=ECDAA=] attestation key has been compromised, it can be added to the RogueList (i.e., the list of revoked
+If an [=ECDAA=] [=attestation private key=] has been compromised, it can be added to the RogueList (i.e., the list of revoked
 authenticators) maintained by the related ECDAA-Issuer.
 
 See also the related security consideration for [=[RPS]=] in [[#sctn-revoked-attestation-certificates]].
@@ -5900,15 +5901,15 @@ than a [=man-in-the-middle attack=] against conventional password authentication
 
 ### Revoked Attestation Certificates ### {#sctn-revoked-attestation-certificates}
 
-If attestation certificate validation fails due to a revoked intermediate attestation CA certificate, and the [=[RP]=]'s policy
+If [=attestation certificate=] validation fails due to a revoked intermediate attestation CA certificate, and the [=[RP]=]'s policy
 requires rejecting the registration/authentication request in these situations, then it is RECOMMENDED that the [=[RP]=] also
 un-registers (or marks with a trust level equivalent to "[=self attestation=]") [=public key credentials=] that were registered
-after the CA compromise date using an attestation certificate chaining up to the same intermediate CA. It is thus RECOMMENDED
-that [=[RPS]=] remember intermediate attestation CA certificates during Authenticator registration in order to un-register
-related [=public key credentials=] if the registration was performed after revocation of such certificates.
+after the CA compromise date using an [=attestation certificate=] chaining up to the same intermediate CA. It is thus RECOMMENDED
+that [=[RPS]=] remember intermediate attestation CA certificates during [=registration=] in order to un-register
+related [=public key credentials=] if the [=registration=] was performed after revocation of such certificates.
 
-If an [=ECDAA=] attestation key has been compromised, it can be added to the RogueList (i.e., the list of revoked
-authenticators) maintained by the related ECDAA-Issuer. The [=[RP]=] SHOULD verify whether an authenticator belongs to the
+If an [=ECDAA=] [=attestation private key=] has been compromised, it can be added to the RogueList (i.e., the list of revoked
+authenticators) maintained by the related ECDAA-Issuer. The [=[RP]=] SHOULD verify whether an [=authenticator=] belongs to the
 RogueList when performing ECDAA-Verify (see section 3.6 in [[!FIDOEcdaaAlgorithm]]). For example, the FIDO Metadata Service
 [[FIDOMetadataService]] provides one way to access such information.
 
@@ -6030,22 +6031,27 @@ instead of revealing the biometric data itself to the [=[RP]=].
 
 ### Attestation Privacy ### {#sctn-attestation-privacy}
 
-Attestation keys can be used to track users or link various online identities of the same user together. This can be mitigated
-in several ways, including:
+[=Attestation certificates=] and [=attestation key pairs=] and can be used to track users
+or link various online identities of the same user together.
+This can be mitigated in several ways, including:
 
 - A [=[WAA]=] manufacturer may choose to ship [=authenticators=] in batches
-    where [=authenticators=] in a batch share the same attestation key (called [=Basic Attestation=]).
-    This will anonymize the user at the risk of not being able to revoke a particular attestation key if its private key is compromised.
+    where [=authenticators=] in a batch share the same [=attestation certificate=] (called [=Basic Attestation=]).
+    This will anonymize the user at the risk of not being able to revoke a particular [=attestation certificate=]
+    if its [=attestation private key|private key=] is compromised.
     The [=authenticator=] manufacturer SHOULD then ensure that such batches are large enough to provide meaningful anonymization,
     while also minimizing the batch size in order to limit the number of affected users
-    in case an attestation private key is compromised.
+    in case an [=attestation private key=] is compromised.
 
-    [[UAFProtocol]] requires that at least 100,000 [=authenticator=] devices share the same attestation certificate in order to produce
+    [[UAFProtocol]] requires that at least 100,000 [=authenticator=] devices share the same [=attestation certificate=] in order to produce
     sufficiently large groups. This may serve as guidance about suitable batch sizes.
 
-- A [=[WAA]=] may be capable of dynamically generating different attestation keys (and requesting related
-    certificates) per-[=origin=] (similar to the [=Attestation CA=] approach). For example, an [=authenticator=] can ship with a
-    master attestation key (and certificate), and combined with a cloud-operated <dfn>Anonymization CA</dfn>, can dynamically generate per-[=origin=] attestation keys and attestation certificates.
+- A [=[WAA]=] may be capable of dynamically generating different [=attestation key pairs=] (and requesting related
+    [=attestation certificate|certificates=]) per-[=origin=]
+    (similar to the [=Attestation CA=] approach). For example, an [=authenticator=] can ship with a
+    master [=attestation private key=] (and [=attestation certificate|certificate=]),
+    and combined with a cloud-operated <dfn>Anonymization CA</dfn>,
+    can dynamically generate per-[=origin=] [=attestation key pairs=] and [=attestation certificates=].
 
     Note: In various places outside this specification, the term "Privacy CA" is used to refer to what is termed here
         as an [=Anonymization CA=]. Because the Trusted Computing Group (TCG) also used the term "Privacy CA" to refer to what

--- a/index.bs
+++ b/index.bs
@@ -457,7 +457,7 @@ In this flow, the [=[WRP]=] does not have a preference for [=platform authentica
 
 1. The [=client=] connects to the authenticator, performing any pairing actions if necessary.
 
-1. The authenticator shows appropriate UI for the user to provide a biometric or other authorization gesture.
+1. The authenticator shows appropriate UI for the user to provide a biometric or other [=authorization gesture=].
 
 1. The authenticator returns a response to the [=client=], which in turn returns a response to the [=[RP]=] script. If
     the user declined to select an authenticator or provide authorization, an appropriate error is returned.
@@ -587,7 +587,7 @@ credential.
     notification, the user is shown a friendly selection menu of acceptable credentials using the account information provided
     when creating the credentials, along with some information on the [=origin=] that is requesting these keys.
 
-1. The authenticator obtains a biometric or other authorization gesture from the user.
+1. The authenticator obtains a biometric or other [=authorization gesture=] from the user.
 
 1. The authenticator returns a response to the [=client=], which in turn returns a response to the [=[RP]=] script.
     If the user declined to select a credential or provide an authorization, an appropriate error is returned.

--- a/index.bs
+++ b/index.bs
@@ -2701,7 +2701,7 @@ The [=public key credential=] type uses certain data structures that are specifi
 follows.
 
 
-### Client Data Used in WebAuthn Signatures (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#dictionary-client-data}
+### Client Data Used in [=WebAuthn Signatures=] (dictionary <dfn dictionary>CollectedClientData</dfn>) ### {#dictionary-client-data}
 
 The <dfn>client data</dfn> represents the contextual bindings of both the [=[WRP]=] and the [=client=]. It is a key-value
 mapping whose keys are strings. Values can be any type that has a valid encoding in JSON. Its structure is defined by the
@@ -2964,7 +2964,7 @@ made by that manufacturer, and different (with high probability) from the AAGUID
 The AAGUID for a given type of authenticator SHOULD be randomly generated to ensure this. The [=[RP]=] MAY use the AAGUID to infer certain
 properties of the authenticator, such as certification level and strength of key protection, using information from other sources.
 
-The primary function of the authenticator is to provide WebAuthn signatures, which are bound to various contextual data. These
+The primary function of the authenticator is to provide [=WebAuthn signatures=], which are bound to various contextual data. These
 data are observed and added at different levels of the stack as a signature request passes from the server to the
 authenticator. In verifying a signature, the server checks these bindings against expected values. These contextual bindings
 are divided in two: Those added by the [=[RP]=] or the client, referred to as [=client data=]; and those added by the authenticator,
@@ -3001,6 +3001,7 @@ Authenticators produce cryptographic signatures for two distinct purposes:
     provided, and the prompt shown to the user by the [=authenticator=]. The [=assertion signature=] format is illustrated in
     [Figure 4, below](#fig-signature).
 
+The term <dfn>WebAuthn signature</dfn> refers to both [=attestation signatures=] and [=assertion signatures=].
 The formats of these signatures, as well as the procedures for generating them, are specified below.
 
 ## Authenticator Data ## {#sctn-authenticator-data}

--- a/index.bs
+++ b/index.bs
@@ -842,7 +842,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Authentication</dfn>
 : <dfn>Authentication Ceremony</dfn>
 :: The [=ceremony=] where a user, and the user's [=client=] (containing at least one [=authenticator=]) work in
-    concert to cryptographically prove to a [=[RP]=] that the user controls the [=credential private key=] associated with a
+    concert to cryptographically prove to a [=[RP]=] that the user controls the [=credential private key=] of a
     previously-registered [=public key credential=] (see [=Registration=]). Note that this includes a [=test of user presence=] or
     [=user verification=].
 

--- a/index.bs
+++ b/index.bs
@@ -3871,7 +3871,7 @@ calling {{CredentialsContainer/create()|navigator.credentials.create()}} they se
 
 : <dfn>Self Attestation</dfn> (<dfn>Self</dfn>)
 :: In the case of [=self attestation=], also known as surrogate basic attestation [[UAFProtocol]], the Authenticator does not have
-    any specific [=attestation key pair=]. Instead it uses the [=credential private key=] to create the attestation signature.
+    any specific [=attestation key pair=]. Instead it uses the [=credential private key=] to create the [=attestation signature=].
     Authenticators without meaningful protection measures for an [=attestation private key=] typically use this attestation type.
 
 : <dfn>Attestation CA</dfn> (<dfn>AttCA</dfn>)
@@ -4276,10 +4276,10 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
     The semantics of the fields are as follows:
 
     : alg
-    :: A {{COSEAlgorithmIdentifier}} containing the identifier of the algorithm used to generate the attestation signature.
+    :: A {{COSEAlgorithmIdentifier}} containing the identifier of the algorithm used to generate the [=attestation signature=].
 
     : sig
-    :: A byte string containing the attestation signature.
+    :: A byte string containing the [=attestation signature=].
 
     : x5c
     :: The elements of this array contain |attestnCert| and its certificate chain, each encoded in X.509 format. The attestation
@@ -4426,7 +4426,7 @@ engine.
     :: The version of the TPM specification to which the signature conforms.
 
     : alg
-    :: A {{COSEAlgorithmIdentifier}} containing the identifier of the algorithm used to generate the attestation signature.
+    :: A {{COSEAlgorithmIdentifier}} containing the identifier of the algorithm used to generate the [=attestation signature=].
 
     : x5c
     :: |aikCert| followed by its certificate chain, in X.509 encoding.
@@ -4440,7 +4440,7 @@ engine.
         step 3.5 in [[!FIDOEcdaaAlgorithm]].
 
     : sig
-    :: The attestation signature, in the form of a TPMT_SIGNATURE structure as specified in [[!TPMv2-Part2]] section 11.3.4.
+    :: The [=attestation signature=], in the form of a TPMT_SIGNATURE structure as specified in [[!TPMv2-Part2]] section 11.3.4.
 
     : certInfo
     :: The TPMS_ATTEST structure over which the above signature was computed, as specified in [[!TPMv2-Part2]] section 10.12.8.
@@ -6062,8 +6062,8 @@ This can be mitigated in several ways, including:
         confusion in the specific context of this specification.
 
 - A [=[WAA]=] can implement [=Elliptic Curve based direct anonymous attestation=] (see [[FIDOEcdaaAlgorithm]]).
-    Using this scheme, the authenticator generates a blinded attestation signature. This allows the [=[WRP]=] to verify the
-    signature using the [=ECDAA-Issuer public key=], but the attestation signature does not serve as a global correlation handle.
+    Using this scheme, the authenticator generates a blinded [=attestation signature=]. This allows the [=[WRP]=] to verify the
+    signature using the [=ECDAA-Issuer public key=], but the [=attestation signature=] does not serve as a global correlation handle.
 
 
 ### Privacy of [PII] Stored in Authenticators ### {#sctn-pii-privacy}

--- a/index.bs
+++ b/index.bs
@@ -822,9 +822,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Terminology # {#sctn-terminology}
 
-: <dfn>Assertion</dfn>
-:: See [=Authentication Assertion=].
-
 : <dfn>Attestation</dfn>
 :: Generally, <em>attestation</em> is a statement serving to bear witness, confirm, or authenticate.
     In the WebAuthn context, [=attestation=] is employed to <em>attest</em> to the <em>provenance</em> of an [=authenticator=]
@@ -850,6 +847,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [=user verification=].
 
 : <dfn>Authentication Assertion</dfn>
+: <dfn>Assertion</dfn>
 :: The cryptographically signed {{AuthenticatorAssertionResponse}} object returned by an [=authenticator=] as the result of an
     [=authenticatorGetAssertion=] operation.
 

--- a/index.bs
+++ b/index.bs
@@ -595,7 +595,7 @@ credential.
 1. If an assertion was successfully generated and returned,
     - The script sends the assertion to the server.
     - The server examines the assertion, extracts the [=credential ID=], looks up the registered
-        credential public key in its database, and verifies the assertion's authentication signature.
+        credential public key in its database, and verifies the [=assertion signature=].
         If valid, it looks up the identity associated with the assertion's [=credential ID=]; that
         identity is now authenticated. If the [=credential ID=] is not recognized by the server (e.g.,
         it has been deregistered due to inactivity) then the authentication has failed; each [=[RP]=]
@@ -3099,7 +3099,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
     then the authenticator will set both the `UP` [=flag=] and the `UV` [=flag=].
 
 - For [=attestation signatures=], the authenticator MUST set the AT [=flag=] and include the <code>[=attestedCredentialData=]</code>.
-    For [=assertion signature|authentication signatures=], the AT [=flag=] MUST NOT be set and the <code>[=attestedCredentialData=]</code> MUST NOT be included.
+    For [=assertion signatures=], the AT [=flag=] MUST NOT be set and the <code>[=attestedCredentialData=]</code> MUST NOT be included.
 
 - If the authenticator does not include any [=authDataExtensions|extension data=], it MUST set the `ED` [=flag=] to zero, and to one if
     [=authDataExtensions|extension data=] is included.

--- a/index.bs
+++ b/index.bs
@@ -4697,7 +4697,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
         received by the [=client=] from the authenticator.
 
 : Signing procedure
-:: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
+:: If the [=credential public key=] of the [=attestedCredentialData|attested credential=] is not of algorithm -7 ("ES256"), stop and return an error.
     Otherwise, let |authenticatorData| denote the [=authenticator data for the attestation=],
     and let |clientDataHash| denote the [=hash of the serialized client data=]. (Since SHA-256 is used to hash the
     serialized [=client data=], |clientDataHash| will be 32 bytes long.)

--- a/index.bs
+++ b/index.bs
@@ -4520,7 +4520,7 @@ TPM [=attestation certificate=] MUST have the following fields/extensions:
 
 ## Android Key Attestation Statement Format ## {#sctn-android-key-attestation}
 
-When the [=authenticator=] in question is a platform-provided Authenticator on the Android "N" or later platform, the
+When the [=authenticator=] in question is a [=platform authenticator=] on the Android "N" or later platform, the
 attestation statement is based on the [Android key
 attestation](https://source.android.com/security/keystore/attestation). In these cases, the attestation statement
 is produced by a component running in a secure operating environment, but the [=authenticator data for the attestation=] is
@@ -4596,7 +4596,7 @@ data</dfn> is identified by the OID "1.3.6.1.4.1.11129.2.1.17", and its schema i
 
 ## Android SafetyNet Attestation Statement Format ## {#sctn-android-safetynet-attestation}
 
-When the [=authenticator=] is platform-provided by certain Android platforms, the attestation
+When the [=authenticator=] is a [=platform authenticator=] on certain Android platforms, the attestation
 statement may be based on the [SafetyNet API](https://developer.android.com/training/safetynet/attestation#compat-check-response). In
 this case the [=authenticator data=] is completely controlled by the caller of the SafetyNet API (typically an application
 running on the Android platform) and the attestation statement  provides some statements about the health of the platform
@@ -5660,12 +5660,12 @@ IANA "WebAuthn Attestation Statement Format Identifier" registry established by 
 - Specification Document: Section [[#sctn-tpm-attestation]] of this specification
     <br/><br/>
 - WebAuthn Attestation Statement Format Identifier: android-key
-- Description: Platform-provided authenticators based on versions "N", and later, may provide this proprietary "hardware
+- Description: [=Platform authenticators=] on versions "N", and later, may provide this proprietary "hardware
     attestation" statement.
 - Specification Document: Section [[#sctn-android-key-attestation]] of this specification
     <br/><br/>
 - WebAuthn Attestation Statement Format Identifier: android-safetynet
-- Description: Android-based, platform-provided authenticators MAY produce an attestation statement based on the Android
+- Description: Android-based [=platform authenticators=] MAY produce an attestation statement based on the Android
     SafetyNet API.
 - Specification Document: Section [[#sctn-android-safetynet-attestation]] of this specification
     <br/><br/>

--- a/index.bs
+++ b/index.bs
@@ -3080,7 +3080,7 @@ The [=authenticator data=] structure is a byte array of 37 bytes or more, laid o
 </figure>
 
 The [=RP ID=] is originally received from the [=client=] when the credential is created, and again when an [=assertion=] is generated.
-However, it differs from other [=client data=] in some important ways. First, unlike the client data, the [=RP ID=] of a
+However, it differs from other [=client data=] in some important ways. First, unlike the [=client data=], the [=RP ID=] of a
 credential does not change between operations but instead remains the same for the lifetime of that credential. Secondly, it is
 validated by the authenticator during the [=authenticatorGetAssertion=] operation, by verifying that the [=RP ID=] that
 the requested [=public key credential|credential=] is [=scoped=] to exactly matches the [=RP ID=] supplied by the [=client=].
@@ -4700,7 +4700,7 @@ This attestation statement format is used with FIDO U2F authenticators using the
 :: If the credential public key of the given credential is not of algorithm -7 ("ES256"), stop and return an error.
     Otherwise, let |authenticatorData| denote the [=authenticator data for the attestation=],
     and let |clientDataHash| denote the [=hash of the serialized client data=]. (Since SHA-256 is used to hash the
-    serialized client data, |clientDataHash| will be 32 bytes long.)
+    serialized [=client data=], |clientDataHash| will be 32 bytes long.)
 
     Generate a Registration Response Message as specified in [[!FIDO-U2F-Message-Formats]] [=Section 4.3=], with the application parameter set to the
     SHA-256 hash of the [=RP ID=] that the given [=public key credential|credential=] is [=scoped=] to, the challenge parameter set to |clientDataHash|, and the key handle

--- a/index.bs
+++ b/index.bs
@@ -1891,7 +1891,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         :   If |issuedRequests| is empty, <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty, and no |authenticator| will become available for any [=public key credentials=] therein,
         ::  Indicate to the user that no eligible credential could be found. When the user acknowledges the dialog, return a {{DOMException}} whose name is "{{NotAllowedError}}".
 
-            Note: One way a [=client platform=] can determine that no |authenticator| will become available is by examining the <code>{{transports}}</code> members of the present <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>, if any. For example, if all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] list only <code>{{AuthenticatorTransport/internal}}</code>, but all internal |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] may list <code>{{transports}}</code> that the [=client platform=] does not support.
+            Note: One way a [=client platform=] can determine that no |authenticator| will become available is by examining the <code>{{transports}}</code> members of the present <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>, if any. For example, if all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] list only <code>{{AuthenticatorTransport/internal}}</code>, but all [=platform authenticator|platform=] |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] may list <code>{{transports}}</code> that the [=client platform=] does not support.
 
         :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
@@ -2852,8 +2852,9 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     ::  Indicates the respective [=authenticator=] can be contacted over Bluetooth Smart (Bluetooth Low Energy / BLE).
 
     :   <dfn>internal</dfn>
-    ::  Indicates the respective [=authenticator=] is contacted using a [=client device=]-specific transport. These authenticators are not
-        removable from the [=client device=].
+    ::  Indicates the respective [=authenticator=] is contacted using a [=client device=]-specific transport,
+        i.e., it is a [=platform authenticator=].
+        These authenticators are not removable from the [=client device=].
 </div>
 
 


### PR DESCRIPTION
Fixes some of #358:

>- [x] [Authentication Assertion](https://www.w3.org/TR/webauthn/#authentication-assertion)      
>    - [x] [Assertion](https://www.w3.org/TR/webauthn/#assertion)
>- [x] attestation key pair    
>    - [x]  attestation key(s)
>    - [x]  public attestation keys
>- [x]  authenticator (these terms are the union of ones appearing in the spec and also used in various discussions):
>    - [x]  [platform authenticator](https://www.w3.org/TR/webauthn/#platform-authenticators)
>    - [x]  platform-provided authenticator
>    - [x]  internal authenticator
>    - [ ]  others?
>    - [x]  [roaming authenticator](https://www.w3.org/TR/webauthn/#roaming-authenticators)
>    - [ ]  others?
>- [x]  public key 
>    - [x]  credential public key (the term we are using as this time (see #79))
>    - [x]  public key of the credential
>- [x]  private key
>    - [x]  credential private key (the term we are using as this time (see #79))
>    - [x]  private key associated with the credential
>    - [x]  private key of the selected credential
>- [x]  signature
>    - [x]  webauthn signature
>    - [x]  assertion signature
>    - [x]  authentication signature
>- [x]  user verification
>    - [x]  obtains a biometric or other authorization gesture from the user (should be "verifies the user"?)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1334.html" title="Last updated on Oct 23, 2019, 8:11 PM UTC (36c5574)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1334/fc62216...36c5574.html" title="Last updated on Oct 23, 2019, 8:11 PM UTC (36c5574)">Diff</a>