### PR TITLE
Remove webdriver-spec.html from WebDriver URLs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -264,7 +264,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl
     type: dfn;
         text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-reference
 
-spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#
     type: dfn
         text: WebDriver error; url: dfn-error
         text: WebDriver error code; url: dfn-error-code

--- a/index.bs
+++ b/index.bs
@@ -264,7 +264,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl
     type: dfn;
         text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-reference
 
-spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
         text: WebDriver error; url: dfn-error
         text: WebDriver error code; url: dfn-error-code


### PR DESCRIPTION
It redirects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 3, 2020, 6:17 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebauthn%2F7f541a26c796fd90d1be02fe85332f25bed3c291%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webauthn%231432.)._
</details>
