### PR TITLE
<div> cannot appear within <figure>

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3756,11 +3756,11 @@ In these cases, the [=authenticator=] provides no guarantees about its operation
     <img src="images/fido-attestation-structures.svg"/>
     <figcaption>[=Attestation object=] layout illustrating the included [=authenticator data=] (containing [=attested credential
     data=]) and the [=attestation statement=].</figcaption>
-    <div class="note">
-        This figure illustrates only the `packed` [=attestation statement format=]. Several additional [=attestation statement
-        formats=] are defined in [[#sctn-defined-attestation-formats]].
-    </div>
 </figure>
+<div class="note">
+  This figure illustrates only the `packed` [=attestation statement format=]. Several additional [=attestation statement
+  formats=] are defined in [[#sctn-defined-attestation-formats]].
+</div>
 
 An important component of the [=attestation object=] is the <dfn>attestation statement</dfn>. This is a specific type of signed
 data object, containing statements about a [=public key credential=] itself and the [=authenticator=] that created it. It


### PR DESCRIPTION
See [figure content model](https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element)

cc @wseltzer


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1350.html" title="Last updated on Nov 26, 2019, 8:20 PM UTC (171a2cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1350/8927216...171a2cd.html" title="Last updated on Nov 26, 2019, 8:20 PM UTC (171a2cd)">Diff</a>