### PR TITLE
Add `largeBlob` extension.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -221,6 +221,7 @@ spec: FIDO-CTAP; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-ps-20190130
     type: dfn
         text: CTAP2 canonical CBOR encoding form; url: ctap2-canonical-cbor-encoding-form
         text: §6.2. Responses; url: responses
+        text: large, per-credential blobs; url: large-blob
 
 spec: FIDO-APPID; urlPrefix: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html
     type: dfn
@@ -5839,6 +5840,8 @@ Note: [=[RPS]=] can assume that the opaque data will be compressed when being wr
 Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension is not defined in the [=registration extension|registration=] context.
 
 Since certificates are sizable relative to the storage capabilities of typical authenticators, user agents SHOULD consider what indications and confirmations are suitable to best guide the user in allocating this limited resource and prevent abuse.
+
+Note: In order to interoperate, user agents storing large blobs on authenticators using [[!FIDO-CTAP]] are expected to use the provisions detailed in that specification for storing [=large, per-credential blobs=].
 
 : Extension identifier
 :: `largeBlob`

--- a/index.bs
+++ b/index.bs
@@ -5848,7 +5848,7 @@ This [=client extension|client=] [=registration extension=] and [=authentication
     };
     </xmp>
 
-    <div dfn-type="dict-member" dfn-for="CredentialPropertiesOutput">
+    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsClientInputs">
         :   <dfn>blobWrite</dfn>
         ::  An opaque byte string that the [=[WRP]=] wishes to store with the freshly created credential (in the [=registration extension=] case) or an existing credential (in the case of an [=authentication extension=]).
 
@@ -5857,7 +5857,7 @@ This [=client extension|client=] [=registration extension=] and [=authentication
     </div>
 
 : Client extension processing ([=registration extension|registration=])
-:: If {{AuthenticationExtensionsClientInputs/blobWrite}} is present, attempt to store its contents on the [=authenticator=], associated with the freshly created credential. Set {{AuthenticationExtensionsClientInputs/blobWritten}} to `true` if successful and `false` otherwise.
+:: If {{AuthenticationExtensionsClientInputs/blobWrite}} is present, attempt to store its contents on the [=authenticator=], associated with the freshly created credential. Set {{AuthenticationExtensionsClientOutputs}}.{{AuthenticationExtensionsClientOutputs/blobWritten}} to `true` if successful and `false` otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])
 ::
@@ -5876,12 +5876,12 @@ This [=client extension|client=] [=registration extension=] and [=authentication
     };
     </xmp>
 
-    <div dfn-type="dict-member" dfn-for="CredentialPropertiesOutput">
+    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsClientOutputs">
         :   <dfn>blob</dfn>
         ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid in the [=authentication extension=] case and only present if {{AuthenticationExtensionsClientInputs/blobRead}} was `true`.
 
         :   <dfn>blobWritten</dfn>
-        ::  A boolean that indicates that the contents of {{AuthenticationExtensionsClientInputs/blobWrite}} were successfully store on the [=authenticator=], associated with the specified extension.
+        ::  A boolean that indicates that the contents of {{AuthenticationExtensionsClientInputs/blobWrite}} were successfully stored on the [=authenticator=], associated with the specified extension.
     </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -5834,6 +5834,8 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 
 This [=client extension|client=] [=authentication extension=] allows a [=[RP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[RPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[RP]=] might wish to issue certificates rather than run a centralised authentication service.
 
+Note: [=[RPS]=] can assume that the opaque data will be compressed when being written to a space-limited device and so need not compress it themselves.
+
 Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension is not defined in the [=registration extension|registration=] context.
 
 Since certificates are sizable relative to the storage capabilities of typical authenticators, user agents SHOULD consider what indications and confirmations are suitable to best guide the user in allocating this limited resource and prevent abuse.

--- a/index.bs
+++ b/index.bs
@@ -5832,7 +5832,7 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 
 ## Large blob storage extension (<dfn>largeBlob</dfn>) ## {#sctn-large-blob-extension}
 
-This [=client extension|client=] [=authentication extension=] allows a [=[WRP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[WRPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[WRP]=] might wish to issue certificates rather than run a centralised authentication service.
+This [=client extension|client=] [=authentication extension=] allows a [=[RP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[RPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[RP]=] might wish to issue certificates rather than run a centralised authentication service.
 
 Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension is not defined in the [=registration extension|registration=] context.
 
@@ -5854,10 +5854,10 @@ Since certificates are sizable relative to the storage capabilities of typical a
 
     <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsClientInputs">
         :   <dfn>largeBlobWrite</dfn>
-        ::  An opaque byte string that the [=[WRP]=] wishes to store with the existing credential.
+        ::  An opaque byte string that the [=[RP]=] wishes to store with the existing credential.
 
         :   <dfn>largeBlobRead</dfn>
-        ::  A boolean that indicates that the [=[WRP]=] would like to fetch the previously-written blob associated with the asserted credential.
+        ::  A boolean that indicates that the [=[RP]=] would like to fetch the previously-written blob associated with the asserted credential.
     </div>
 
 : Client extension processing ([=authentication extension|authentication=])

--- a/index.bs
+++ b/index.bs
@@ -5849,53 +5849,55 @@ Since certificates are sizable relative to the storage capabilities of typical a
 : Client extension input
 ::  <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
-        ArrayBuffer largeBlobWrite;
-        boolean largeBlobRead;
+        AuthenticationExtensionsLargeBlobInputs largeBlob;
+    };
+
+    dictionary AuthenticationExtensionsLargeBlobInputs {
+        boolean read;
+        ArrayBuffer write;
     };
     </xmp>
 
-    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsClientInputs">
-        :   <dfn>largeBlobWrite</dfn>
-        ::  An opaque byte string that the [=[RP]=] wishes to store with the existing credential.
-
-        :   <dfn>largeBlobRead</dfn>
+    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsLargeBlobInputs">
+        :   <dfn>read</dfn>
         ::  A boolean that indicates that the [=[RP]=] would like to fetch the previously-written blob associated with the asserted credential.
+
+        :   <dfn>write</dfn>
+        ::  An opaque byte string that the [=[RP]=] wishes to store with the existing credential.
     </div>
 
 : Client extension processing ([=authentication extension|authentication=])
 ::
-       1. If {{AuthenticationExtensionsClientInputs/largeBlobRead}} is present and has the value `true`:
+       1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value `true`:
            1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to read any data associated with the asserted credential.
-           1. If successful, set {{AuthenticationExtensionsClientOutputs/largeBlob}} to the result.
-       1. If {{AuthenticationExtensionsClientInputs/largeBlobWrite}} is present, {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element, and {{AuthenticationExtensionsClientInputs/largeBlobRead}} is not present, or has the value `false`:
-           1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to store the contents of {{AuthenticationExtensionsClientInputs/largeBlobWrite}} on the [=authenticator=], associated with the indicated credential.
-           1. Set {{AuthenticationExtensionsClientOutputs/largeBlobWritten}} to `true` if successful and `false` otherwise.
+           1. If successful, set {{AuthenticationExtensionsLargeBlobOutputs/blob}} to the result.
+       1. If {{AuthenticationExtensionsLargeBlobInputs/write}} is present, {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element, and {{AuthenticationExtensionsLargeBlobInputs/read}} is not present, or has the value `false`:
+           1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to store the contents of {{AuthenticationExtensionsLargeBlobInputs/write}} on the [=authenticator=], associated with the indicated credential.
+           1. Set {{AuthenticationExtensionsLargeBlobOutputs/written}} to `true` if successful and `false` otherwise.
 
 : Client extension output
 :: <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-        ArrayBuffer largeBlob;
-        boolean largeBlobWritten;
+        AuthenticationExtensionsLargeBlobOutputs largeBlob;
+    };
+
+    dictionary AuthenticationExtensionsLargeBlobOutputs {
+        ArrayBuffer blob;
+        boolean written;
     };
     </xmp>
 
-    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsClientOutputs">
-        :   <dfn>largeBlob</dfn>
-        ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid in the [=authentication extension=] case and only present if {{AuthenticationExtensionsClientInputs/largeBlobRead}} was `true`.
+    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsLargeBlobOutputs">
+        :   <dfn>blob</dfn>
+        ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid if {{AuthenticationExtensionsLargeBlobInputs/read}} was `true`.
 
-        :   <dfn>largeBlobWritten</dfn>
-        ::  A boolean that indicates that the contents of {{AuthenticationExtensionsClientInputs/largeBlobWrite}} were successfully stored on the [=authenticator=], associated with the specified extension.
+        :   <dfn>written</dfn>
+        ::  A boolean that indicates that the contents of {{AuthenticationExtensionsLargeBlobInputs/write}} were successfully stored on the [=authenticator=], associated with the specified credential.
     </div>
 
 
-: Authenticator extension input
-:: None.
-
 : Authenticator extension processing
-:: None.
-
-: Authenticator extension output
-:: None.
+:: This extension directs the user-agent to cause the large blob to be stored on, or retrieved from, the authenticator. It thus does not specify any direct authenticator interaction for [=[RPS]=].
 
 
 # User Agent Automation # {#sctn-automation}

--- a/index.bs
+++ b/index.bs
@@ -5830,6 +5830,71 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 :: None.
 
 
+## Blob storage extension (<dfn>blob</dfn>) ## {#sctn-blob-extension}
+
+This [=client extension|client=] [=registration extension=] and [=authentication extension=] allows a [=[WRP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[WRPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[WRP]=] might be a user-agent extension, built with Web technologies, but which does not have an online service for storage.
+
+: Extension identifier
+:: `blob`
+
+: Operation applicability
+:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
+
+: Client extension input
+::  <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientInputs {
+        ArrayBuffer blobWrite;
+        boolean blobRead;
+    };
+    </xmp>
+
+    <div dfn-type="dict-member" dfn-for="CredentialPropertiesOutput">
+        :   <dfn>blobWrite</dfn>
+        ::  An opaque byte string that the [=[WRP]=] wishes to store with the freshly created credential (in the [=registration extension=] case) or an existing credential (in the case of an [=authentication extension=]).
+
+        :   <dfn>blobRead</dfn>
+        ::  A boolean that indicates that the [=[WRP]=] would like to fetch the previously-written blob associated with the asserted credential. Only valid as an [=authentication extension=] and ignored in the case of a [=registration extension=].
+    </div>
+
+: Client extension processing ([=registration extension|registration=])
+:: If {{AuthenticationExtensionsClientInputs/blobWrite}} is present, attempt to store its contents on the [=authenticator=], associated with the freshly created credential. Set {{AuthenticationExtensionsClientInputs/blobWritten}} to `true` if successful and `false` otherwise.
+
+: Client extension processing ([=authentication extension|authentication=])
+::
+       1. If {{AuthenticationExtensionsClientInputs/blobWrite}} is present and {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element:
+           1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to store the contents of {{AuthenticationExtensionsClientInputs/blobWrite}} on the [=authenticator=], associated with the indicated credential.
+           1. Set {{AuthenticationExtensionsClientOutputs/blobWritten}} to `true` if successful and `false` otherwise.
+       1. If {{AuthenticationExtensionsClientInputs/blobRead}} is present and has the value `true`:
+           1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to read any data associated with the asserted credential.
+           1. If successful, set {{AuthenticationExtensionsClientOutputs/blob}} to the result.
+
+: Client extension output
+:: <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientOutputs {
+        ArrayBuffer blob;
+        boolean blobWritten;
+    };
+    </xmp>
+
+    <div dfn-type="dict-member" dfn-for="CredentialPropertiesOutput">
+        :   <dfn>blob</dfn>
+        ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid in the [=authentication extension=] case and only present if {{AuthenticationExtensionsClientInputs/blobRead}} was `true`.
+
+        :   <dfn>blobWritten</dfn>
+        ::  A boolean that indicates that the contents of {{AuthenticationExtensionsClientInputs/blobWrite}} were successfully store on the [=authenticator=], associated with the specified extension.
+    </div>
+
+
+: Authenticator extension input
+:: None.
+
+: Authenticator extension processing
+:: None.
+
+: Authenticator extension output
+:: None.
+
+
 # User Agent Automation # {#sctn-automation}
 
 For the purposes of user agent automation and [=web application=] testing, this document defines a number of [[WebDriver]] [=extension commands=].

--- a/index.bs
+++ b/index.bs
@@ -5830,58 +5830,59 @@ At this time, one [=credential property=] is defined: the [=resident key credent
 :: None.
 
 
-## Blob storage extension (<dfn>blob</dfn>) ## {#sctn-blob-extension}
+## Large blob storage extension (<dfn>largeBlob</dfn>) ## {#sctn-large-blob-extension}
 
-This [=client extension|client=] [=registration extension=] and [=authentication extension=] allows a [=[WRP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[WRPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[WRP]=] might be a user-agent extension, built with Web technologies, but which does not have an online service for storage.
+This [=client extension|client=] [=authentication extension=] allows a [=[WRP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[WRPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[WRP]=] might wish to issue certificates rather than run a centralised authentication service.
+
+Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension is not defined in the [=registration extension|registration=] context.
+
+Since certificates are sizable relative to the storage capabilities of typical authenticators, user agents SHOULD consider what indications and confirmations are suitable to best guide the user in allocating this limited resource and prevent abuse.
 
 : Extension identifier
-:: `blob`
+:: `largeBlob`
 
 : Operation applicability
-:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
+:: [=authentication extension|Authentication=]
 
 : Client extension input
 ::  <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
-        ArrayBuffer blobWrite;
-        boolean blobRead;
+        ArrayBuffer largeBlobWrite;
+        boolean largeBlobRead;
     };
     </xmp>
 
     <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsClientInputs">
-        :   <dfn>blobWrite</dfn>
-        ::  An opaque byte string that the [=[WRP]=] wishes to store with the freshly created credential (in the [=registration extension=] case) or an existing credential (in the case of an [=authentication extension=]).
+        :   <dfn>largeBlobWrite</dfn>
+        ::  An opaque byte string that the [=[WRP]=] wishes to store with the existing credential.
 
-        :   <dfn>blobRead</dfn>
-        ::  A boolean that indicates that the [=[WRP]=] would like to fetch the previously-written blob associated with the asserted credential. Only valid as an [=authentication extension=] and ignored in the case of a [=registration extension=].
+        :   <dfn>largeBlobRead</dfn>
+        ::  A boolean that indicates that the [=[WRP]=] would like to fetch the previously-written blob associated with the asserted credential.
     </div>
-
-: Client extension processing ([=registration extension|registration=])
-:: If {{AuthenticationExtensionsClientInputs/blobWrite}} is present, attempt to store its contents on the [=authenticator=], associated with the freshly created credential. Set {{AuthenticationExtensionsClientOutputs}}.{{AuthenticationExtensionsClientOutputs/blobWritten}} to `true` if successful and `false` otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])
 ::
-       1. If {{AuthenticationExtensionsClientInputs/blobWrite}} is present and {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element:
-           1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to store the contents of {{AuthenticationExtensionsClientInputs/blobWrite}} on the [=authenticator=], associated with the indicated credential.
-           1. Set {{AuthenticationExtensionsClientOutputs/blobWritten}} to `true` if successful and `false` otherwise.
-       1. If {{AuthenticationExtensionsClientInputs/blobRead}} is present and has the value `true`:
+       1. If {{AuthenticationExtensionsClientInputs/largeBlobRead}} is present and has the value `true`:
            1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to read any data associated with the asserted credential.
-           1. If successful, set {{AuthenticationExtensionsClientOutputs/blob}} to the result.
+           1. If successful, set {{AuthenticationExtensionsClientOutputs/largeBlob}} to the result.
+       1. If {{AuthenticationExtensionsClientInputs/largeBlobWrite}} is present, {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element, and {{AuthenticationExtensionsClientInputs/largeBlobRead}} is not present, or has the value `false`:
+           1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to store the contents of {{AuthenticationExtensionsClientInputs/largeBlobWrite}} on the [=authenticator=], associated with the indicated credential.
+           1. Set {{AuthenticationExtensionsClientOutputs/largeBlobWritten}} to `true` if successful and `false` otherwise.
 
 : Client extension output
 :: <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-        ArrayBuffer blob;
-        boolean blobWritten;
+        ArrayBuffer largeBlob;
+        boolean largeBlobWritten;
     };
     </xmp>
 
     <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsClientOutputs">
-        :   <dfn>blob</dfn>
-        ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid in the [=authentication extension=] case and only present if {{AuthenticationExtensionsClientInputs/blobRead}} was `true`.
+        :   <dfn>largeBlob</dfn>
+        ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid in the [=authentication extension=] case and only present if {{AuthenticationExtensionsClientInputs/largeBlobRead}} was `true`.
 
-        :   <dfn>blobWritten</dfn>
-        ::  A boolean that indicates that the contents of {{AuthenticationExtensionsClientInputs/blobWrite}} were successfully stored on the [=authenticator=], associated with the specified extension.
+        :   <dfn>largeBlobWritten</dfn>
+        ::  A boolean that indicates that the contents of {{AuthenticationExtensionsClientInputs/largeBlobWrite}} were successfully stored on the [=authenticator=], associated with the specified extension.
     </div>
 
 


### PR DESCRIPTION
This allows “RPs” who, in this case will likely be browser extensions or
PWAs in offline mode, to store small amounts of arbitrary data with a
credential.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1402.html" title="Last updated on Jun 5, 2020, 11:03 PM UTC (30d6438)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1402/50679f5...agl:30d6438.html" title="Last updated on Jun 5, 2020, 11:03 PM UTC (30d6438)">Diff</a>