### PR TITLE
Add "MDN Panels" to spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -28,6 +28,7 @@ Previous Version: https://www.w3.org/TR/2016/WD-webauthn-20160902/
 Previous Version: https://www.w3.org/TR/2016/WD-webauthn-20160531/
 Shortname: webauthn
 Level: 2
+Include MDN Panels: yes
 Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
 Editor: Alexei Czeskis, w3cid 87258, Google, aczeskis@google.com
 Editor: Jeff Hodges, w3cid 43843, Google, jdhodges@google.com

--- a/index.bs
+++ b/index.bs
@@ -28,7 +28,7 @@ Previous Version: https://www.w3.org/TR/2016/WD-webauthn-20160902/
 Previous Version: https://www.w3.org/TR/2016/WD-webauthn-20160531/
 Shortname: webauthn
 Level: 2
-Include MDN Panels: yes
+Include MDN Panels: maybe
 Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
 Editor: Alexei Czeskis, w3cid 87258, Google, aczeskis@google.com
 Editor: Jeff Hodges, w3cid 43843, Google, jdhodges@google.com


### PR DESCRIPTION
This adds `Include MDN Panels: yes` to the spec "metadata". They are documented here:

https://tabatkins.github.io/bikeshed/#metadata-include-mdn-panels

This will add little widgets to the right side of the spec for each interface (that's been documented in MDN's "browser compatibility data" repo). These widgets summarize the implementation status of the interface in various browsers.

MDN's "browser compatibility data" repo is here:

https://github.com/mdn/browser-compat-data

A rendering of MDN's present WebAuthn implementation state is here:

https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API#Browser_compatibility

( the underlying BCD data is updated by "the community" submitting PRs at https://github.com/mdn/browser-compat-data.  I am unsure whether the current data wrt webauthn api is up-to-date or not.  Apparently, the Web_Authentication_API#Browser_compatibility tables could be more up-to-date, see https://github.com/mdn/sprints/issues/3222 )


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1411.html" title="Last updated on May 13, 2020, 6:48 PM UTC (81e482c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1411/d530669...81e482c.html" title="Last updated on May 13, 2020, 6:48 PM UTC (81e482c)">Diff</a>