### PR TITLE
update CTAP reference to point to fido-client-to-authenticator-protocol-v2.0-ps-20190130.html

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -213,7 +213,7 @@ spec: WHATWG URL; urlPrefix: https://url.spec.whatwg.org/
     type: dfn
         text: same site; url: host-same-site
 
-spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
+spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
         text: §6.2. Responses; url: responses
@@ -7058,7 +7058,7 @@ for their contributions as our W3C Team Contacts.
     "authors": ["M. Antoine", "V. Bharadwaj", "C. Brand", "A. Czeskis", "J. Ehrensvärd", "J. Hodges", "M. B. Jones", "A. Kumar",
         "R. Lindemann", "M. J. Ploch", "A. Powers", "J. Verrept"],
     "title": "Client to Authenticator Protocol",
-    "href": "https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html",
+    "href": "https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html",
     "status": "FIDO Alliance Implementation Draft",
     "date": "27 February 2018"
   },


### PR DESCRIPTION
fixes #1360


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1365.html" title="Last updated on Jan 22, 2020, 10:40 PM UTC (abbae30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1365/6349d24...abbae30.html" title="Last updated on Jan 22, 2020, 10:40 PM UTC (abbae30)">Diff</a>