### PR TITLE
Prohibit Create Credential from cross-origin iframes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3009,9 +3009,9 @@ needs.
 
 ## Feature Policy integration ## {#sctn-feature-policy}
 
-This specification defines a [=policy-controlled feature=] identified by
-the feature-identifier token "<code><dfn data-lt="publickey-credentials-feature" export>publickey-credentials</dfn></code>".
-Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
+This specification defines two [=policy-controlled features=] identified by
+the feature-identifier tokens "<code><dfn data-lt="publickey-credentials-get-feature" export>publickey-credentials-get</dfn></code>" and "<code><dfn data-lt="publickey-credentials-create-feature" export>publickey-credentials-create</dfn></code>".
+Their [=default allowlists=] are '<code>self</code>'. [[!Feature-Policy]]
 
 A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
 [=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via
@@ -3026,9 +3026,9 @@ Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual fe
 ## Using Web Authentication within <code>iframe</code> elements ## {#sctn-iframe-guidance}
 
 The [=Web Authentication API=] is disabled by default in cross-origin <{iframe}>s.
-To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=], specify the <{iframe/allow}> attribute on the <{iframe}> element and include the <code><a data-lt="publickey-credentials-feature">publickey-credentials</a></code> feature-identifier token in the <{iframe/allow}> attribute's value.
+To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=]'s {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method, specify the <{iframe/allow}> attribute on the <{iframe}> element and include the <code><a data-lt="publickey-credentials-get-feature">publickey-credentials-get</a></code> feature-identifier token in the <{iframe/allow}> attribute's value.
 
-
+Note: The <code><a data-lt="publickey-credentials-create-feature">publickey-credentials-create</a></code> feature-identifier token is reserved for future use.
 
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}

--- a/index.bs
+++ b/index.bs
@@ -1428,6 +1428,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialCreationOptions/publicKey}}</code> is [=present=].
 
+1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], return a "{{NotAllowedError}}" {{DOMException}}.
+
+    Note: This "sameOriginWithAncestors" restriction aims to address a tracking concern raised in [Issue #1336](https://github.com/w3c/webauthn/issues/1336). This may be revised in future versions of this specification.
+
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
 1. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is [=present=], check if its value lies within a
@@ -3011,7 +3015,6 @@ Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
 A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
 [=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via
-<code><a idl for="CredentialsContainer" lt="create()">navigator.credentials.create({publicKey:..., ...})</a></code> and
 <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code>.
 If disabled in any document, no content in the document will be [=allowed to use=]
 the foregoing methods: attempting to do so will [return an error](https://www.w3.org/2001/tag/doc/promises-guide#errors).

--- a/index.bs
+++ b/index.bs
@@ -3009,9 +3009,9 @@ needs.
 
 ## Feature Policy integration ## {#sctn-feature-policy}
 
-This specification defines two [=policy-controlled features=] identified by
-the feature-identifier tokens "<code><dfn data-lt="publickey-credentials-get-feature" export>publickey-credentials-get</dfn></code>" and "<code><dfn data-lt="publickey-credentials-create-feature" export>publickey-credentials-create</dfn></code>".
-Their [=default allowlists=] are '<code>self</code>'. [[!Feature-Policy]]
+This specification defines one [=policy-controlled features=] identified by
+the feature-identifier token "<code><dfn data-lt="publickey-credentials-feature" export>publickey-credentials-get</dfn></code>".	
+Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
 
 A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
 [=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via
@@ -3028,7 +3028,6 @@ Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual fe
 The [=Web Authentication API=] is disabled by default in cross-origin <{iframe}>s.
 To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=]'s {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method, specify the <{iframe/allow}> attribute on the <{iframe}> element and include the <code><a data-lt="publickey-credentials-get-feature">publickey-credentials-get</a></code> feature-identifier token in the <{iframe/allow}> attribute's value.
 
-Note: The <code><a data-lt="publickey-credentials-create-feature">publickey-credentials-create</a></code> feature-identifier token is reserved for future use.
 
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}


### PR DESCRIPTION
This reverts part of PR #1276, again prohibiting the use of the Create method when `sameOriginWithAncestors` is `false`. The `Note` is simplified, since the integration between Credential Management and Feature Policy is now complete.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jcjones/webauthn/pull/1394.html" title="Last updated on Apr 8, 2020, 7:02 PM UTC (1c16985)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1394/a636817...jcjones:1c16985.html" title="Last updated on Apr 8, 2020, 7:02 PM UTC (1c16985)">Diff</a>