### PR TITLE
reverting and restoring automation section et al...

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,7 @@ Former Editor: Angelo Liao, w3cid 94342, Microsoft, huliao@microsoft.com
 !Contributors: <a href="mailto:cbrand@google.com">Christiaan Brand</a> (Google)
 !Contributors: <a href="mailto:agl@google.com">Adam Langley</a> (Google)
 !Contributors: <a href="mailto:mandyam@qti.qualcomm.com">Giridhar Mandyam</a> (Qualcomm)
+!Contributors: <a href="mailto:nsatragno@google.com">Nina Satragno</a> (Google)
 !Contributors: <a href="mailto:sweeden@au1.ibm.com">Shane Weeden</a> (IBM)
 !Contributors: <a href="mailto:mkwst@google.com">Mike West</a> (Google)
 !Contributors: <a href="mailto:jyasskin@google.com">Jeffrey Yasskin</a> (Google)
@@ -137,6 +138,7 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
         url: sec-object-internal-methods-and-internal-slots
             text: internal method
             text: internal slot
+        text: own property; url: sec-own-property
 
 spec: RFC8152; urlPrefix: https://tools.ietf.org/html/rfc8152
     type: dfn
@@ -254,6 +256,22 @@ spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
 spec: webidl; urlPrefix: https://heycam.github.io/webidl
     type: dfn;
         text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-reference
+
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
+    type: dfn
+        text: WebDriver error; url: dfn-error
+        text: WebDriver error code; url: dfn-error-code
+        text: extension command; url: dfn-extension-command
+        text: extension command name; url: dfn-extension-command-name
+        text: getting a property; url: dfn-getting-properties
+        text: set a property; url: dfn-set-a-property
+        text: prefix; url: dfn-url-prefix
+        text: invalid argument; url: dfn-invalid-argument
+        text: local end; url: dfn-local-end
+        text: remote end steps; url: dfn-remote-end-steps
+        text: session; url: dfn-session
+        text: success; url: dfn-success
+        text: trying; url: dfn-try
 
 spec: UTR29
     urlPrefix: https://unicode.org/reports/tr29/
@@ -1202,6 +1220,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: The entity whose <dfn>web application</dfn> utilizes the [[#sctn-api|Web Authentication API]] to [=registration|register=] and
     [=authentication|authenticate=] users.
 
+    A [=[RP]=] implementation typically consists of both some client-side script
+    that invokes the [=Web Authentication API=] in the [=client=],
+    and a server-side component that executes the [[#sctn-rp-operations|[RP] operations]] and other application logic.
+    Communication between the two components MUST use HTTPS or equivalent transport security,
+    but is otherwise beyond the scope of this specification.
+
         Note: While the term [=[RP]=] is also often used in other contexts (e.g., X.509 and OAuth), an entity acting as a [=[RP]=] in one
         context is not necessarily a [=[RP]=] in other contexts. In this specification, the term [=[WRP]=] is often shortened
         to be just [=[RP]=], and explicitly refers to a [=[RP]=] in the WebAuthn context. Note that in any concrete instantiation
@@ -1413,8 +1437,17 @@ When this method is invoked, the user agent MUST execute the following algorithm
     |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present|not
     present=], then set |lifetimeTimer| to a [=client=]-specific default.
 
-        Note: A suggested reasonable range for the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is
-        15 seconds to 120 seconds.
+        Recommended ranges and defaults for the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| are as follows.
+          If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
+            <dl class="switch">
+                :   is set to {{UserVerificationRequirement/discouraged}}
+                ::  Recommended range: 30000 milliseconds to 180000 milliseconds.
+                ::  Recommended default value: 120000 milliseconds (2 minutes).
+
+                :   is set to {{UserVerificationRequirement/required}} or {{UserVerificationRequirement/preferred}}
+                ::  Recommended range: 30000 milliseconds to 600000 milliseconds.
+                ::  Recommended default value: 300000 milliseconds (5 minutes).
+            </dl>
 
         Note: The user agent should take cognitive guidelines into considerations regarding timeout for users with special needs.
 
@@ -1839,8 +1872,17 @@ When this method is invoked, the user agent MUST execute the following algorithm
     Set a timer |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialRequestOptions/timeout}} member of
     |options| is [=present|not present=], then set |lifetimeTimer| to a [=client=]-specific default.
 
-        Note: A suggested reasonable range for the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is
-        15 seconds to 120 seconds.
+        Recommended ranges and defaults for the {{PublicKeyCredentialRequestOptions/timeout}} member of |options| are as follows.
+          If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
+            <dl class="switch">
+                :   is set to {{UserVerificationRequirement/discouraged}}
+                ::  Recommended range: 30000 milliseconds to 180000 milliseconds.
+                ::  Recommended default value: 120000 milliseconds (2 minutes).
+
+                :   is set to {{UserVerificationRequirement/required}} or {{UserVerificationRequirement/preferred}}
+                ::  Recommended range: 30000 milliseconds to 600000 milliseconds.
+                ::  Recommended default value: 300000 milliseconds (5 minutes).
+            </dl>
 
         Note: The user agent should take cognitive guidelines into considerations regarding timeout for users with special needs.
 
@@ -2856,6 +2898,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     :   <dfn>transports</dfn>
     ::  This OPTIONAL member contains a hint as to how the [=client=] might communicate with the [=managing authenticator=] of the
         [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values.
+        The {{AuthenticatorAttestationResponse/getTransports()}} operation can provide suitable values for this member.
 </div>
 
 
@@ -4040,12 +4083,20 @@ structures.
 
 ## Registering a New Credential ## {#sctn-registering-a-new-credential}
 
-When registering a new credential, represented by an {{AuthenticatorAttestationResponse}} structure |response| and an
-{{AuthenticationExtensionsClientOutputs}} structure |clientExtensionResults|, as part of a [=registration ceremony=], a
-[=[RP]=] MUST proceed as follows:
+In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as follows:
 
-1. Let |options| be the {{PublicKeyCredentialCreationOptions}} that was passed
-    as the <code>{{CredentialCreationOptions/publicKey}}</code> option in the {{CredentialsContainer/create()}} call.
+1. Let |options| be a new {{PublicKeyCredentialCreationOptions}} structure configured to the [=[RP]=]'s needs for the ceremony.
+
+1. Call {{CredentialsContainer/create()|navigator.credentials.create()}} and pass |options|
+    as the <code>{{CredentialCreationOptions/publicKey}}</code> option.
+    Let |credential| be the result of the successfully resolved promise.
+    If the promise is rejected, abort the ceremony with a user-visible error.
+
+1. Let |response| be <code>|credential|.{{PublicKeyCredential/response}}</code>.
+    If |response| is not an instance of {{AuthenticatorAttestationResponse}}, abort the ceremony with a user-visible error.
+
+1. Let |clientExtensionResults| be the result of calling
+    <code>|credential|.{{PublicKeyCredential/getClientExtensionResults()}}</code>.
 
 1. Let |JSONtext| be the result of
     running [=UTF-8 decode=] on the value of <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code>.
@@ -4118,12 +4169,12 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
     example, the FIDO Metadata Service [[FIDOMetadataService]] provides one way to obtain such information, using the
     <code>[=aaguid=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|.
 
-1. Assess the attestation trustworthiness using the outputs of the [=verification procedure=] in step 16, as follows:
+1. Assess the attestation trustworthiness using the outputs of the [=verification procedure=] in step 19, as follows:
         - If [=None|no attestation=] was provided, verify that [=None=] attestation is acceptable under [=[RP]=] policy.
         - If [=self attestation=] was used, verify that [=self attestation=] is acceptable under [=[RP]=] policy.
         - If [=ECDAA=] was used, verify that the [=identifier of the ECDAA-Issuer public key=],
              returned as the [=attestation trust path=] from the [=verification procedure=],
-             is included in the set of acceptable trust anchors obtained in step 17.
+             is included in the set of acceptable trust anchors obtained in step 20.
         - Otherwise, use the X.509 certificates returned as the [=attestation trust path=] from the [=verification procedure=]
             to verify that the attestation public key correctly chains up to an acceptable root certificate.
 
@@ -4139,7 +4190,15 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
     - Associate the <code>[=credentialId=]</code> with a new stored [=signature counter=] value
         initialized to the value of <code>|authData|.[=signCount=]</code>.
 
-1. If the attestation statement |attStmt| successfully verified but is not trustworthy per step 18 above, the [=[RP]=] SHOULD fail
+    It is RECOMMENDED to also:
+
+    - Associate the <code>[=credentialId=]</code> with the transport hints
+        returned by calling <code>|credential|.{{AuthenticatorAttestationResponse/getTransports()}}</code>.
+        It is RECOMMENDED to use these to populate the {{PublicKeyCredentialDescriptor/transports}}
+        of the {{PublicKeyCredentialRequestOptions/allowCredentials}} option in future {{CredentialsContainer/get()}} calls
+        to help the [=client=] know how to find a suitable [=authenticator=].
+
+1. If the attestation statement |attStmt| successfully verified but is not trustworthy per step 21 above, the [=[RP]=] SHOULD fail
     the [=registration ceremony=].
 
     NOTE: However, if permitted by policy, the [=[RP]=] MAY register the [=credential ID=] and credential public key but treat the
@@ -4148,18 +4207,26 @@ When registering a new credential, represented by an {{AuthenticatorAttestationR
         See [[FIDOSecRef]] and [[UAFProtocol]] for a more detailed discussion.
 
 Verification of [=attestation objects=] requires that the [=[RP]=] has a trusted method of determining acceptable trust anchors
-in step 17 above. Also, if certificates are being used, the [=[RP]=] MUST have access to certificate status information for the
+in step 20 above. Also, if certificates are being used, the [=[RP]=] MUST have access to certificate status information for the
 intermediate CA certificates. The [=[RP]=] MUST also be able to build the attestation certificate chain if the client did not
 provide this chain in the attestation information.
 
 
 ## Verifying an Authentication Assertion ## {#sctn-verifying-assertion}
 
-When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {{AuthenticationExtensionsClientOutputs}} structure
-|clientExtensionResults|, as part of an [=authentication ceremony=], the [=[RP]=] MUST proceed as follows:
+In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as follows:
 
-1. Let |options| be the {{PublicKeyCredentialRequestOptions}} that was passed
-    as the <code>{{CredentialCreationOptions/publicKey}}</code> option in the {{CredentialsContainer/get()}} call.
+1. Let |options| be a new {{PublicKeyCredentialRequestOptions}} structure configured to the [=[RP]=]'s needs for the ceremony.
+
+1. Call {{CredentialsContainer/get()|navigator.credentials.get()}} and pass |options|
+    as the <code>{{CredentialRequestOptions/publicKey}}</code> option.
+    Let |credential| be the result of the successfully resolved promise.
+    If the promise is rejected, abort the ceremony with a user-visible error.
+
+1. Let |response| be <code>|credential|.{{PublicKeyCredential/response}}</code>.
+    If |response| is not an instance of {{AuthenticatorAssertionResponse}}, abort the ceremony with a user-visible error.
+
+1. Let |clientExtensionResults| be the result of calling <code>|credential|.{{PublicKeyCredential/getClientExtensionResults()}}</code>.
 
 1. If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> [=list/is not empty=],
     verify that <code>|credential|.{{Credential/id}}</code> identifies one of the [=public key credentials=]
@@ -4171,11 +4238,11 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
     <dl class="switch">
         :  If the user was identified before the [=authentication ceremony=] was initiated, e.g., via a username or cookie,
         :: verify that the identified user is the owner of |credentialSource|. If
-            <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
+            <code>|response|.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
             let |userHandle| be its value. Verify that |userHandle| also maps to the same user.
 
         :  If the user was not identified before the [=authentication ceremony=] was initiated,
-        :: verify that <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAssertionResponse/userHandle}}</code> is
+        :: verify that <code>|response|.{{AuthenticatorAssertionResponse/userHandle}}</code> is
             present, and that the user identified by this value is the owner of |credentialSource|.
     </dl>
 
@@ -4183,7 +4250,7 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {
     [=base64url encoding=] is inappropriate for your use case), look up the corresponding [=credential public key=]
     and let |credentialPublicKey| be that [=credential public key=].
 
-1. Let |cData|, |authData| and |sig| denote the value of |credential|'s {{PublicKeyCredential/response}}'s
+1. Let |cData|, |authData| and |sig| denote the value of |response|'s
     {{AuthenticatorResponse/clientDataJSON}}, {{AuthenticatorAssertionResponse/authenticatorData}}, and
     {{AuthenticatorAssertionResponse/signature}} respectively.
 
@@ -4888,7 +4955,7 @@ operation. Likewise, clients can choose to produce a [=client extension output=]
 understand by encoding the [=authenticator extension output=] value into JSON, provided that the CBOR output uses only types
 present in JSON.
 
-When clients choose to pass through extensions they do not recognize,
+When [=clients=] choose to pass through extensions they do not recognize,
 the JavaScript values in the [=client extension inputs=]
 are converted to [=CBOR=] values in the [=authenticator extension inputs=].
 When the JavaScript value is an [=%ArrayBuffer%=], it is converted to a [=CBOR=] byte array.
@@ -4898,6 +4965,13 @@ using the rules defined in Section 4.2 of [[!RFC7049]] (Converting from JSON to 
 but operating on inputs of JavaScript type values rather than inputs of JSON type values.
 Once these conversions are done,
 canonicalization of the resulting [=CBOR=] MUST be performed using the [=CTAP2 canonical CBOR encoding form=].
+
+Note that the JavaScript numeric conversion rules have the consequence that
+when a client passes through an extension it does not recognize,
+if the extension uses floating point values,
+[=authenticators=] need to be prepared to receive those values as [=CBOR=] integers,
+should the [=authenticator=] want the extension to always work without actual [=client=] support for it.
+This will happen when the floating point values used happen to be integers.
 
 Likewise, when clients receive outputs from extensions they have passed through that they do not recognize,
 the [=CBOR=] values in the [=authenticator extension outputs=]
@@ -5704,6 +5778,415 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 :: None.
 
 
+# User Agent Automation # {#sctn-automation}
+
+For the purposes of user agent automation and [=web application=] testing, this document defines a number of [[WebDriver]] [=extension commands=].
+
+## <dfn>Virtual Authenticators</dfn> ## {#sctn-automation-virtual-authenticators}
+
+These WebDriver [=extension commands=] create and interact with [=Virtual Authenticators=]: software implementations of the
+<a>Authenticator Model</a>. <a>Virtual Authenticators</a> are stored in a <dfn>Virtual Authenticator Database</dfn>.
+Each stored [=virtual authenticator=] has the following properties:
+
+: <dfn>authenticatorId</dfn>
+:: An non-null string made using up to 48 characters from the `unreserved` production defined in Appendix A of [[RFC3986]]
+    that uniquely identifies the [=Virtual Authenticator=].
+: |protocol|
+:: The protocol the [=Virtual Authenticator=] speaks: either `ctap2` or `ctap1/u2f` [[FIDO-CTAP]].
+: |transport|
+:: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
+    authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].
+: |hasResidentKey|
+:: If set to [TRUE] the authenticator will support [=resident credentials=].
+: |hasUserVerification|
+:: If set to [TRUE], the authenticator supports [=user verification=].
+: |isUserConsenting|
+:: Determines the result of all [=user consent=] [=authorization gestures=], and by extension, any [=test of user presence=]
+    performed on the [=Virtual Authenticator=]. If set to [TRUE], a [=user consent=] will always be granted. If set to
+    [FALSE], it will not be granted.
+: |isUserVerified|
+:: Determines the result of [=User Verification=] performed on the [=Virtual Authenticator=]. If set to [TRUE],
+    [=User Verification=] will always succeed. If set to [FALSE], it will fail.
+
+    Note: This property has no effect if |hasUserVerification| is set to [FALSE].
+
+## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
+
+The [=Add Virtual Authenticator=] WebDriver [=extension command=] creates a software [=Virtual Authenticator=]. It is
+defined as follows:
+
+<figure id="table-addVirtualAuthenticator" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>POST</td>
+                <td>`/session/{session id}/webauthn/authenticator`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|. It contains the following |key| and |value| pairs:
+
+<figure id="table-authenticatorConfiguration" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Value Type</th>
+                <th>Valid Values</th>
+                <th>Default</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>|protocol|</td>
+                <td>string</td>
+                <td>`"ctap1/u2f"`, `"ctap2"`</td>
+                <td>None</td>
+            </tr>
+            <tr>
+                <td>|transport|</td>
+                <td>string</td>
+                <td>{{AuthenticatorTransport}} values</td>
+                <td>None</td>
+            </tr>
+            <tr>
+                <td>|hasResidentKey|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[FALSE]</td>
+            </tr>
+            <tr>
+                <td>|hasUserVerification|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[FALSE]</td>
+            </tr>
+            <tr>
+                <td>|isUserConsenting|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[TRUE]</td>
+            </tr>
+            <tr>
+                <td>|isUserVerified|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[FALSE]</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+
+     Note: |parameters| is a [=Authenticator Configuration=] object.
+ 1. Let |authenticator| be a new [=Virtual Authenticator=].
+ 1. For each enumerable [=own property=] in |parameters|:
+    1. Let |key| be the name of the property.
+    1. Let |value| be the result of [=getting a property=] named |key| from |parameters|.
+    1. If there is no matching `key` for |key| in |parameters|, return a [=WebDriver error=] with
+        [=WebDriver error code=] [=invalid argument=].
+    1. If |value| is not one of the `valid values` for that |key|, return a [=WebDriver error=] with [=WebDriver error code=]
+        [=invalid argument=].
+    1. [=Set a property=] |key| to |value| on |authenticator|.
+ 1. For each property in [=Authenticator Configuration=] with a default defined:
+    1. If `key` is not a defined property of |authenticator|, [=set a property=] `key` to `default` on |authenticator|.
+ 1. For each property in [=Authenticator Configuration=]:
+    1. If `key` is not a defined property of |authenticator|, return a [=WebDriver error=] with [=WebDriver error code=]
+        [=invalid argument=].
+ 1. Generate a valid unique [=authenticatorId=].
+ 1. [=Set a property=] `authenticatorId` to |authenticatorId| on |authenticator|.
+ 1. Store |authenticator| in the [=Virtual Authenticator Database=].
+ 1. Return [=success=] with data |authenticatorId|.
+
+## <dfn>Remove Virtual Authenticator</dfn> ## {#sctn-automation-remove-virtual-authenticator}
+
+The [=Remove Virtual Authenticator=] WebDriver [=extension command=] removes a previously created [=Virtual Authenticator=].
+It is defined as follows:
+
+<figure id="table-removeVirtualAuthenticator" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>DELETE</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Remove the [=Virtual Authenticator=] identified by |authenticatorId| from the [=Virtual Authenticator Database=]
+ 1. Return [=success=].
+
+## <dfn>Add Credential</dfn> ## {#sctn-automation-add-credential}
+
+The [=Add Credential=] WebDriver [=extension command=] injects a [=Public Key Credential Source=] into an existing
+[=Virtual Authenticator=]. It is defined as follows:
+
+<figure id="table-addCredential" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>POST</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credential`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|. It contains the following |key| and |value| pairs:
+
+<figure id="table-credentialParameters" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Description</th>
+                <th>Value Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>|credentialId|</td>
+                <td>The [=public key credential source/id|Credential ID=] encoded using [=Base64url Encoding=].</td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|isResidentCredential|</td>
+                <td>
+                    If set to [TRUE], a [=resident credential=] is created. If set to [FALSE], a [=non-resident credential=]
+                    is created instead.
+                </td>
+                <td>boolean</td>
+            </tr>
+            <tr>
+                <td>|rpId|</td>
+                <td>The [=public key credential source/rpId|Relying Party ID=] the credential is scoped to.</td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|privateKey|</td>
+                <td>
+                    An asymmetric key package containing a single [=public key credential source/privateKey|private key=]
+                    per [[RFC5958]], encoded using [=Base64url Encoding=].
+                </td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|userHandle|</td>
+                <td>
+                    The [=public key credential source/userHandle=] associated to the credential encoded using
+                    [=Base64url Encoding=]. This property may not be defined.
+                </td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|signCount|</td>
+                <td>The initial value for a [=signature counter=] associated to the [=public key credential source=].</td>
+                <td>number</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+
+     Note: |parameters| is a [=Credential Parameters=] object.
+ 1. Let |credentialId| be the result of decoding [=Base64url Encoding=] on the |parameters|' |credentialId| property.
+ 1. If |credentialId| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |isResidentCredential| be the |parameters|' |isResidentCredential| property.
+ 1. If |isResidentCredential| is not defined, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |rpId| be the |parameters|' |rpId| property.
+ 1. If |rpId| is not a valid [=RP ID=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |privateKey| be the result of decoding [=Base64url Encoding=] on the |parameters|' |privateKey| property.
+ 1. If |privateKey| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |privateKey| is not a validly-encoded asymmetric key package containing a single ECDSA private key on the P-256
+     curve per [[RFC5958]], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If the |parameters|' |userHandle| property is defined:
+     1. Let |userHandle| be the result of decoding [=Base64url Encoding=] on the |parameters|' |userHandle| property.
+     1. If |userHandle| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Otherwise:
+    1. If |isResidentCredential| is [TRUE], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+    1. Let |userHandle| be `null`.
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |authenticator| be the [=Virtual Authenticator=] matched by |authenticatorId|.
+ 1. If |isResidentCredential| is [TRUE] and the |authenticator|'s |hasResidentKey| property is [FALSE], return a
+     [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |credential| be a new [=Client-side-resident Public Key Credential Source=] if |isResidentCredential| is [TRUE]
+     or a [=Server-side-resident Public Key Credential Source=] otherwise whose items are:
+    : [=public key credential source/type=]
+    :: {{public-key}}
+    : [=public key credential source/id=]
+    :: |credentialId|
+    : [=public key credential source/privateKey=]
+    :: |privateKey|
+    : [=public key credential source/rpId=]
+    :: |rpId|
+    : [=public key credential source/userHandle=]
+    :: |userHandle|
+ 1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'
+     |signCount| or `0` if |signCount| is `null`.
+ 1. Store the |credential| and |counter| in the database of the |authenticator|.
+ 1. Return [=success=].
+
+## <dfn>Get Credentials</dfn> ## {#sctn-automation-get-credentials}
+
+The [=Get Credentials=] WebDriver [=extension command=] returns one [=Credential Parameters=] object for every
+[=Public Key Credential Source=] stored in a [=Virtual Authenticator=], regardless of whether they were
+stored using [=Add Credential=] or {{CredentialsContainer/create()|navigator.credentials.create()}}. It is defined as follows:
+
+<figure id="table-getCredentials" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>GET</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credentials`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |credentialsArray| be an empty array.
+ 1. For each [=Public Key Credential Source=] |credential|, managed by the authenticator identified by |authenticatorId|,
+    construct a corresponding [=Credential Parameters=] [=Object=] and add it to |credentialsArray|.
+ 1. Return [=success=] with data containing |credentialsArray|.
+
+## <dfn>Remove Credential</dfn> ## {#sctn-automation-remove-credential}
+
+The [=Remove Credential=] WebDriver [=extension command=] removes a [=Public Key Credential Source=] stored on a
+[=Virtual Authenticator=]. It is defined as follows:
+
+<figure id="table-removeCredential" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>DELETE</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credentials/{credentialId}`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |authenticator| be the [=Virtual Authenticator=] identified by |authenticatorId|.
+ 1. If |credentialId| does not match any [=Public Key Credential Source=] managed by |authenticator|, return a [=WebDriver error=]
+     with [=WebDriver error code=] [=invalid argument=].
+ 1. Remove the [=Public Key Credential Source=] identified by |credentialId| managed by |authenticator|.
+ 1. Return [=success=].
+
+## <dfn>Remove All Credentials</dfn> ## {#sctn-automation-remove-all-credentials}
+
+The [=Remove All Credentials=] WebDriver [=extension command=] removes all [=Public Key Credential Sources=] stored on a
+[=Virtual Authenticator=]. It is defined as follows:
+
+<figure id="table-removeAllCredentials" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>DELETE</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credentials`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Remove all [=Public Key Credential Sources=] managed by the [=Virtual Authenticator=] identified by |authenticatorId|.
+ 1. Return [=success=].
+
+## <dfn>Set User Verified</dfn> ## {#sctn-automation-set-user-verified}
+
+The [=Set User Verified=] [=extension command=] sets the |isUserVerified| property on the [=Virtual Authenticator=]. It
+is defined as follows:
+
+<figure id="table-setUserVerified" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>POST</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/uv`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If |isUserVerified| is not a defined property of |parameters|, return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+ 1. Let |authenticator| be the [=Virtual Authenticator=] identified by |authenticatorId|.
+ 1. Set the |authenticator|'s |isUserVerified| property to the |parameters|' |isUserVerified| property.
+ 1. Return [=success=].
+
 # IANA Considerations # {#sctn-IANA}
 
 ## WebAuthn Attestation Statement Format Identifier Registrations ## {#sctn-att-fmt-reg}
@@ -6252,9 +6735,9 @@ leakage due to such an attack:
     - When verifying an {{AuthenticatorAssertionResponse}} response from the [=authenticator=], make it indistinguishable whether
           verification failed because the signature is invalid or because no such user or credential is registered.
 
-    - Perform a different authentication step, such as username and password authentication,
-        before initiating the WebAuthn [=authentication ceremony=].
-        This moves the username enumeration problem from the WebAuthn [=authentication ceremony=]
+    - Perform a multi-step [=authentication ceremony=], e.g., beginning with supplying username and password or a session cookie,
+        before initiating the WebAuthn [=ceremony=] as a subsequent step.
+        This moves the username enumation problem from the WebAuthn step
         to the preceding authentication step, where it may be easier to solve.
 
 
@@ -6262,28 +6745,30 @@ leakage due to such an attack:
 
 [INFORMATIVE]
 
-This privacy consideration applies to [=[RPS]=] supporting [=single-factor=] authentication with [=non-resident credentials=].
+This privacy consideration applies to [=[RPS]=] that support [=authentication ceremonies=]
+with a non-[=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument as the first authentication step.
+For example, if using authentication with [=non-resident credentials=] as the first authentication step.
 
 In this case the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument risks leaking [PII],
-if the user can initiate an [=authentication ceremony=] by only providing a username.
+since it exposes the user's [=credential IDs=] to an unauthenticated caller.
 [=Credential IDs=] are designed to not be correlatable between [=[RPS]=],
 but the length of a [=credential ID=] might be a hint as to what type of [=authenticator=] created it.
 It is likely that a user will use the same username and set of [=authenticators=] for several [=[RPS]=],
 so the number of [=credential IDs=] in {{PublicKeyCredentialRequestOptions/allowCredentials}} and their lengths
 might serve as a global correlation handle to de-anonymize the user.
+Knowing a user's [=credential IDs=] also makes it possible to confirm guesses about the user's identity
+given only momentary physical access to one of the user's [=authenticators=].
 
-The simplest ways to prevent this information leak
-is to not support [=single-factor=] authentication with [=non-resident credentials=],
-for example by:
+In order to prevent such information leakage, the [=[RP]=] could for example:
 
-- Performing a separate authentication step,
-    such as username and password authentication, before initiating the WebAuthn [=authentication ceremony=]
-    and exposing the user's [=credential IDs=].
-- Requiring [=resident credentials=] for [=single-factor=] authentication,
+- Perform a separate authentication step,
+    such as username and password authentication or session cookie authentication,
+    before initiating the WebAuthn [=authentication ceremony=] and exposing the user's [=credential IDs=].
+- Use [=resident credentials=],
     so the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument is not needed.
 
-If [=single-factor=] authentication with [=non-resident credentials=] is a requirement,
-i.e., {{PublicKeyCredentialRequestOptions/allowCredentials}} needs to be exposed given only a username,
+If the above prevention measures are not available,
+i.e., if {{PublicKeyCredentialRequestOptions/allowCredentials}} needs to be exposed given only a username,
 the [=[RP]=] could mitigate the privacy leak using the same approach of returning imaginary [=credential IDs=]
 as discussed in [[#sctn-username-enumeration]].
 


### PR DESCRIPTION
somehow I accidentally deleted @nsatragno's automation section when I merged-in the updates to `draft-hodges-webauthn-registries*`, sigh....  

hopefully this fixes it without messing anything else up....

NOTE: WE SHOULD NOT MAKE ANY MERGES TO MASTER UNTIL THIS IS RESOLVED!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1340.html" title="Last updated on Nov 5, 2019, 11:51 PM UTC (e2ecccd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1340/28e8d9d...e2ecccd.html" title="Last updated on Nov 5, 2019, 11:51 PM UTC (e2ecccd)">Diff</a>