### PR TITLE
Fix #1285 - Remove icons from PublicKeyCredentialEntity

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -517,7 +517,6 @@ The sample code for generating and registering a new key follows:
         id: Uint8Array.from(window.atob("MIIBkzCCATigAwIBAjCCAZMwggE4oAMCAQIwggGTMII="), c=>c.charCodeAt(0)),
         name: "alex.p.mueller@example.com",
         displayName: "Alex P. Müller",
-        icon: "https://pics.example.com/00/p/aBjjjpqPb.png"
       },
 
       // This Relying Party will accept either an ES256 or RS256 credential, but
@@ -2381,7 +2380,6 @@ associated with or [=scoped=] to, respectively.
 <xmp class="idl">
     dictionary PublicKeyCredentialEntity {
         required DOMString    name;
-        USVString             icon;
     };
 </xmp>
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialEntity">
@@ -2420,13 +2418,6 @@ associated with or [=scoped=] to, respectively.
 
         [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialEntity/name}} member's
         value. Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value so that it fits within 64 bytes. See [[#sctn-strings]] about truncation and other considerations.
-
-    :   <dfn>icon</dfn>
-    ::  A [=URL serializer|serialized=] URL which resolves to an image associated with the entity. For example, this could be
-        a user's avatar or a [=[RP]=]'s logo. This URL MUST be an [=a priori authenticated URL=]. [=Authenticators=] MUST
-        accept and store a 128-byte minimum length for an icon member's value.
-        Authenticators MAY ignore an icon member's value if its length is greater than 128 bytes.
-        The URL's scheme MAY be "data" to avoid fetches of the URL, at the cost of needing more storage.
 </div>
 
 
@@ -3683,7 +3674,7 @@ or [=authenticatorGetAssertion=] operation currently in progress.
 
 ## String Handling ## {#sctn-strings}
 
-Authenticators may be required to store arbitrary strings chosen by a [=[RP]=], for example the {{PublicKeyCredentialEntity/name}}, {{PublicKeyCredentialUserEntity/displayName}}, and {{PublicKeyCredentialEntity/icon}} members in a {{PublicKeyCredentialUserEntity}}. Each will have some accommodation for the potentially limited resources available to an [=authenticator=].
+Authenticators may be required to store arbitrary strings chosen by a [=[RP]=], for example the {{PublicKeyCredentialEntity/name}} and {{PublicKeyCredentialUserEntity/displayName}} in a {{PublicKeyCredentialUserEntity}}. Each will have some accommodation for the potentially limited resources available to an [=authenticator=].
 
 If string value truncation is the chosen accommodation then authenticators MAY truncate in order to make the string fit within a length equal or greater than the specified minimum supported length. Such truncation MAY also respect UTF-8 sequence boundaries or [=grapheme cluster=] boundaries [[UTR29]]. This defines the maximum truncation permitted and authenticators MUST NOT truncate further.
 


### PR DESCRIPTION
As discussed in issue #1285, the image URL fields for PublicKeyCredentialEntity,
while intended for user interface design, are potent correlation mechanisms if
they are downloaded by RPs. RPs would have to take extraordinary care, beyond
reasonable measures, to avoid uses by RPs with mal-intent to cross-correlate
accounts. It is better for User Agents to use existing origin/icon mechanisms for
their UX designs, or to define new such mechanisms as-needed, that are
origin-wide rather than provide the possibility to embed detailed tracking
information into these URLs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jcjones/webauthn/pull/1337.html" title="Last updated on Oct 30, 2019, 7:52 PM UTC (dbcf596)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1337/03f8406...jcjones:dbcf596.html" title="Last updated on Oct 30, 2019, 7:52 PM UTC (dbcf596)">Diff</a>