### PR TITLE
Substitute enum types in dictionaries with DOMStrings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2689,7 +2689,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
         unsigned long                        timeout;
         USVString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-        UserVerificationRequirement          userVerification = "preferred";
+        DOMString                            userVerification = "preferred";
         AuthenticationExtensionsClientInputs extensions;
     };
 </xmp>
@@ -2715,8 +2715,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
 
     :   <dfn>userVerification</dfn>
     ::  This OPTIONAL member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
-        {{CredentialsContainer/get()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
-        requirement.
+        {{CredentialsContainer/get()}} operation. The value SHOULD be a member of {{UserVerificationRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset. Eligible authenticators are filtered to only those capable of satisfying this requirement.
 
     :   <dfn>extensions</dfn>
     ::  This OPTIONAL member contains additional parameters requesting additional processing by the client and authenticator.

--- a/index.bs
+++ b/index.bs
@@ -2371,7 +2371,7 @@ optionally evidence of [=user consent=] to a specific transaction.
         unsigned long                                timeout;
         sequence<PublicKeyCredentialDescriptor>      excludeCredentials = [];
         AuthenticatorSelectionCriteria               authenticatorSelection;
-        AttestationConveyancePreference              attestation = "none";
+        DOMString                                    attestation = "none";
         AuthenticationExtensionsClientInputs         extensions;
     };
 </xmp>
@@ -2418,7 +2418,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 
     :   <dfn>attestation</dfn>
     ::  This member is intended for use by [=[RPS]=] that wish to express their preference for [=attestation conveyance=].
-        The default is {{AttestationConveyancePreference/none}}.
+        The value SHOULD be a member of {{AttestationConveyancePreference}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset. The default is {{AttestationConveyancePreference/none}}.
 
     :   <dfn>extensions</dfn>
     ::  This member contains additional parameters requesting additional processing by the client and authenticator. For
@@ -2915,7 +2915,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
     :   <dfn>transports</dfn>
     ::  This OPTIONAL member contains a hint as to how the [=client=] might communicate with the [=managing authenticator=] of the
-        [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values.
+        [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
 
         The {{AuthenticatorAttestationResponse/getTransports()}} operation can provide suitable values for this member.
         When [[#sctn-registering-a-new-credential|registering a new credential]],

--- a/index.bs
+++ b/index.bs
@@ -2348,7 +2348,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     This dictionary is used to supply additional parameters when creating a new credential.
 
     :   <dfn>type</dfn>
-    ::  This member specifies the type of credential to be created. The value SHOULD be a member of {{PublicKeyCredentialType}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
+    ::  This member specifies the type of credential to be created. The value SHOULD be a member of {{PublicKeyCredentialType}} but [=client platforms=] MUST ignore unknown values, ignoring any {{PublicKeyCredentialParameters}} with an unknown {{PublicKeyCredentialParameters/type}}.
 
     :   <dfn>alg</dfn>
     ::  This member specifies the cryptographic signature algorithm with which the newly generated credential will be used, and
@@ -2907,14 +2907,14 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialDescriptor">
     :   <dfn>type</dfn>
-    ::  This member contains the type of the [=public key credential=] the caller is referring to. The value SHOULD be a member of {{PublicKeyCredentialType}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
+    ::  This member contains the type of the [=public key credential=] the caller is referring to. The value SHOULD be a member of {{PublicKeyCredentialType}} but [=client platforms=] MUST ignore any {{PublicKeyCredentialDescriptor}} with an unknown {{PublicKeyCredentialDescriptor/type}}.
 
     :   <dfn>id</dfn>
     ::  This member contains the [=credential ID=] of the [=public key credential=] the caller is referring to.
 
     :   <dfn>transports</dfn>
     ::  This OPTIONAL member contains a hint as to how the [=client=] might communicate with the [=managing authenticator=] of the
-        [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
+        [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values.
 
         The {{AuthenticatorAttestationResponse/getTransports()}} operation can provide suitable values for this member.
         When [[#sctn-registering-a-new-credential|registering a new credential]],

--- a/index.bs
+++ b/index.bs
@@ -799,6 +799,16 @@ would be obtained by the specification's algorithms.
 A conforming User Agent MUST also be a conforming implementation of the IDL fragments of this specification, as described in the
 “Web IDL” specification. [[!WebIDL]]
 
+### Enumerations as DOMString types ### {#sct-domstring-backwards-compatibility}
+
+Enumeration types are not referenced by other parts of the Web IDL because that
+would preclude other values from being used without updating this specification
+and its implementations. It is important for backwards compatibility that
+[=client platforms=] and [=[RPS]=] handle unknown values. Enumerations for this
+specification exist here for documentation and as a registry. Where the
+enumerations are represented elsewhere, they are typed as {{DOMString}}s, for
+example in {{PublicKeyCredentialDescriptor/transports}}.
+
 ## Authenticators ## {#sctn-conforming-authenticators}
 
 A [=[WAA]=] MUST provide the operations defined by [[#sctn-authenticator-model]], and those operations MUST behave as
@@ -2630,6 +2640,8 @@ to [[#sctn-createCredential|create a credential]].
     };
 </xmp>
 
+Note: The {{AuthenticatorAttachment}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+
 <div dfn-type="enum-value" dfn-for="AuthenticatorAttachment">
     :   <dfn>platform</dfn>
     ::  This value indicates [=platform attachment=].
@@ -2655,6 +2667,8 @@ credential|credentials=]. The [=client=] and user will then use whichever is ava
         "required"
     };
 </xmp>
+
+Note: The {{ResidentKeyRequirement}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
 
 This enumeration's values describe the [=[RP]=]'s requirements for [=client-side discoverable credentials=] (formerly known as [=resident credentials=] or [=resident keys=]):
 
@@ -2692,6 +2706,8 @@ during credential generation.
         "enterprise"
     };
 </xmp>
+
+Note: The {{AttestationConveyancePreference}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
 
 <div dfn-type="enum-value" dfn-for="AttestationConveyancePreference">
     :   <dfn>none</dfn>
@@ -2899,6 +2915,8 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
                         {{TokenBinding/id}} member MUST be present.
                 </div>
 
+                Note: The {{TokenBindingStatus}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+
             :   <dfn>id</dfn>
             ::  This member MUST be present if {{TokenBinding/status}} is {{TokenBindingStatus/present}}, and MUST be a [=base64url
                 encoding=] of the [=Token Binding ID=] that was used when communicating with the [=[RP]=].
@@ -3016,12 +3034,15 @@ If additional fields are added to {{CollectedClientData}} then verifiers that em
     };
 </xmp>
 
+Note: The {{PublicKeyCredentialType}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+
 <div dfn-type="enum-value" dfn-for="PublicKeyCredentialType">
     This enumeration defines the valid credential types. It is an extension point; values can be added to it in the future, as
     more credential types are defined. The values of this enumeration are used for versioning the Authentication Assertion and
     attestation structures according to the type of the authenticator.
 
     Currently one credential type is defined, namely "<dfn>public-key</dfn>".
+
 </div>
 
 
@@ -3070,14 +3091,14 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     };
 </xmp>
 
+Note: The {{AuthenticatorTransport}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+
 <div dfn-type="enum-value" dfn-for="AuthenticatorTransport">
     [=Authenticators=] may implement various [[#enum-transport|transports]] for communicating with [=clients=]. This enumeration
     defines hints as to how clients might communicate with a particular authenticator in order to obtain an assertion for a
     specific credential. Note that these hints represent the [=[WRP]=]'s best belief as to how an authenticator may be reached. A
     [=[RP]=] will typically learn of the supported transports for a [=public key credential=] via
     {{AuthenticatorAttestationResponse/getTransports()}}.
-
-    Note: The {{AuthenticatorTransport}} enumeration is not referenced by other parts of the Web IDL because that would preclude other values from being used without updating this specification and its implementations. It is important for backwards compatibility that [=client platforms=] and [=[RPS]=] handle unknown values. Therefore it exists here for documentation and as a registry. Where transports are represented elsewhere, they are typed as {{DOMString}}s, for example in {{PublicKeyCredentialDescriptor/transports}}.
 
     :   <dfn>usb</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over removable USB.
@@ -3120,6 +3141,8 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
 A [=[WRP]=] may require [=user verification=] for some of its operations but not for others, and may use this type to express its
 needs.
+
+Note: The {{UserVerificationRequirement}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
 
 <div dfn-type="enum-value" dfn-for="UserVerificationRequirement">
     :   <dfn>required</dfn>

--- a/index.bs
+++ b/index.bs
@@ -2814,7 +2814,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     };
 
     dictionary TokenBinding {
-        required TokenBindingStatus status;
+        required DOMString status;
         DOMString id;
     };
 
@@ -2845,7 +2845,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
 
         <div dfn-type="dict-member" dfn-for="TokenBinding">
             :   <dfn>status</dfn>
-            ::  This member is one of the following:
+            ::  This member SHOULD be a member of {{TokenBindingStatus}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the {{CollectedClientData/tokenBinding}} member was absent. When known, this member is one of the following:
 
                 <div dfn-type="enum-value" dfn-for="TokenBindingStatus">
                     :   <dfn>supported</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1783,7 +1783,7 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                         ::  |attestationObject|
 
                         :   {{AuthenticatorAttestationResponse/[[transports]]}}
-                        ::  A sequence of zero or more unique {{DOMString}}s, in lexicographical order, that the |authenticator| is believed to support. The values SHOULD be members of {{AuthenticatorTransport}}.
+                        ::  A sequence of zero or more unique {{DOMString}}s, in lexicographical order, that the |authenticator| is believed to support. The values SHOULD be members of {{AuthenticatorTransport}}, but [=client platforms=] MUST ignore unknown values.
 
                             If a user agent does not wish to divulge this information it MAY substitute an arbitrary sequence designed to preserve privacy. This sequence MUST still be valid, i.e. lexicographically sorted and free of duplicates. For example, it may use the empty sequence. Either way, in this case the user agent takes the risk that [=[RP]=] behavior may be suboptimal.
 

--- a/index.bs
+++ b/index.bs
@@ -2339,7 +2339,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 
 <xmp class="idl">
     dictionary PublicKeyCredentialParameters {
-        required PublicKeyCredentialType      type;
+        required DOMString                    type;
         required COSEAlgorithmIdentifier      alg;
     };
 </xmp>
@@ -2348,7 +2348,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     This dictionary is used to supply additional parameters when creating a new credential.
 
     :   <dfn>type</dfn>
-    ::  This member specifies the type of credential to be created.
+    ::  This member specifies the type of credential to be created. The value SHOULD be a member of {{PublicKeyCredentialType}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
 
     :   <dfn>alg</dfn>
     ::  This member specifies the cryptographic signature algorithm with which the newly generated credential will be used, and

--- a/index.bs
+++ b/index.bs
@@ -295,7 +295,7 @@ spec:html; type:dfn; for:environment settings object; text:global object
 spec:infra; type:dfn; for:/; text:set
 spec:infra; type:dfn; text:list
 spec:infra; type:dfn; for:struct; text:item
-spec:infra; type:dfn; for:map-exists; text:exists
+spec:infra; type:dfn; for:map; text:exists
 spec:url; type:dfn; text:domain
 spec:url; type:dfn; for:url; text:host
 spec:url; type:dfn; text:valid domain;
@@ -2418,7 +2418,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 
     :   <dfn>attestation</dfn>
     ::  This member is intended for use by [=[RPS]=] that wish to express their preference for [=attestation conveyance=].
-        The value SHOULD be a member of {{AttestationConveyancePreference}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset. The default is {{AttestationConveyancePreference/none}}.
+        The value SHOULD be a member of {{AttestationConveyancePreference}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=]. The default is {{AttestationConveyancePreference/none}}.
 
     :   <dfn>extensions</dfn>
     ::  This member contains additional parameters requesting additional processing by the client and authenticator. For
@@ -2554,7 +2554,7 @@ attributes.
 <div dfn-type="dict-member" dfn-for="AuthenticatorSelectionCriteria">
     :   <dfn>authenticatorAttachment</dfn>
     ::  If this member is [=present|present=], eligible authenticators are filtered to only authenticators attached with the
-        specified [[#enum-attachment]]. The value SHOULD be a member of {{AuthenticatorAttachment}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
+        specified [[#enum-attachment]]. The value SHOULD be a member of {{AuthenticatorAttachment}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=].
 
     :   <dfn>requireResidentKey</dfn>
     ::  Note: This member is retained for backwards compatibility with WebAuthn Level 1 but is deprecated in favour of {{residentKey}}.
@@ -2569,12 +2569,12 @@ attributes.
     ::  Note: This member supersedes {{requireResidentKey}}. If both are present and the [=client=] understands {{residentKey}}, then
         {{residentKey}} is used and {{requireResidentKey}} is ignored.
 
-        The value SHOULD be a member of {{ResidentKeyRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset. See {{ResidentKeyRequirement}} for the description of {{residentKey}}'s values and semantics.
+        The value SHOULD be a member of {{ResidentKeyRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=]. See {{ResidentKeyRequirement}} for the description of {{residentKey}}'s values and semantics.
 
     :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/create()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
-        requirement. The value SHOULD be a member of {{UserVerificationRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
+        requirement. The value SHOULD be a member of {{UserVerificationRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=].
 </div>
 
 
@@ -2715,7 +2715,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
 
     :   <dfn>userVerification</dfn>
     ::  This OPTIONAL member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
-        {{CredentialsContainer/get()}} operation. The value SHOULD be a member of {{UserVerificationRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset. Eligible authenticators are filtered to only those capable of satisfying this requirement.
+        {{CredentialsContainer/get()}} operation. The value SHOULD be a member of {{UserVerificationRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=]. Eligible authenticators are filtered to only those capable of satisfying this requirement.
 
     :   <dfn>extensions</dfn>
     ::  This OPTIONAL member contains additional parameters requesting additional processing by the client and authenticator.
@@ -2845,7 +2845,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
 
         <div dfn-type="dict-member" dfn-for="TokenBinding">
             :   <dfn>status</dfn>
-            ::  This member SHOULD be a member of {{TokenBindingStatus}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the {{CollectedClientData/tokenBinding}} member was absent. When known, this member is one of the following:
+            ::  This member SHOULD be a member of {{TokenBindingStatus}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the {{CollectedClientData/tokenBinding}} [=map/exist|member does not exist=]. When known, this member is one of the following:
 
                 <div dfn-type="enum-value" dfn-for="TokenBindingStatus">
                     :   <dfn>supported</dfn>

--- a/index.bs
+++ b/index.bs
@@ -2299,7 +2299,7 @@ during registration.
     ::  This operation returns the value of {{AuthenticatorAttestationResponse/[[transports]]}}.
 
     :   <dfn>\[[transports]]</dfn>
-    ::  This [=internal slot=] contains a sequence of zero or more unique {{DOMString}}s in lexicographical order. These values are the transports that the [=authenticator=] is believed to support, or an empty sequence if the information is unavailable. The values SHOULD be members of {{AuthenticatorTransport}} but [=[RPS]=] MUST accept unknown values.
+    ::  This [=internal slot=] contains a sequence of zero or more unique {{DOMString}}s in lexicographical order. These values are the transports that the [=authenticator=] is believed to support, or an empty sequence if the information is unavailable. The values SHOULD be members of {{AuthenticatorTransport}} but [=[RPS]=] MUST ignore unknown values.
 </div>
 
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}

--- a/index.bs
+++ b/index.bs
@@ -2544,17 +2544,17 @@ attributes.
 
 <xmp class="idl">
     dictionary AuthenticatorSelectionCriteria {
-        AuthenticatorAttachment      authenticatorAttachment;
+        DOMString                    authenticatorAttachment;
         boolean                      requireResidentKey = false;
         ResidentKeyRequirement       residentKey;
-        UserVerificationRequirement  userVerification = "preferred";
+        DOMString                    userVerification = "preferred";
     };
 </xmp>
 
 <div dfn-type="dict-member" dfn-for="AuthenticatorSelectionCriteria">
     :   <dfn>authenticatorAttachment</dfn>
     ::  If this member is [=present|present=], eligible authenticators are filtered to only authenticators attached with the
-        specified [[#enum-attachment]].
+        specified [[#enum-attachment]]. The value SHOULD be a member of {{AuthenticatorAttachment}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
 
     :   <dfn>requireResidentKey</dfn>
     ::  Note: This member is retained for backwards compatibility with WebAuthn Level 1 but is deprecated in favour of {{residentKey}}.
@@ -2574,7 +2574,7 @@ attributes.
     :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
         {{CredentialsContainer/create()}} operation. Eligible authenticators are filtered to only those capable of satisfying this
-        requirement.
+        requirement. The value SHOULD be a member of {{UserVerificationRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -2895,7 +2895,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
 
 <xmp class="idl">
     dictionary PublicKeyCredentialDescriptor {
-        required PublicKeyCredentialType      type;
+        required DOMString                    type;
         required BufferSource                 id;
         sequence<DOMString>                   transports;
     };
@@ -2907,7 +2907,7 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialDescriptor">
     :   <dfn>type</dfn>
-    ::  This member contains the type of the [=public key credential=] the caller is referring to.
+    ::  This member contains the type of the [=public key credential=] the caller is referring to. The value SHOULD be a member of {{PublicKeyCredentialType}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset.
 
     :   <dfn>id</dfn>
     ::  This member contains the [=credential ID=] of the [=public key credential=] the caller is referring to.

--- a/index.bs
+++ b/index.bs
@@ -2546,7 +2546,7 @@ attributes.
     dictionary AuthenticatorSelectionCriteria {
         DOMString                    authenticatorAttachment;
         boolean                      requireResidentKey = false;
-        ResidentKeyRequirement       residentKey;
+        DOMString                    residentKey;
         DOMString                    userVerification = "preferred";
     };
 </xmp>
@@ -2569,7 +2569,7 @@ attributes.
     ::  Note: This member supersedes {{requireResidentKey}}. If both are present and the [=client=] understands {{residentKey}}, then
         {{residentKey}} is used and {{requireResidentKey}} is ignored.
 
-        See {{ResidentKeyRequirement}} for the description of {{residentKey}}'s values and semantics.
+        The value SHOULD be a member of {{ResidentKeyRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the member was unset. See {{ResidentKeyRequirement}} for the description of {{residentKey}}'s values and semantics.
 
     :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the


### PR DESCRIPTION
This fixes issue #1376, auditing all enums passed into WebAuthn to ensure that WebAuthn can be extended without causing WebIDL failures for lagging implementations.

I believe I caught them all. I prefixed all the targets with `>>` in the list below:

```
dictionary PublicKeyCredentialCreationOptions {
    required PublicKeyCredentialRpEntity         rp;
    required PublicKeyCredentialUserEntity       user;

    required BufferSource                             challenge;
    required sequence<PublicKeyCredentialParameters>  pubKeyCredParams;

    unsigned long                                timeout;
    sequence<PublicKeyCredentialDescriptor>      excludeCredentials = [];
    AuthenticatorSelectionCriteria               authenticatorSelection;
>>    AttestationConveyancePreference              attestation = "none";
    AuthenticationExtensionsClientInputs         extensions;
};


dictionary PublicKeyCredentialRequestOptions {
    required BufferSource                challenge;
    unsigned long                        timeout;
    USVString                            rpId;
    sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
>>    UserVerificationRequirement          userVerification = "preferred";
    AuthenticationExtensionsClientInputs extensions;
};

dictionary AuthenticatorSelectionCriteria {
>>    AuthenticatorAttachment      authenticatorAttachment;
    boolean                      requireResidentKey = false;
>>    UserVerificationRequirement  userVerification = "preferred";
};

dictionary PublicKeyCredentialDescriptor {
>>    required PublicKeyCredentialType      type;
    required BufferSource                 id;
    sequence<DOMString>                   transports;
};

dictionary TokenBinding {
>>    required TokenBindingStatus status;
    DOMString id;
};

dictionary PublicKeyCredentialParameters {
>>    required PublicKeyCredentialType      type;
    required COSEAlgorithmIdentifier      alg;
};
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jcjones/webauthn/pull/1392.html" title="Last updated on May 15, 2020, 6:04 PM UTC (42dbe07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1392/d530669...jcjones:42dbe07.html" title="Last updated on May 15, 2020, 6:04 PM UTC (42dbe07)">Diff</a>