### PR TITLE
use '(client-side) discoverable credential' terminology

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -979,25 +979,35 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: This refers in general to the combination of the user's [=client platform=], [=authenticators=], and everything gluing
     it all together.
 
-: <dfn>Client-side-resident Public Key Credential Source</dfn>
-: <dfn>Resident Credential</dfn>
-:: A [=Client-side-resident Public Key Credential Source=], or [=Resident Credential=] for short,
-    is a [=public key credential source=] that is discoverable and usable in [=authentication ceremonies=]
-    without providing [=credential ID=]s,
-    i.e., calling {{CredentialsContainer/get()|navigator.credentials.get()}}
-    with an [=list/is empty|empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+: <dfn>Client-side discoverable Public Key Credential Source</dfn>
+: <dfn>Client-side discoverable Credential</dfn>
+: <dfn>Discoverable Credential</dfn>
+: \[DEPRECATED] <dfn>Resident Credential</dfn>
+: <dfn>Resident Key</dfn>
+:: Note: Historically, [=client-side discoverable credentials=] have  been known as [=resident credentials=] or [=resident keys=].
+    Due to the phrases `ResidentKey` and `residentKey` being widely used in both the [=web authentication api|WebAuthn 
+    API=] and also in the [=Authenticator Model=], e.g., in dictionary member names, algorithm variable names, and 
+    operation parameters, the latter usage of `resident` within their 
+    names has not been changed, i.e., for backwards compatibility purposes. Also, the term [=resident key=] is
+    defined here as equivalent to a [=client-side discoverable credential=].
 
-    As a consequence, a [=resident credential capable=] [=authenticator=] can generate an [=assertion signature=]
-    for a [=resident credential=] given only an [=RP ID=],
+    A [=Client-side discoverable Public Key Credential Source=], or [=Discoverable Credential=] for short,
+    is a [=public key credential source=] that is <strong><em>discoverable</em></strong> and usable in [=authentication ceremonies=]
+    where the [=[RP]=] does not provide any [=credential ID=]s,
+    i.e., the [=[RP]=] invokes {{CredentialsContainer/get()|navigator.credentials.get()}}
+    with an <strong><em>[=list/is empty|empty=]</em></strong> {{PublicKeyCredentialRequestOptions/allowCredentials}} argument. This means that the [=[RP]=] does not necessarily need to first disambiguate the user.
+
+    As a consequence, a [=discoverable credential capable=] [=authenticator=] can generate an [=assertion signature=]
+    for a [=discoverable credential=] given only an [=RP ID=],
     which in turn means that the [=public key credential source=]
     is stored in the [=authenticator=] or [=client platform=].
-    This is in contrast to a [=server-side-resident public key credential source=],
+    This is in contrast to a [=server-side discoverable public key credential source=],
     which requires that the [=authenticator=] is given both the [=RP ID=] and the [=credential ID=]
     but does not require [=client-side=] storage of the [=public key credential source=].
 
     See also: [=client-side credential storage modality=].
 
-    Note: [=Resident credentials=] are also usable in [=authentication ceremonies=] where [=credential ID=]s are given,
+    Note: [=Client-side discoverable credentials=] are also usable in [=authentication ceremonies=] where [=credential ID=]s are given,
     i.e., when calling {{CredentialsContainer/get()|navigator.credentials.get()}}
     with a non-[=list/is empty|empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
 
@@ -1041,7 +1051,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Credential Properties</dfn>
 :: A [=credential property=] is some characteristic property of a [=public key credential source=], such as whether it is a
-    [=resident credential=] or a [=non-resident credential=].
+    [=client-side discoverable credential=] or a [=server-side credential=].
 
 : <dfn>Human Palatability</dfn>
 :: An identifier that is [=human palatability|human-palatable=] is intended to be rememberable and reproducible by typical human
@@ -1149,18 +1159,27 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         These restrictions on origin values apply to [=WebAuthn Clients=]. If other specifications mimic the [=Web Authentication API=] to make WebAuthn [=credentials=] usable on other platforms (e.g. native mobile applications), they might have different rules for binding a caller to a [=Relying Party Identifier=]. Such rules are outside the scope of this specification.
     </div>
 
-: <dfn>Server-side-resident Public Key Credential Source</dfn>
-: <dfn>Non-Resident Credential</dfn>
-:: A [=Server-side-resident Public Key Credential Source=], or [=Non-Resident Credential=] for short,
-    is a [=public key credential source=] that cannot be used in an [=authentication ceremony=]
-    without providing the [=authenticator=] with the [=credential ID=], e.g.,
-    the credential is only usable when its [=credential ID=] is specified in the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument.
+: <dfn>Server-side discoverable Public Key Credential Source</dfn>
+: <dfn>Server-side Credential</dfn>
+: \[DEPRECATED] <dfn>Non-Resident Credential</dfn>
+:: Note: Historically, [=server-side credentials=] have been known as [=non-resident credentials=].
+    For backwards compatibility purposes, the various [=web authentication api|WebAuthn API=] and
+    [=Authenticator Model=] components
+    having various forms of `resident` within their names have not been changed.
 
-    As a consequence, [=client-side=] storage of the [=public key credential source=]
-    is not required for a [=non-resident credential=].
-    This is in contrast to a [=client-side-resident public key credential source=],
-    which does not require the [=credential ID=] to be provided
-    but instead requires [=client-side=] storage of the [=public key credential source=].
+    A [=Server-side discoverable Public Key Credential Source=], or [=Server-side Credential=] for short,
+    is a [=public key credential source=] that is only usable in an [=authentication ceremony=]
+    when the [=[RP]=] supplies its [=credential ID=] in {{CredentialsContainer/get()|navigator.credentials.get()}}'s
+    {{PublicKeyCredentialRequestOptions/allowCredentials}} argument. This means that the [=[RP]=] must
+    manage the credential's storage and discovery, as well as be able to first disambiguate the user in order to
+    discover the the user's credential, and supply it in the
+    {{CredentialsContainer/get()|navigator.credentials.get()}} call.
+
+    [=Client-side=] storage of the [=public key credential source=]
+    is not required for a [=server-side credential=].
+    This is in contrast to a [=client-side discoverable credential=],
+    which does not require the user to first be disambiguated in order to provide the user's [=credential ID=]s
+    to a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
     See also: [=server-side credential storage modality=].
 
@@ -1587,7 +1606,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                       <dl class="switch">
                           :   is present and set to {{ResidentKeyRequirement/required}}
-                          ::  If the |authenticator| is not capable of storing a [=client-side-resident public key credential
+                          ::  If the |authenticator| is not capable of storing a [=client-side discoverable public key credential
                               source=], [=iteration/continue=].
 
                           :   is present and set to {{ResidentKeyRequirement/preferred}} or {{ResidentKeyRequirement/discouraged}}
@@ -1595,7 +1614,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                           :   is [=not present=]
                           ::  if <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>
-                              is set to [TRUE] and the |authenticator| is not capable of storing a [=client-side-resident public
+                              is set to [TRUE] and the |authenticator| is not capable of storing a [=client-side discoverable public
                               key credential source=], [=iteration/continue=].
                       </dl>
 
@@ -2561,8 +2580,8 @@ attributes.
         {{requireResidentKey}} is ignored if the caller supplies {{residentKey}} and the latter is understood by the [=client=].
         Otherwise, {{requireResidentKey}}'s value is used. Note that {{requireResidentKey}}'s value defaults to [FALSE].
 
-        If used in absence of {{residentKey}}, it describes the [=[RP]=]'s requirements regarding [=resident credentials=].
-        If {{requireResidentKey}} is set to [TRUE], the authenticator MUST create a [=client-side-resident public key credential source=]
+        If used in absence of {{residentKey}}, it describes the [=[RP]=]'s requirements regarding [=client-side discoverable credentials=].
+        If {{requireResidentKey}} is set to [TRUE], the authenticator MUST create a [=client-side discoverable public key credential source=]
         when creating a [=public key credential=].
 
     :   <dfn>residentKey</dfn>
@@ -2618,27 +2637,27 @@ credential|credentials=]. The [=client=] and user will then use whichever is ava
     };
 </xmp>
 
-This enumeration's values describe the [=[RP]=]'s requirements for [=resident credentials=]:
+This enumeration's values describe the [=[RP]=]'s requirements for [=client-side discoverable credentials=] (formerly known as [=resident credentials=] or [=resident keys=]):
 
 <div dfn-type="enum-value" dfn-for="ResidentKeyRequirement">
     :   <dfn>discouraged</dfn>
-    ::  This value indicates the [=[RP]=] prefers creating a [=non-resident credential=], but will accept a
-        [=resident credential=].
+    ::  This value indicates the [=[RP]=] prefers creating a [=server-side credential=], but will accept a
+        [=client-side discoverable credential=].
 
     :   <dfn>preferred</dfn>
-    ::  This value indicates the [=[RP]=] prefers creating a [=resident credential=], but will accept a
-        [=non-resident credential=].
+    ::  This value indicates the [=[RP]=] prefers creating a [=client-side discoverable credential=], but will accept a
+        [=server-side credential=].
 
     :   <dfn>required</dfn>
-    ::  This value indicates the [=[RP]=] requires a [=resident credential=], and is prepared to receive an error
-        if a [=resident credential=] cannot be created.
+    ::  This value indicates the [=[RP]=] requires a [=client-side discoverable credential=], and is prepared to receive an error
+        if a [=client-side discoverable credential=] cannot be created.
 </div>
 
-Note: The [=[RP]=] can use a combination of the value provided for |options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}
-and the [=credProps|Credential Properties Extension=]'s return value to determine  whether or not the authenticator created a [=resident credential=].
-This is useful when values of  {{ResidentKeyRequirement/discouraged}} or {{ResidentKeyRequirement/preferred}} are used for
-|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}, because in those cases it is possible for an
-[=authenticator=] to create either a [=resident credential=] or a [=non-resident credential=].
+Note: The [=[RP]=] can use a combination of the values provided for <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
+and the [=credProps|Credential Properties Extension=]'s return value to determine  whether or not the authenticator created a [=client-side discoverable credential=].
+This is useful when values of {{ResidentKeyRequirement/discouraged}} or {{ResidentKeyRequirement/preferred}} are used for
+<code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>, because in those cases it is possible for an
+[=authenticator=] to create either a [=client-side discoverable credential=] or a [=server-side credential=].
 
 
 ### <dfn>Attestation Conveyance</dfn> Preference Enumeration (enum <dfn enum>AttestationConveyancePreference</dfn>) ### {#enum-attestation-convey}
@@ -3276,7 +3295,7 @@ For example:
     since it's built directly into the [=client device=] rather than being a separate device that the user may have to locate.
 - For [=second-factor=] authentication in addition to a traditional username and password, any [=authenticator=] can be used.
 - Passwordless [=multi-factor=] authentication requires an [=authenticator=]
-    capable of [=user verification=], and in some cases also [=resident credential capable=].
+    capable of [=user verification=], and in some cases also [=discoverable credential capable=].
 - A laptop computer might support connecting to [=roaming authenticators=] via USB and Bluetooth,
     while a mobile phone might only support NFC.
 
@@ -3286,7 +3305,7 @@ The above examples illustrate the the primary <dfn>authenticator type</dfn> char
     &mdash; the [=authenticator attachment modality=].
     A [=roaming authenticator=] can support one or more [[#enum-transport|transports]] for communicating with the [=client=].
 - Whether the authenticator is capable of [=user verification=] &mdash; the [=authentication factor capability=].
-- Whether the authenticator is [=resident credential capable=] &mdash; the [=credential storage modality=].
+- Whether the authenticator is [=discoverable credential capable=] &mdash; the [=credential storage modality=].
 
 These characteristics are independent and may in theory be combined in any way,
 but <a href="#table-authenticatorTypes">Table <span class="table-ref-following"/></a>
@@ -3356,12 +3375,12 @@ have less distinguished use cases:
 - The [=credential storage modality=] is less relevant for a [=platform authenticator=] than for a [=roaming authenticator=],
     since users using a [=platform authenticator=] can typically be identified by a session cookie or the like
     (i.e., ambient credentials).
-- A [=roaming authenticator=] that is [=resident credential capable=] but not [=multi-factor capable=]
+- A [=roaming authenticator=] that is [=discoverable credential capable=] but not [=multi-factor capable=]
     can be used for [=single-factor=] authentication without a username,
     where the user is automatically identified by the [=user handle=]
     and possession of the [=credential private key=] is used as the only [=authentication factor=].
     This can be useful in some situations, but makes the user particularly vulnerable to theft of the [=authenticator=].
-- A [=roaming authenticator=] that is [=multi-factor capable=] but not [=resident credential capable=]
+- A [=roaming authenticator=] that is [=multi-factor capable=] but not [=discoverable credential capable=]
     can be used for [=multi-factor=] authentication, but requires the user to be identified first
     which risks leaking [PII]; see [[#sctn-credential-id-privacy-leak]].
 
@@ -3412,7 +3431,7 @@ backup [=public key credential|credentials=] in case another [=authenticator=] i
 An [=authenticator=] can store a [=public key credential source=] in one of two ways:
 
  1. In persistent storage embedded in the [=authenticator=], [=client=] or [=client device=], e.g., in a secure element.
-    This is a technical requirement for a [=client-side-resident public key credential source=].
+    This is a technical requirement for a [=client-side discoverable public key credential source=].
 
  1. By encrypting (i.e., wrapping) the [=credential private key=] such that only this [=authenticator=] can decrypt (i.e., unwrap) it and letting the resulting
     ciphertext be the [=credential ID=] for the [=public key credential source=]. The [=credential ID=] is stored by the [=[RP]=]
@@ -3426,14 +3445,14 @@ An [=authenticator=] can store a [=public key credential source=] in one of two 
 Which of these storage strategies an [=authenticator=] supports defines the [=authenticator=]'s <dfn>credential storage
 modality</dfn> as follows:
 
-- An [=authenticator=] has the <dfn>client-side credential storage modality</dfn> if it supports [=client-side-resident public key
-    credential sources=]. An [=authenticator=] with [=client-side credential storage modality=] is also called <dfn>resident
+- An [=authenticator=] has the <dfn>client-side credential storage modality</dfn> if it supports [=client-side discoverable public key
+    credential sources=]. An [=authenticator=] with [=client-side credential storage modality=] is also called <dfn>discoverable
     credential capable</dfn>.
 
 - An [=authenticator=] has the <dfn>server-side credential storage modality</dfn> if it does not have the [=client-side credential storage
     modality=], i.e., it only supports storing [=credential private keys=] as a ciphertext in the [=credential ID=].
 
-Note that a [=resident credential capable=] [=authenticator=] MAY support both storage strategies. In this case, the [=authenticator=] MAY
+Note that a [=discoverable credential capable=] [=authenticator=] MAY support both storage strategies. In this case, the [=authenticator=] MAY
 at its discretion use different storage strategies for different [=public key credential|credentials=], though subject to the
 {{AuthenticatorSelectionCriteria/residentKey}} or {{AuthenticatorSelectionCriteria/requireResidentKey}} options of
 {{CredentialsContainer/create()}}.
@@ -3547,7 +3566,7 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
         is [=bound credential|bound=] to it,
         and responds as if the user simply declined consent to create a credential.
 
-1. If |requireResidentKey| is [TRUE] and the authenticator cannot store a [=client-side-resident public key credential source=],
+1. If |requireResidentKey| is [TRUE] and the authenticator cannot store a [=client-side discoverable public key credential source=],
     return an error code equivalent to "{{ConstraintError}}" and terminate the operation.
 1. If |requireUserVerification| is [TRUE] and the authenticator cannot perform [=user verification=], return an error code
     equivalent to "{{ConstraintError}}" and terminate the operation.
@@ -3589,7 +3608,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             : [=otherUI=]
             :: Any other information the authenticator chooses to include.
         </dl>
-    1. If |requireResidentKey| is [TRUE] or the authenticator chooses to create a [=client-side-resident public key credential source=]:
+    1. If |requireResidentKey| is [TRUE] or the authenticator chooses to create a [=client-side discoverable public key credential source=]:
         1. Let |credentialId| be a new [=credential id=].
         1. Set |credentialSource|.[=public key credential source/id=] to |credentialId|.
         1. Let |credentials| be this authenticator's [=credentials map=].
@@ -5771,7 +5790,8 @@ as candidates to be employed in a [=registration ceremony=].
 
 This [=client extension|client=] [=registration extension=] facilitates reporting certain [=credential properties=] known by the [=client=] to the requesting [=[WRP]=] upon creation of a [=public key credential source=] as a result of a [=registration ceremony=].
 
-At this time, one [=credential property=] is defined: the [=resident key credential property=].
+At this time, one [=credential property=] is defined: the [=resident key credential property=]
+(i.e., [=client-side discoverable credential property=]).
 
 : Extension identifier
 :: `credProps`
@@ -5805,12 +5825,13 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 
     <div dfn-type="dict-member" dfn-for="CredentialPropertiesOutput">
         :   <dfn>rk</dfn>
-        ::  This OPTIONAL property, known abstractly as the <dfn dfn-type="dfn">resident key credential property</dfn>,
+        ::  This OPTIONAL property, known abstractly as the <dfn dfn-type="dfn">resident key credential property</dfn>
+            (i.e., <dfn dfn-type="dfn">client-side discoverable credential property</dfn>),
             is a Boolean value indicating whether the {{PublicKeyCredential}} returned as a result of a [=registration ceremony=]
-            is a [=resident credential=].
-            If {{rk}} is [TRUE], the credential is a [=resident credential=];
-            if {{rk}} is [FALSE], the credential is a [=non-resident credential=].
-            If {{rk}} is [=not present=], it is not known whether the credential is a [=resident credential=] or a [=non-resident credential=].
+            is a [=client-side discoverable credential=].
+            If {{rk}} is [TRUE], the credential is a [=discoverable credential=];
+            if {{rk}} is [FALSE], the credential is a [=server-side credential=].
+            If {{rk}} is [=not present=], it is not known whether the credential is a [=discoverable credential=] or a [=server-side credential=].
     </div>
 
 
@@ -5878,7 +5899,7 @@ Each stored [=virtual authenticator=] has the following properties:
 :: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
     authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].
 : |hasResidentKey|
-:: If set to [TRUE] the authenticator will support [=resident credentials=].
+:: If set to [TRUE] the authenticator will support [=client-side discoverable credentials=].
 : |hasUserVerification|
 :: If set to [TRUE], the authenticator supports [=user verification=].
 : |isUserConsenting|
@@ -6062,7 +6083,7 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
             <tr>
                 <td>|isResidentCredential|</td>
                 <td>
-                    If set to [TRUE], a [=resident credential=] is created. If set to [FALSE], a [=non-resident credential=]
+                    If set to [TRUE], a [=client-side discoverable credential=] is created. If set to [FALSE], a [=server-side credential=]
                     is created instead.
                 </td>
                 <td>boolean</td>
@@ -6124,8 +6145,8 @@ The [=remote end steps=] are:
  1. Let |authenticator| be the [=Virtual Authenticator=] matched by |authenticatorId|.
  1. If |isResidentCredential| is [TRUE] and the |authenticator|'s |hasResidentKey| property is [FALSE], return a
      [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
- 1. Let |credential| be a new [=Client-side-resident Public Key Credential Source=] if |isResidentCredential| is [TRUE]
-     or a [=Server-side-resident Public Key Credential Source=] otherwise whose items are:
+ 1. Let |credential| be a new [=Client-side discoverable Public Key Credential Source=] if |isResidentCredential| is [TRUE]
+     or a [=Server-side discoverable Public Key Credential Source=] otherwise whose items are:
     : [=public key credential source/type=]
     :: {{public-key}}
     : [=public key credential source/id=]
@@ -6666,7 +6687,7 @@ authentication, they are designed to be minimally identifying and not shared bet
     or a small group of [=authenticators=]. This is detailed further in [[#sctn-attestation-privacy]]. A pair of malicious
     [=[RPS]=] thus cannot correlate users between their systems by tracking individual [=authenticators=].
 
-Additionally, a [=client-side-resident public key credential source=] can optionally include a [=user
+Additionally, a [=client-side discoverable public key credential source=] can optionally include a [=user
 handle=] specified by the [=[RP]=]. The [=public key credential|credential=] can then be used to both identify and
 [=authentication|authenticate=] the user. This means that a privacy-conscious [=[RP]=] can allow the user to create an account
 without a traditional username, further improving non-correlatability between [=[RPS]=].
@@ -6866,7 +6887,7 @@ leakage due to such an attack:
 
 This privacy consideration applies to [=[RPS]=] that support [=authentication ceremonies=]
 with a non-[=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument as the first authentication step.
-For example, if using authentication with [=non-resident credentials=] as the first authentication step.
+For example, if using authentication with [=server-side credentials=] as the first authentication step.
 
 In this case the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument risks leaking [PII],
 since it exposes the user's [=credential IDs=] to an unauthenticated caller.
@@ -6883,7 +6904,7 @@ In order to prevent such information leakage, the [=[RP]=] could for example:
 - Perform a separate authentication step,
     such as username and password authentication or session cookie authentication,
     before initiating the WebAuthn [=authentication ceremony=] and exposing the user's [=credential IDs=].
-- Use [=resident credentials=],
+- Use [=client-side discoverable credentials=],
     so the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument is not needed.
 
 If the above prevention measures are not available,

--- a/index.bs
+++ b/index.bs
@@ -995,7 +995,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     is a [=public key credential source=] that is <strong><em>discoverable</em></strong> and usable in [=authentication ceremonies=]
     where the [=[RP]=] does not provide any [=credential ID=]s,
     i.e., the [=[RP]=] invokes {{CredentialsContainer/get()|navigator.credentials.get()}}
-    with an <strong><em>[=list/is empty|empty=]</em></strong> {{PublicKeyCredentialRequestOptions/allowCredentials}} argument. This means that the [=[RP]=] does not necessarily need to first disambiguate the user.
+    with an <strong><em>[=list/is empty|empty=]</em></strong> {{PublicKeyCredentialRequestOptions/allowCredentials}} argument. This means that the [=[RP]=] does not necessarily need to first identify the user.
 
     As a consequence, a [=discoverable credential capable=] [=authenticator=] can generate an [=assertion signature=]
     for a [=discoverable credential=] given only an [=RP ID=],

--- a/index.bs
+++ b/index.bs
@@ -987,8 +987,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 :: Note: Historically, [=client-side discoverable credentials=] have  been known as [=resident credentials=] or [=resident keys=].
     Due to the phrases `ResidentKey` and `residentKey` being widely used in both the [=web authentication api|WebAuthn 
     API=] and also in the [=Authenticator Model=] (e.g., in dictionary member names, algorithm variable names, and
-    operation parameters) the latter usage of `resident` within their
-    names has not been changed, i.e., for backwards compatibility purposes. Also, the term [=resident key=] is
+    operation parameters) the usage of `resident` within their
+    names has not been changed for backwards compatibility purposes. Also, the term [=resident key=] is
     defined here as equivalent to a [=client-side discoverable credential=].
 
     A [=Client-side discoverable Public Key Credential Source=], or [=Discoverable Credential=] for short,
@@ -1001,7 +1001,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     for a [=discoverable credential=] given only an [=RP ID=],
     which in turn necessitates that the [=public key credential source=]
     is stored in the [=authenticator=] or [=client platform=].
-    This is in contrast to a [=server-side discoverable public key credential source=],
+    This is in contrast to a [=Server-side Public Key Credential Source=],
     which requires that the [=authenticator=] is given both the [=RP ID=] and the [=credential ID=]
     but does not require [=client-side=] storage of the [=public key credential source=].
 
@@ -1159,26 +1159,26 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         These restrictions on origin values apply to [=WebAuthn Clients=]. If other specifications mimic the [=Web Authentication API=] to make WebAuthn [=credentials=] usable on other platforms (e.g. native mobile applications), they might have different rules for binding a caller to a [=Relying Party Identifier=]. Such rules are outside the scope of this specification.
     </div>
 
-: <dfn>Server-side discoverable Public Key Credential Source</dfn>
+: <dfn>Server-side Public Key Credential Source</dfn>
 : <dfn>Server-side Credential</dfn>
 : \[DEPRECATED] <dfn>Non-Resident Credential</dfn>
 :: Note: Historically, [=server-side credentials=] have been known as [=non-resident credentials=].
     For backwards compatibility purposes, the various [=web authentication api|WebAuthn API=] and
     [=Authenticator Model=] components
-    having various forms of `resident` within their names have not been changed.
+    with various forms of `resident` within their names have not been changed.
 
-    A [=Server-side discoverable Public Key Credential Source=], or [=Server-side Credential=] for short,
+    A [=Server-side Public Key Credential Source=], or [=Server-side Credential=] for short,
     is a [=public key credential source=] that is only usable in an [=authentication ceremony=]
     when the [=[RP]=] supplies its [=credential ID=] in {{CredentialsContainer/get()|navigator.credentials.get()}}'s
     {{PublicKeyCredentialRequestOptions/allowCredentials}} argument. This means that the [=[RP]=] must
     manage the credential's storage and discovery, as well as be able to first identify the user in order to
-    discover the user's credential, and supply it in the
+    discover the [=credential IDs=] to supply in the
     {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
     [=Client-side=] storage of the [=public key credential source=]
     is not required for a [=server-side credential=].
     This is in contrast to a [=client-side discoverable credential=],
-    which does not require the user to first be identified in order to provide the user's [=credential ID=]s
+    which instead does not require the user to first be identified in order to provide the user's [=credential ID=]s
     to a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
     See also: [=server-side credential storage modality=].
@@ -2653,8 +2653,8 @@ This enumeration's values describe the [=[RP]=]'s requirements for [=client-side
         if a [=client-side discoverable credential=] cannot be created.
 </div>
 
-Note: [=[RPS]=] can determine whether or not the authenticator created a [=client-side discoverable credential=] by evaluating the [=credProps|Credential Properties Extension=]'s return value in light of
-the value it provided for <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>.
+Note: [=[RPS]=] can determine whether or not the authenticator created a [=client-side discoverable credential=] by inspecting the [=credProps|Credential Properties Extension=]'s return value in light of
+the value provided for <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>.
 This is useful when values of {{ResidentKeyRequirement/discouraged}} or {{ResidentKeyRequirement/preferred}} are used for
 <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>, because in those cases it is possible for an
 [=authenticator=] to create <em>either</em> a [=client-side discoverable credential=] or a [=server-side credential=].
@@ -6146,7 +6146,7 @@ The [=remote end steps=] are:
  1. If |isResidentCredential| is [TRUE] and the |authenticator|'s |hasResidentKey| property is [FALSE], return a
      [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |credential| be a new [=Client-side discoverable Public Key Credential Source=] if |isResidentCredential| is [TRUE]
-     or a [=Server-side discoverable Public Key Credential Source=] otherwise whose items are:
+     or a [=Server-side Public Key Credential Source=] otherwise whose items are:
     : [=public key credential source/type=]
     :: {{public-key}}
     : [=public key credential source/id=]

--- a/index.bs
+++ b/index.bs
@@ -1172,7 +1172,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     when the [=[RP]=] supplies its [=credential ID=] in {{CredentialsContainer/get()|navigator.credentials.get()}}'s
     {{PublicKeyCredentialRequestOptions/allowCredentials}} argument. This means that the [=[RP]=] must
     manage the credential's storage and discovery, as well as be able to first disambiguate the user in order to
-    discover the the user's credential, and supply it in the
+    discover the user's credential, and supply it in the
     {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
     [=Client-side=] storage of the [=public key credential source=]

--- a/index.bs
+++ b/index.bs
@@ -999,7 +999,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
     As a consequence, a [=discoverable credential capable=] [=authenticator=] can generate an [=assertion signature=]
     for a [=discoverable credential=] given only an [=RP ID=],
-    which in turn means that the [=public key credential source=]
+    which in turn necessitates that the [=public key credential source=]
     is stored in the [=authenticator=] or [=client platform=].
     This is in contrast to a [=server-side discoverable public key credential source=],
     which requires that the [=authenticator=] is given both the [=RP ID=] and the [=credential ID=]

--- a/index.bs
+++ b/index.bs
@@ -1171,14 +1171,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     is a [=public key credential source=] that is only usable in an [=authentication ceremony=]
     when the [=[RP]=] supplies its [=credential ID=] in {{CredentialsContainer/get()|navigator.credentials.get()}}'s
     {{PublicKeyCredentialRequestOptions/allowCredentials}} argument. This means that the [=[RP]=] must
-    manage the credential's storage and discovery, as well as be able to first disambiguate the user in order to
+    manage the credential's storage and discovery, as well as be able to first identify the user in order to
     discover the user's credential, and supply it in the
     {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
     [=Client-side=] storage of the [=public key credential source=]
     is not required for a [=server-side credential=].
     This is in contrast to a [=client-side discoverable credential=],
-    which does not require the user to first be disambiguated in order to provide the user's [=credential ID=]s
+    which does not require the user to first be identified in order to provide the user's [=credential ID=]s
     to a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
     See also: [=server-side credential storage modality=].

--- a/index.bs
+++ b/index.bs
@@ -2653,11 +2653,11 @@ This enumeration's values describe the [=[RP]=]'s requirements for [=client-side
         if a [=client-side discoverable credential=] cannot be created.
 </div>
 
-Note: The [=[RP]=] can use a combination of the values provided for <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
-and the [=credProps|Credential Properties Extension=]'s return value to determine  whether or not the authenticator created a [=client-side discoverable credential=].
+Note: [=[RPS]=] can determine whether or not the authenticator created a [=client-side discoverable credential=] by evaluating the [=credProps|Credential Properties Extension=]'s return value in light of
+the value it provided for <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>.
 This is useful when values of {{ResidentKeyRequirement/discouraged}} or {{ResidentKeyRequirement/preferred}} are used for
 <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>, because in those cases it is possible for an
-[=authenticator=] to create either a [=client-side discoverable credential=] or a [=server-side credential=].
+[=authenticator=] to create <em>either</em> a [=client-side discoverable credential=] or a [=server-side credential=].
 
 
 ### <dfn>Attestation Conveyance</dfn> Preference Enumeration (enum <dfn enum>AttestationConveyancePreference</dfn>) ### {#enum-attestation-convey}

--- a/index.bs
+++ b/index.bs
@@ -983,11 +983,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Client-side discoverable Credential</dfn>
 : <dfn>Discoverable Credential</dfn>
 : \[DEPRECATED] <dfn>Resident Credential</dfn>
-: <dfn>Resident Key</dfn>
+: \[DEPRECATED] <dfn>Resident Key</dfn>
 :: Note: Historically, [=client-side discoverable credentials=] have  been known as [=resident credentials=] or [=resident keys=].
     Due to the phrases `ResidentKey` and `residentKey` being widely used in both the [=web authentication api|WebAuthn 
-    API=] and also in the [=Authenticator Model=], e.g., in dictionary member names, algorithm variable names, and 
-    operation parameters, the latter usage of `resident` within their 
+    API=] and also in the [=Authenticator Model=] (e.g., in dictionary member names, algorithm variable names, and
+    operation parameters) the latter usage of `resident` within their
     names has not been changed, i.e., for backwards compatibility purposes. Also, the term [=resident key=] is
     defined here as equivalent to a [=client-side discoverable credential=].
 


### PR DESCRIPTION
..rather than the 'resident credential' and 'resident key' terms.  Also changed 'non-resident credential' to 'server-side credential', along with other related fixups. Marked the former terms as DEPRECATED.

fixes #1379 (may only "improve" it due to not addressing the notion of "forbidden to create a client-side cred", though the latter perhaps ought to be in its own issue separate from #1379)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1398.html" title="Last updated on Apr 27, 2020, 8:24 PM UTC (2da3bdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1398/a636817...2da3bdd.html" title="Last updated on Apr 27, 2020, 8:24 PM UTC (2da3bdd)">Diff</a>