### PR TITLE
Add a WebDriver Extension Capability

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5800,9 +5800,9 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 
 For the purposes of user agent automation and [=web application=] testing, this document defines a number of [[WebDriver]] [=extension commands=].
 
-## WebAuthn WebDriver Capability ## {#sctn-automation-webdriver-capability}
+## WebAuthn WebDriver Extension Capability ## {#sctn-automation-webdriver-capability}
 
-In order to advertise the availability of the [=extension commands=] defined below, a new [=extension capability=] is added.
+In order to advertise the availability of the [=extension commands=] defined below, a new [=extension capability=] is defined.
 
 <figure id="table-virtualAuthenticatorsWebdriverCapability" class="table">
     <table class="data">

--- a/index.bs
+++ b/index.bs
@@ -261,6 +261,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
     type: dfn
         text: WebDriver error; url: dfn-error
         text: WebDriver error code; url: dfn-error-code
+        text: endpoint node; url: dfn-endpoint-node
+        text: extension capability; url: dfn-extension-capability
         text: extension command; url: dfn-extension-command
         text: extension command name; url: dfn-extension-command-name
         text: getting a property; url: dfn-getting-properties
@@ -268,10 +270,12 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
         text: prefix; url: dfn-url-prefix
         text: invalid argument; url: dfn-invalid-argument
         text: local end; url: dfn-local-end
+        text: matching capabilities; url: dfn-matching-capabilities
         text: remote end steps; url: dfn-remote-end-steps
         text: session; url: dfn-session
         text: success; url: dfn-success
         text: trying; url: dfn-try
+        text: validating capabilities; url: dfn-validate-capabilities
 
 spec: UTR29
     urlPrefix: https://unicode.org/reports/tr29/
@@ -5795,6 +5799,41 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 # User Agent Automation # {#sctn-automation}
 
 For the purposes of user agent automation and [=web application=] testing, this document defines a number of [[WebDriver]] [=extension commands=].
+
+## WebAuthn WebDriver Capability ## {#sctn-automation-webdriver-capability}
+
+In order to advertise the availability of the [=extension commands=] defined below, a new [=extension capability=] is added.
+
+<figure id="table-virtualAuthenticatorsWebdriverCapability" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Capability</th>
+                <th>Key</th>
+                <th>Value Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Virtual Authenticators Support</td>
+                <td>`":virtualAuthenticators"`</td>
+                <td>boolean</td>
+                <td>Indicates whether the [=endpoint node=] supports all [=Virtual Authenticators=] commands.</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+When [=validating capabilities=], the extension-specific substeps to validate `":webauthn"` with `value` are the following:
+
+    ::  If `value` is not a [=boolean=] return a [=WebDriver Error=] with [=WebDriver error code=] [=invalid argument=].
+        Otherwise, let `deserialized` be set to `value`.
+
+When [=matching capabilities=], the extension-specific steps to match `":webauthn"` with `value` are the following:
+
+    ::  If `value` is [TRUE] and the [=endpoint node=] does not support any of the [=Virtual Authenticators=] commands,
+        the match is unsuccessful. Otherwise, the match is successful.
 
 ## <dfn>Virtual Authenticators</dfn> ## {#sctn-automation-virtual-authenticators}
 

--- a/index.bs
+++ b/index.bs
@@ -5817,7 +5817,7 @@ In order to advertise the availability of the [=extension commands=] defined bel
         <tbody>
             <tr>
                 <td>Virtual Authenticators Support</td>
-                <td>`":virtualAuthenticators"`</td>
+                <td>`"webauthn:virtualAuthenticators"`</td>
                 <td>boolean</td>
                 <td>Indicates whether the [=endpoint node=] supports all [=Virtual Authenticators=] commands.</td>
             </tr>
@@ -5825,12 +5825,12 @@ In order to advertise the availability of the [=extension commands=] defined bel
     </table>
 </figure>
 
-When [=validating capabilities=], the extension-specific substeps to validate `":webauthn"` with `value` are the following:
+When [=validating capabilities=], the extension-specific substeps to validate `"webauthn:virtualAuthenticators"` with `value` are the following:
 
     ::  If `value` is not a [=boolean=] return a [=WebDriver Error=] with [=WebDriver error code=] [=invalid argument=].
         Otherwise, let `deserialized` be set to `value`.
 
-When [=matching capabilities=], the extension-specific steps to match `":webauthn"` with `value` are the following:
+When [=matching capabilities=], the extension-specific steps to match `"webauthn:virtualAuthenticators"` with `value` are the following:
 
     ::  If `value` is [TRUE] and the [=endpoint node=] does not support any of the [=Virtual Authenticators=] commands,
         the match is unsuccessful. Otherwise, the match is successful.


### PR DESCRIPTION
Add a WebDriver capability that indicates support for the Virtual Authenticators automation API. This [simplifies integration between browser automation frameworks](https://github.com/SeleniumHQ/selenium/pull/7760#issuecomment-559856654) and the automation API.

Fixes #1351


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nsatragno/webauthn/pull/1353.html" title="Last updated on Dec 12, 2019, 11:29 PM UTC (75c00b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1353/90aaad9...nsatragno:75c00b2.html" title="Last updated on Dec 12, 2019, 11:29 PM UTC (75c00b2)">Diff</a>