### PR TITLE
Add clearer recommendation on what to do with transport hints

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2904,7 +2904,13 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     :   <dfn>transports</dfn>
     ::  This OPTIONAL member contains a hint as to how the [=client=] might communicate with the [=managing authenticator=] of the
         [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values.
+
         The {{AuthenticatorAttestationResponse/getTransports()}} operation can provide suitable values for this member.
+        When [[#sctn-registering-a-new-credential|registering a new credential]],
+        the [=[RP]=] SHOULD store the value returned from {{AuthenticatorAttestationResponse/getTransports()}}.
+        When creating a {{PublicKeyCredentialDescriptor}} for that credential,
+        the [=[RP]=] SHOULD retrieve that stored value
+        and set it as the {{PublicKeyCredentialDescriptor/transports}} member.
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -4198,7 +4198,8 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 
     - Associate the <code>[=credentialId=]</code> with the transport hints
         returned by calling <code>|credential|.{{AuthenticatorAttestationResponse/getTransports()}}</code>.
-        It is RECOMMENDED to use these to populate the {{PublicKeyCredentialDescriptor/transports}}
+        This value SHOULD NOT be modified before or after storing it.
+        It is RECOMMENDED to use this value to populate the {{PublicKeyCredentialDescriptor/transports}}
         of the {{PublicKeyCredentialRequestOptions/allowCredentials}} option in future {{CredentialsContainer/get()}} calls
         to help the [=client=] know how to find a suitable [=authenticator=].
 
@@ -4221,6 +4222,11 @@ provide this chain in the attestation information.
 In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as follows:
 
 1. Let |options| be a new {{PublicKeyCredentialRequestOptions}} structure configured to the [=[RP]=]'s needs for the ceremony.
+
+    If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is [=present=],
+    the {{PublicKeyCredentialDescriptor/transports}} member of each value SHOULD be set to
+    the value returned by <code>|credential|.{{AuthenticatorAttestationResponse/getTransports()}}</code>
+    when the credential was registered.
 
 1. Call {{CredentialsContainer/get()|navigator.credentials.get()}} and pass |options|
     as the <code>{{CredentialRequestOptions/publicKey}}</code> option.

--- a/index.bs
+++ b/index.bs
@@ -2910,7 +2910,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
         the [=[RP]=] SHOULD store the value returned from {{AuthenticatorAttestationResponse/getTransports()}}.
         When creating a {{PublicKeyCredentialDescriptor}} for that credential,
         the [=[RP]=] SHOULD retrieve that stored value
-        and set it as the {{PublicKeyCredentialDescriptor/transports}} member.
+        and set it as the value of the {{PublicKeyCredentialDescriptor/transports}} member.
 </div>
 
 


### PR DESCRIPTION
Fixes #1368.

With this we have

- A normative RECOMMENDation to store the transport hints in the registration operation
- A normative SHOULD to put them in as arguments to `get()`
- A mention of `getTransports()` in the [`PublicKeyCredentialDescriptor.transports`](https://w3c.github.io/webauthn/#dom-publickeycredentialdescriptor-transports) description
- A mention of `getTransports()` in the [`AuthenticatorTransport`](https://w3c.github.io/webauthn/#enumdef-authenticatortransport) description

Should we add hooks anywhere else too?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1369.html" title="Last updated on Feb 27, 2020, 12:33 PM UTC (eb02738)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1369/66ad76b...eb02738.html" title="Last updated on Feb 27, 2020, 12:33 PM UTC (eb02738)">Diff</a>