### PR TITLE
Fix IANA Registration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5042,7 +5042,7 @@ match WebAuthn extension identifiers in a case-sensitive fashion.
 Extensions that may exist in multiple versions should take care to include a version in their identifier. In effect, different
 versions are thus treated as different extensions, e.g., `myCompany_extension_01`
 
-[[#sctn-defined-extensions]] defines an initial set of extensions and their identifiers.
+[[#sctn-defined-extensions]] defines an additional set of extensions and their identifiers.
 See the IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]]
 for an up-to-date list of registered WebAuthn Extension Identifiers.
 
@@ -5138,7 +5138,7 @@ There MUST NOT be any values returned for ignored extensions.
 
 # Defined Extensions # {#sctn-defined-extensions}
 
-This section defines the initial set of extensions to be registered in the
+This section defines an additional set of extensions to be registered in the
 IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]].
 These MAY be implemented by user agents targeting broad interoperability.
 
@@ -5947,16 +5947,9 @@ IANA "WebAuthn Attestation Statement Format Identifier" registry established by 
 This section registers the [=extension identifier=] values defined in Section [[#sctn-extensions]] in the
 IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]].
 
-- WebAuthn Extension Identifier: appid
-- Description: This [=authentication extension=] allows [=[WRPS]=] that have previously registered a credential using the legacy
-    FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]] to request an assertion.
+- WebAuthn Extension Identifier: appidExclude
+- Description: This registration extension allows [=[WRPS]=] to exclude authenticators which contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
 - Specification Document: Section [[#sctn-appid-extension]] of this specification
-    <br/><br/>
-- WebAuthn Extension Identifier: uvm
-- Description: This [=registration extension=] and [=authentication extension=] enables use of a user verification method.
-    The user verification method extension returns to the [=[WRP]=] which user verification methods (factors) were
-    used for the WebAuthn operation.
-- Specification Document: Section [[#sctn-uvm-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: credProps
 - Description: This [=client extension|client=] [=registration extension=] enables reporting of a newly-created [=credential=]'s properties,

--- a/index.bs
+++ b/index.bs
@@ -5239,7 +5239,7 @@ Instead, in step three, the comparison on the host is relaxed to accept hosts on
 
 ## FIDO AppID Exclusion Extension (appidExclude) ## {#sctn-appid-exclude-extension}
 
-This registration extension allows [=[WRPS]=] to exclude authenticators which contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
+This registration extension allows [=[WRPS]=] to exclude authenticators that contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
 
 During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a population of users with legacy credentials already registered. The [appid](#sctn-appid-extension) extension allows the sign-in flow to be transitioned smoothly but, when transitioning the registration flow, the [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) field will not be effective in excluding authenticators with legacy credentials because its contents are taken to be WebAuthn credentials. This extension directs [=client platforms=] to consider the contents of [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials) as both WebAuthn and legacy FIDO credentials. Note that U2F key handles commonly use [=base64url encoding=] but must be decoded to their binary form when used in [excludeCredentials](#dom-publickeycredentialcreationoptions-excludecredentials).
 
@@ -5948,7 +5948,7 @@ This section registers the [=extension identifier=] values defined in Section [[
 IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registries]].
 
 - WebAuthn Extension Identifier: appidExclude
-- Description: This registration extension allows [=[WRPS]=] to exclude authenticators which contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
+- Description: This registration extension allows [=[WRPS]=] to exclude authenticators that contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
 - Specification Document: Section [[#sctn-appid-exclude-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: credProps

--- a/index.bs
+++ b/index.bs
@@ -5949,7 +5949,7 @@ IANA "WebAuthn Extension Identifier" registry established by [[!WebAuthn-Registr
 
 - WebAuthn Extension Identifier: appidExclude
 - Description: This registration extension allows [=[WRPS]=] to exclude authenticators which contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
-- Specification Document: Section [[#sctn-appid-extension]] of this specification
+- Specification Document: Section [[#sctn-appid-exclude-extension]] of this specification
     <br/><br/>
 - WebAuthn Extension Identifier: credProps
 - Description: This [=client extension|client=] [=registration extension=] enables reporting of a newly-created [=credential=]'s properties,


### PR DESCRIPTION
Fixes #1400 adds IANA registration for appidExclude and removes allready registerd extensions.  Changes wording from initial registrations to additional registrations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1408.html" title="Last updated on Apr 22, 2020, 2:49 AM UTC (df594fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1408/b978138...df594fe.html" title="Last updated on Apr 22, 2020, 2:49 AM UTC (df594fe)">Diff</a>