### PR TITLE
remove 'lightning' AuthenticatorTransport enum value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2915,8 +2915,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
         "usb",
         "nfc",
         "ble",
-        "internal",
-        "lightning"
+        "internal"
     };
 </xmp>
 
@@ -2931,9 +2930,6 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
     :   <dfn>usb</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over removable USB.
-
-    :   <dfn>lightning</dfn>
-    ::  Indicates the respective [=authenticator=] can be contacted over removable Lightning.
 
     :   <dfn>nfc</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over Near Field Communication (NFC).


### PR DESCRIPTION
fixes #1294


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1364.html" title="Last updated on Jan 22, 2020, 10:30 PM UTC (2923f10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1364/6349d24...2923f10.html" title="Last updated on Jan 22, 2020, 10:30 PM UTC (2923f10)">Diff</a>