### PR TITLE
Default to ES256 and RS256 if pubKeyCredParams is empty

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1490,18 +1490,21 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
     a {{COSEAlgorithmIdentifier}}.
 
-1. If <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code> [=list/is empty=]:
+1. If <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>'s [=list/size=]
+    <dl class="switch">
+        :   is zero
+        ::  [=list/Append=] the pair of {{PublicKeyCredentialType}} with value {{public-key}} and a
+            {{COSEAlgorithmIdentifier}} with value <code>-7</code> ("ES256") to |credTypesAndPubKeyAlgs|.
 
-    1. [=list/Append=] the pair of {{PublicKeyCredentialType}} with value {{public-key}} and a
-        {{COSEAlgorithmIdentifier}} with value <code>-7</code> ("ES256") to |credTypesAndPubKeyAlgs|.
+        :   is non-zero
+        ::  [=list/for each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
 
-1. Otherwise, [=list/for each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
-
-    1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
-        by this implementation, then [=continue=].
-    1. Let |alg| be <code>|current|.{{PublicKeyCredentialParameters/alg}}</code>.
-    1. [=list/Append=] the pair of <code>|current|.{{PublicKeyCredentialParameters/type}}</code> and |alg| to
-        |credTypesAndPubKeyAlgs|.
+            1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
+                by this implementation, then [=continue=].
+            1. Let |alg| be <code>|current|.{{PublicKeyCredentialParameters/alg}}</code>.
+            1. [=list/Append=] the pair of <code>|current|.{{PublicKeyCredentialParameters/type}}</code> and |alg| to
+                |credTypesAndPubKeyAlgs|.
+    </dl>
 
 1. If |credTypesAndPubKeyAlgs| [=list/is empty=], return a {{DOMException}} whose name is
     "{{NotSupportedError}}", and terminate this algorithm.

--- a/index.bs
+++ b/index.bs
@@ -1493,8 +1493,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 1. If <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>'s [=list/size=]
     <dl class="switch">
         :   is zero
-        ::  [=list/Append=] the pair of {{PublicKeyCredentialType}} with value {{public-key}} and a
-            {{COSEAlgorithmIdentifier}} with value <code>-7</code> ("ES256") to |credTypesAndPubKeyAlgs|.
+        ::  [=list/Append=] the following pairs of {{PublicKeyCredentialType}} and {{COSEAlgorithmIdentifier}} values to |credTypesAndPubKeyAlgs|:
+             * {{public-key}} and <code>-7</code> ("ES256").
+             * {{public-key}} and <code>-257</code> ("RS256").
 
         :   is non-zero
         ::  [=list/For each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:

--- a/index.bs
+++ b/index.bs
@@ -1490,7 +1490,12 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
     a {{COSEAlgorithmIdentifier}}.
 
-1. [=list/For each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
+1. If <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code> [=list/is empty=]:
+
+    1. [=list/Append=] the pair of {{PublicKeyCredentialType}} with value {{public-key}} and a
+        {{COSEAlgorithmIdentifier}} with value <code>-7</code> ("ES256") to |credTypesAndPubKeyAlgs|.
+
+1. Otherwise, [=list/for each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
 
     1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
         by this implementation, then [=continue=].
@@ -1498,8 +1503,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     1. [=list/Append=] the pair of <code>|current|.{{PublicKeyCredentialParameters/type}}</code> and |alg| to
         |credTypesAndPubKeyAlgs|.
 
-1. If |credTypesAndPubKeyAlgs| [=list/is empty=] and <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>
-    [=list/is not empty=], return a {{DOMException}} whose name is "{{NotSupportedError}}", and terminate this algorithm.
+1. If |credTypesAndPubKeyAlgs| [=list/is empty=], return a {{DOMException}} whose name is
+    "{{NotSupportedError}}", and terminate this algorithm.
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
 

--- a/index.bs
+++ b/index.bs
@@ -1504,10 +1504,10 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             1. Let |alg| be <code>|current|.{{PublicKeyCredentialParameters/alg}}</code>.
             1. [=list/Append=] the pair of <code>|current|.{{PublicKeyCredentialParameters/type}}</code> and |alg| to
                 |credTypesAndPubKeyAlgs|.
-    </dl>
 
-1. If |credTypesAndPubKeyAlgs| [=list/is empty=], return a {{DOMException}} whose name is
-    "{{NotSupportedError}}", and terminate this algorithm.
+            If |credTypesAndPubKeyAlgs| [=list/is empty=], return a {{DOMException}} whose name is
+               "{{NotSupportedError}}", and terminate this algorithm.
+    </dl>
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
 

--- a/index.bs
+++ b/index.bs
@@ -1497,7 +1497,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             {{COSEAlgorithmIdentifier}} with value <code>-7</code> ("ES256") to |credTypesAndPubKeyAlgs|.
 
         :   is non-zero
-        ::  [=list/for each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
+        ::  [=list/For each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
 
             1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
                 by this implementation, then [=continue=].


### PR DESCRIPTION
Default to algorithm -7 ("ES256") when `options.pubKeyCredParams` is
empty.

Fixes #1383.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nsatragno/webauthn/pull/1387.html" title="Last updated on Mar 25, 2020, 7:46 PM UTC (2feeac6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1387/a0249af...nsatragno:2feeac6.html" title="Last updated on Mar 25, 2020, 7:46 PM UTC (2feeac6)">Diff</a>