### PR TITLE
Add note about risk of ignoring excludeCredentials with mismatched transports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1644,6 +1644,13 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             1. [=list/For each=] credential descriptor |C| in <code>|options|.{{PublicKeyCredentialCreationOptions/excludeCredentials}}</code>:
                 1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
                     mentioned in <code>|C|.{{transports}}</code>, the client MAY [=continue=].
+
+                    Note: If the client chooses to [=continue=], this could result in
+                    inadvertently registering multiple credentials [=bound credential|bound to=] the same [=authenticator=]
+                    if the transport hints in <code>|C|.{{transports}}</code> are not accurate.
+                    For example, stored transport hints could become inaccurate
+                    as a result of software upgrades adding new connectivity options.
+
                 1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as


### PR DESCRIPTION
Fixes #1348.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1359.html" title="Last updated on Jan 13, 2020, 4:33 PM UTC (d7c2014)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1359/b2d74e7...d7c2014.html" title="Last updated on Jan 13, 2020, 4:33 PM UTC (d7c2014)">Diff</a>