### PR TITLE
Use Python 3 in bikeshed Dockerfile

### DIFF
--- a/docker/bikeshed/Dockerfile
+++ b/docker/bikeshed/Dockerfile
@@ -1,10 +1,9 @@
-FROM python:2
+FROM python:3.8
 
 VOLUME /spec
 WORKDIR /spec
 
-RUN git clone --depth=1 --branch=master https://github.com/tabatkins/bikeshed.git /bikeshed
-RUN pip install --editable /bikeshed
+RUN pip install bikeshed
 RUN bikeshed update
 
 ENTRYPOINT ["/usr/local/bin/bikeshed", "--print=console"]


### PR DESCRIPTION
The bundled [bikeshed Dockerfile](https://github.com/w3c/webauthn/tree/f10427d699882e8d7c4c173b25bed83f1e382b3c/docker/bikeshed) fails to build because bikeshed has now migrated to Python 3.