### PR TITLE
name the protocol

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -322,7 +322,8 @@ Beyond that, the intended audiences for this document are the following main gro
 
 <div class="note">
     Note: Along with the [[#sctn-api|Web Authentication API]] itself, this specification defines a
-    request-response <em>cryptographic protocol</em>
+    request-response <em>cryptographic protocol</em>&mdash;the
+    <dfn export>WebAuthn/FIDO2 protocol</dfn>&mdash;
     between a [=[WRP]=] server and an [=authenticator=], where the [=[RP]=]'s request consists of a
     [[#sctn-cryptographic-challenges|challenge]] and other
     input data supplied by the [=[RP]=] and sent to the [=authenticator=].

--- a/index.bs
+++ b/index.bs
@@ -323,8 +323,8 @@ Beyond that, the intended audiences for this document are the following main gro
 <div class="note">
     Note: Along with the [[#sctn-api|Web Authentication API]] itself, this specification defines a
     request-response <em>cryptographic protocol</em>&mdash;the
-    <dfn export>WebAuthn/FIDO2 protocol</dfn>&mdash;
-    between a [=[WRP]=] server and an [=authenticator=], where the [=[RP]=]'s request consists of a
+    <dfn export>WebAuthn/FIDO2 protocol</dfn>&mdash;between
+    a [=[WRP]=] server and an [=authenticator=], where the [=[RP]=]'s request consists of a
     [[#sctn-cryptographic-challenges|challenge]] and other
     input data supplied by the [=[RP]=] and sent to the [=authenticator=].
     The request is conveyed via the


### PR DESCRIPTION
we note in the webauthn spec that the spec defines a protocol as well as an API, but do not name the  protocol. How about the "WebAuthn/FIDO2 protocol" ?

[this name is used in text I'm proposing in my review of PR #1332]


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1335.html" title="Last updated on Oct 24, 2019, 11:31 PM UTC (a3991a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1335/5dbea68...a3991a4.html" title="Last updated on Oct 24, 2019, 11:31 PM UTC (a3991a4)">Diff</a>