### PR TITLE
Specify more about COSE algorithms.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -152,6 +152,7 @@ spec: RFC8152; urlPrefix: https://tools.ietf.org/html/rfc8152
         text: Section 8.1; url: section-8.1
         text: kty; url: section-7.1
         text: crv; url: section-13.1.1
+        text: COSE key; url: section-7
 
 spec: RFC8230; urlPrefix: https://tools.ietf.org/html/rfc8230
     type: dfn
@@ -3144,6 +3145,12 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     A {{COSEAlgorithmIdentifier}}'s value is a number identifying a cryptographic algorithm.
     The algorithm identifiers SHOULD be values registered in the IANA COSE Algorithms registry [[!IANA-COSE-ALGS-REG]],
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
+
+    The COSE algorithms registry leaves degrees of freedom to be specified by other parameters in a [=COSE key=]. In order to promote interoperability, this specification makes the following additional guarantees of [=credential public keys=]:
+        1. Keys with algorithm ES256 (-7) MUST specifiy P-256 (1) as the [=crv=] parameter.
+        1. Keys with algorithm ES384 (-35) MUST specifiy P-384 (2) as the [=crv=] parameter.
+        1. Keys with algorithm ES512 (-36) MUST specifiy P-521 (3) as the [=crv=] parameter.
+        1. Keys with algorithm EdDSA (-8) MUST specifiy Ed25519 (6) as the [=crv=] parameter.
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -3147,10 +3147,10 @@ parameter to the {{CredentialsContainer/create()}} or {{CredentialsContainer/get
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 
     The COSE algorithms registry leaves degrees of freedom to be specified by other parameters in a [=COSE key=]. In order to promote interoperability, this specification makes the following additional guarantees of [=credential public keys=]:
-        1. Keys with algorithm ES256 (-7) MUST specifiy P-256 (1) as the [=crv=] parameter.
-        1. Keys with algorithm ES384 (-35) MUST specifiy P-384 (2) as the [=crv=] parameter.
-        1. Keys with algorithm ES512 (-36) MUST specifiy P-521 (3) as the [=crv=] parameter.
-        1. Keys with algorithm EdDSA (-8) MUST specifiy Ed25519 (6) as the [=crv=] parameter.
+        1. Keys with algorithm ES256 (-7) MUST specify P-256 (1) as the [=crv=] parameter.
+        1. Keys with algorithm ES384 (-35) MUST specify P-384 (2) as the [=crv=] parameter.
+        1. Keys with algorithm ES512 (-36) MUST specify P-521 (3) as the [=crv=] parameter.
+        1. Keys with algorithm EdDSA (-8) MUST specify Ed25519 (6) as the [=crv=] parameter.
 </div>
 
 


### PR DESCRIPTION
[COSEAlgorithmIdentifiers](https://w3c.github.io/webauthn/#typedefdef-cosealgorithmidentifier) aren't very specific.

JOSE [defines](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) an algorithm called “ES256” as “ECDSA using P-256 and SHA-256” — which is fine. COSE [also defines](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) an algorithm called “ES256”, except that the COSE version isn't specific to any curve! It's just ECDSA with SHA-256 hashing. COSE only [says](https://tools.ietf.org/html/rfc8152#section-8.1) that “in order to promote interoperability, it is suggested that SHA-256 be used only with curve P-256”. Technically, an authenticator could return a public key over some other curve, although I bet it breaks lots of RPs.

Similarly, COSE defines an algorithm for “EdDSA”, which is commonly interpreted to mean EdDSA with Ed25519. But, technically, it could also mean EdDSA with the much rarer X448.

I think people thought that they were getting JOSE-style precise algorithms with a COSE algorithm identifier, but that's not true. Thus this change nails down some standard assumptions that are (I believe) currently true in all cases anyway.

(See also fido-alliance/fido-2-specs#862.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 3, 2020, 7:08 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fagl%2Fwebauthn%2F6513a003c289d8046483c590bd82469d2d397b3f%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webauthn%231420.)._
</details>
