### PR TITLE
'loc' extension: cite permissions and geolocation specs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1516,7 +1516,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/crossOrigin}}
-    :: The inverse of the value of the 
+    :: The inverse of the value of the
         {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
     : {{CollectedClientData/tokenBinding}}
@@ -5545,12 +5545,22 @@ This extension enables use of a user verification index.
 
 This extension provides the [=authenticator=]'s current geographic location to the [=[WRP]=].
 
-Note: In almost all cases, this information also discloses the location of the user of the device,
+<div class="note">
+    Note: In almost all cases, this information also discloses the location of the user of the device,
     thereby potentially compromising the user's privacy. A [=conforming user agent=] MUST provide a mechanism that protects the user's privacy and this mechanism
     MUST ensure that no location information is made available through this API without the user's
     express permission [[Permissions]]. Further, the security and privacy considerations
     given in [[!Geolocation-API]] are applicable here and MUST be adhered to.
     See also [[#sctn-security-considerations-client]].
+
+    The location data returned by this extension is conveyed within the
+    signed [=authenticator extension output=], thus it is not possible to remove it from the
+    response message's [=authenticator data=]'s [=authdataextensions|extensions=] member
+    without causing the signature to fail subsequent validation. Implementers of this
+    [=extension=], in the case where the user elects to not reveal their location, must therefore
+    consider whether they will fail requests containing this extension, or remove the extension
+    from requests.
+</div>
 
 : Extension identifier
 :: `loc`
@@ -6371,7 +6381,7 @@ See also the related security consideration for [=[RPS]=] in [[#sctn-revoked-att
 
 ### Browser Permissions Framework and Extensions ### {#sctn-browser-permissions-framework-extensions}
 
-Web Authentication API implementations SHOULD leverage the browser permissions framework 
+Web Authentication API implementations SHOULD leverage the browser permissions framework
 [[Permissions]] when obtaining user
 permissions for certain extensions. An example is the location extension (see [[#sctn-location-extension]]), implementations of
 which MUST make use of the existing browser permissions framework for the Geolocation API,

--- a/index.bs
+++ b/index.bs
@@ -5546,7 +5546,7 @@ This extension enables use of a user verification index.
 This extension provides the [=authenticator=]'s current geographic location to the [=[WRP]=].
 
 Note: In almost all cases, this information also discloses the location of the user of the device,
-    thereby potentially compromising the user's privacy. A [=conforming user agent=] must provide a mechanism that protects the user's privacy and this mechanism
+    thereby potentially compromising the user's privacy. A [=conforming user agent=] MUST provide a mechanism that protects the user's privacy and this mechanism
     MUST ensure that no location information is made available through this API without the user's
     express permission [[Permissions]]. Further, the security and privacy considerations
     given in [[!Geolocation-API]] are applicable here and MUST be adhered to.

--- a/index.bs
+++ b/index.bs
@@ -5543,7 +5543,14 @@ This extension enables use of a user verification index.
 
 ## Location Extension (loc) ## {#sctn-location-extension}
 
-This extension provides the [=authenticator=]'s current location to the WebAuthn [=[WRP]=].
+This extension provides the [=authenticator=]'s current geographic location to the [=[WRP]=].
+
+Note: In almost all cases, this information also discloses the location of the user of the device,
+    thereby potentially compromising the user's privacy. A [=conforming user agent=] must provide a mechanism that protects the user's privacy and this mechanism
+    MUST ensure that no location information is made available through this API without the user's
+    express permission [[Permissions]]. Further, the security and privacy considerations
+    given in [[Geolocation-API]] are applicable here and MUST be adhered to.
+    See also [[#sctn-security-considerations-client]].
 
 : Extension identifier
 :: `loc`
@@ -6364,9 +6371,11 @@ See also the related security consideration for [=[RPS]=] in [[#sctn-revoked-att
 
 ### Browser Permissions Framework and Extensions ### {#sctn-browser-permissions-framework-extensions}
 
-Web Authentication API implementations SHOULD leverage the browser permissions framework as much as possible when obtaining user
+Web Authentication API implementations SHOULD leverage the browser permissions framework 
+[[Permissions]] when obtaining user
 permissions for certain extensions. An example is the location extension (see [[#sctn-location-extension]]), implementations of
-which SHOULD make use of the existing browser permissions framework for the Geolocation API.
+which MUST make use of the existing browser permissions framework for the Geolocation API,
+as prescribed in [[Geolocation-API]].
 
 
 ## Security considerations for [=[RPS]=] ## {#sctn-security-considerations-rp}
@@ -6855,7 +6864,7 @@ for their contributions as our W3C Team Contacts.
         "Giridhar Mandyam",
         "Michael B. Jones"
     ],
-    "date": "February 2018",
+    "date": "October 2019",
     "href": "https://tools.ietf.org/html/draft-hodges-webauthn-registries",
     "publisher": "W3C WebAuthn Working Draft",
     "status": "Active Internet-Draft",

--- a/index.bs
+++ b/index.bs
@@ -5549,7 +5549,7 @@ Note: In almost all cases, this information also discloses the location of the u
     thereby potentially compromising the user's privacy. A [=conforming user agent=] must provide a mechanism that protects the user's privacy and this mechanism
     MUST ensure that no location information is made available through this API without the user's
     express permission [[Permissions]]. Further, the security and privacy considerations
-    given in [[Geolocation-API]] are applicable here and MUST be adhered to.
+    given in [[!Geolocation-API]] are applicable here and MUST be adhered to.
     See also [[#sctn-security-considerations-client]].
 
 : Extension identifier
@@ -6375,7 +6375,7 @@ Web Authentication API implementations SHOULD leverage the browser permissions f
 [[Permissions]] when obtaining user
 permissions for certain extensions. An example is the location extension (see [[#sctn-location-extension]]), implementations of
 which MUST make use of the existing browser permissions framework for the Geolocation API,
-as prescribed in [[Geolocation-API]].
+as prescribed in [[!Geolocation-API]].
 
 
 ## Security considerations for [=[RPS]=] ## {#sctn-security-considerations-rp}


### PR DESCRIPTION
The IETF Sec Area Director (AD) sponsoring [`draft-hodges-webauthn-registries`](https://tools.ietf.org/html/draft-hodges-webauthn-registries) recommended that we bolster the sec & priv considerations for the "loc" (location) extension in the webauthn spec, hence this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1342.html" title="Last updated on Nov 27, 2019, 7:51 PM UTC (8aaa6ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1342/8927216...8aaa6ca.html" title="Last updated on Nov 27, 2019, 7:51 PM UTC (8aaa6ca)">Diff</a>