### PR TITLE
Fix markup error in three headings.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2766,7 +2766,7 @@ Note: [=Authenticator extension outputs=] are conveyed as a part of [=Authentica
 Note: The types defined below&mdash;{{AuthenticationExtensionsClientInputs}}, {{AuthenticationExtensionsClientOutputs}}, and {{AuthenticationExtensionsAuthenticatorInputs}}&mdash;are applicable to both [=registration extensions=] and [=authentication extensions=]. The "Authentication..." portion of their names should be regarded as meaning "WebAuthentication..."
 
 
-### Authentication Extensions Client Inputs (dictionary {{AuthenticationExtensionsClientInputs}}) ## {#iface-authentication-extensions-client-inputs}
+### Authentication Extensions Client Inputs (dictionary {{AuthenticationExtensionsClientInputs}}) ### {#iface-authentication-extensions-client-inputs}
 
 <xmp class="idl">
     dictionary AuthenticationExtensionsClientInputs {
@@ -2776,7 +2776,7 @@ Note: The types defined below&mdash;{{AuthenticationExtensionsClientInputs}}, {{
 This is a dictionary containing the [=client extension input=] values for zero or more [=WebAuthn Extensions=].
 
 
-### Authentication Extensions Client Outputs (dictionary {{AuthenticationExtensionsClientOutputs}}) ## {#iface-authentication-extensions-client-outputs}
+### Authentication Extensions Client Outputs (dictionary {{AuthenticationExtensionsClientOutputs}}) ### {#iface-authentication-extensions-client-outputs}
 
 <xmp class="idl">
     dictionary AuthenticationExtensionsClientOutputs {
@@ -2786,7 +2786,7 @@ This is a dictionary containing the [=client extension input=] values for zero o
 This is a dictionary containing the [=client extension output=] values for zero or more [=WebAuthn Extensions=].
 
 
-### Authentication Extensions Authenticator Inputs (typedef {{AuthenticationExtensionsAuthenticatorInputs}}) ## {#iface-authentication-extensions-authenticator-inputs}
+### Authentication Extensions Authenticator Inputs (typedef {{AuthenticationExtensionsAuthenticatorInputs}}) ### {#iface-authentication-extensions-authenticator-inputs}
 
 <xmp class="idl">
     typedef record<DOMString, DOMString> AuthenticationExtensionsAuthenticatorInputs;


### PR DESCRIPTION
(If you look at the current HTML output, the anchor is mistakening
getting included as part of the heading without this.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1405.html" title="Last updated on Apr 10, 2020, 8:19 PM UTC (185fec7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1405/6626671...agl:185fec7.html" title="Last updated on Apr 10, 2020, 8:19 PM UTC (185fec7)">Diff</a>