### PR TITLE
Update signature counters section.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3219,7 +3219,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 ### <dfn>Signature Counter</dfn> Considerations ### {#sctn-sign-counter}
 
 Authenticators SHOULD implement a [=signature counter=] feature. These counters are conceptually stored for each credential
-by the authenticator. The initial value of a credential's [=signature counter=] is specified in the <code>[=signCount=]</code>
+by the authenticator, or globally for the authenticator as a whole. The initial value of a credential's [=signature counter=] is specified in the <code>[=signCount=]</code>
 value of the [=authenticator data=] returned by [=authenticatorMakeCredential=]. The [=signature counter=] is incremented for each successful
 [=authenticatorGetAssertion=] operation by some positive value, and subsequent values are returned to the [=[WRP]=] within the
 [=authenticator data=] again. The [=signature counter=]'s purpose is to aid [=[RPS]=] in detecting cloned authenticators. Clone
@@ -3227,7 +3227,7 @@ detection is more important for authenticators with limited protection measures.
 
 A [=[RP]=] stores the [=signature counter=] of the most recent [=authenticatorGetAssertion=] operation. (Or the counter from the [=authenticatorMakeCredential=] operation if no [=authenticatorGetAssertion=] has ever been performed on a credential.) In subsequent
 [=authenticatorGetAssertion=] operations, the [=[RP]=] compares the stored [=signature counter=] value with the new
-<code>[=signCount=]</code> value returned in the assertion's [=authenticator data=].  If either are non-zero, and the new <code>[=signCount=]</code> value is less than or equal to the stored value, a cloned authenticator may exist, or the authenticator may be malfunctioning.
+<code>[=signCount=]</code> value returned in the assertion's [=authenticator data=].  If either is non-zero, and the new <code>[=signCount=]</code> value is less than or equal to the stored value, a cloned authenticator may exist, or the authenticator may be malfunctioning.
 
 Detecting a [=signature counter=] mismatch does not indicate whether the current operation was performed by a cloned authenticator or the original authenticator.  [=[RPS]=] should address this situation appropriately relative to their individual situations, i.e., their risk tolerance.
 

--- a/index.bs
+++ b/index.bs
@@ -3218,16 +3218,18 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 
 ### <dfn>Signature Counter</dfn> Considerations ### {#sctn-sign-counter}
 
-Authenticators SHOULD implement a [=signature counter=] feature. The [=signature counter=] is incremented for each successful
-[=authenticatorGetAssertion=] operation by some positive value, and its value is returned to the [=[WRP]=] within the
-[=authenticator data=]. The [=signature counter=]'s purpose is to aid [=[RPS]=] in detecting cloned authenticators. Clone
+Authenticators SHOULD implement a [=signature counter=] feature. These counters are conceptually stored for each credential
+by the authenticator. The initial value of a credential's [=signature counter=] is specified in the <code>[=signCount=]</code>
+value of the [=authenticator data=] returned by [=authenticatorMakeCredential=]. The [=signature counter=] is incremented for each successful
+[=authenticatorGetAssertion=] operation by some positive value, and subsequent values are returned to the [=[WRP]=] within the
+[=authenticator data=] again. The [=signature counter=]'s purpose is to aid [=[RPS]=] in detecting cloned authenticators. Clone
 detection is more important for authenticators with limited protection measures.
 
-A [=[RP]=] stores the [=signature counter=] of the most recent [=authenticatorGetAssertion=] operation. Upon a new
-[=authenticatorGetAssertion=] operation, the [=[RP]=] compares the stored [=signature counter=] value with the new
-<code>[=signCount=]</code> value returned in the assertion's [=authenticator data=].  If this new <code>[=signCount=]</code> value is less than or equal to the stored value, a cloned authenticator may exist, or the authenticator may be malfunctioning.
+A [=[RP]=] stores the [=signature counter=] of the most recent [=authenticatorGetAssertion=] operation. (Or the counter from the [=authenticatorMakeCredential=] operation if no [=authenticatorGetAssertion=] has ever been performed on a credential.) In subsequent
+[=authenticatorGetAssertion=] operations, the [=[RP]=] compares the stored [=signature counter=] value with the new
+<code>[=signCount=]</code> value returned in the assertion's [=authenticator data=].  If either are non-zero, and the new <code>[=signCount=]</code> value is less than or equal to the stored value, a cloned authenticator may exist, or the authenticator may be malfunctioning.
 
-Detecting a [=signature counter=]  mismatch does not indicate whether the current operation was performed by a cloned authenticator or the original authenticator.  [=[RPS]=] should address this situation appropriately relative to their individual situations, i.e., their risk tolerance.
+Detecting a [=signature counter=] mismatch does not indicate whether the current operation was performed by a cloned authenticator or the original authenticator.  [=[RPS]=] should address this situation appropriately relative to their individual situations, i.e., their risk tolerance.
 
 Authenticators:
 - SHOULD implement per credential [=signature counters=].  This prevents the
@@ -3592,15 +3594,19 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     terminate the operation.
 1. Let |processedExtensions| be the result of [=authenticator extension processing=] [=map/for each=] supported [=extension
     identifier=] → [=authenticator extension input=] in |extensions|.
-1. If the [=authenticator=] supports:
+1. If the [=authenticator=]:
     <dl class="switch">
-        :  a global [=signature counter=]
+        : is a U2F device
+        :: let the [=signature counter=] value for the new credential be zero. (U2F devices may support signature counters but do not return a counter when making a credential. See [[FIDO-U2F-Message-Formats]].)
+
+        : supports a global [=signature counter=]
         ::  Use the global [=signature counter=]'s actual value when generating
               [=authenticator data=].
-        : a per credential [=signature counter=]
+
+        : supports a per credential [=signature counter=]
         :: allocate the counter, associate it with the new credential, and initialize the counter value as zero.
 
-        : no [=signature counter=]
+        : does not support a [=signature counter=]
         :: let the [=signature counter=] value for the new credential be constant at zero.
     </dl>
 


### PR DESCRIPTION
This section did not reflect the specified behaviour for signature
counters and did not mention that they are returned in makeCredential
responses too. See linked bug for details.

Fixes #1370


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1390.html" title="Last updated on Apr 2, 2020, 8:04 PM UTC (d7e8b81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1390/ae29ff0...agl:d7e8b81.html" title="Last updated on Apr 2, 2020, 8:04 PM UTC (d7e8b81)">Diff</a>