### PR TITLE
Remove the requirement accept and store a 64-byte minimum length for a name member’s value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2448,7 +2448,7 @@ associated with or [=scoped=] to, respectively.
 
         When [=clients=], [=client platforms=], or [=authenticators=] display a {{PublicKeyCredentialEntity/name}}'s value, they should always use UI elements to provide a clear boundary around the displayed value, and not allow overflow into other elements [[css-overflow-3]].
 
-        Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value so that it fits within 64 bytes. See [[#sctn-strings]] about truncation and other considerations.
+        Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value so that it fits within 64 bytes, if the authenticator stores the value. See [[#sctn-strings]] about truncation and other considerations.
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -2448,8 +2448,7 @@ associated with or [=scoped=] to, respectively.
 
         When [=clients=], [=client platforms=], or [=authenticators=] display a {{PublicKeyCredentialEntity/name}}'s value, they should always use UI elements to provide a clear boundary around the displayed value, and not allow overflow into other elements [[css-overflow-3]].
 
-        [=Authenticators=] MUST accept and store a 64-byte minimum length for a {{PublicKeyCredentialEntity/name}} member's
-        value. Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value so that it fits within 64 bytes. See [[#sctn-strings]] about truncation and other considerations.
+        Authenticators MAY truncate a {{PublicKeyCredentialEntity/name}} member's value so that it fits within 64 bytes. See [[#sctn-strings]] about truncation and other considerations.
 </div>
 
 


### PR DESCRIPTION
Remove the requirement accept and store a 64-byte minimum length for a name member’s value
Fixes #1352


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ve7jtb/webauthn/pull/1354.html" title="Last updated on Feb 19, 2020, 9:44 PM UTC (6955b9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1354/90aaad9...ve7jtb:6955b9c.html" title="Last updated on Feb 19, 2020, 9:44 PM UTC (6955b9c)">Diff</a>