### PR TITLE
Replace AuthenticationExtensionsAuthenticatorInputs with CDDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2896,6 +2896,7 @@ AuthenticationExtensionsAuthenticatorInputs = {
 
 The [=CDDL=] type `AuthenticationExtensionsAuthenticatorInputs` defines a [=CBOR=] map
 containing the [=authenticator extension input=] values for zero or more [=WebAuthn Extensions=].
+Extensions can add members as described in [[#sctn-extension-request-parameters]].
 
 This type is not exposed to the [=[RP]=], but is used by the [=client=] and [=authenticator=].
 
@@ -2910,6 +2911,7 @@ AuthenticationExtensionsAuthenticatorOutputs = {
 
 The [=CDDL=] type `AuthenticationExtensionsAuthenticatorOutputs` defines a [=CBOR=] map
 containing the [=authenticator extension output=] values for zero or more [=WebAuthn Extensions=].
+Extensions can add members as described in [[#sctn-extension-request-parameters]].
 
 
 ## Supporting Data Structures ## {#sctn-supporting-data-structures}
@@ -5278,7 +5280,8 @@ input=],
 and MUST define extensions for the [=CDDL=] types
 <code>[[#iface-authentication-extensions-authenticator-inputs|AuthenticationExtensionsAuthenticatorInputs]]</code>
 and <code>[[#iface-authentication-extensions-authenticator-outputs|AuthenticationExtensionsAuthenticatorOutputs]]</code>
-by defining an additional choice for the `$$extensionInput` and `$$extensionOutput` [=group sockets=].
+by defining an additional choice for the `$$extensionInput` and `$$extensionOutput` [=group sockets=]
+using the [=extension identifier=] as the entry key.
 Extensions that do not require input parameters, and are thus defined as taking a Boolean [=client extension input=]
 value set to [TRUE],
 SHOULD define the [=authenticator extension input=] also as the constant Boolean value [TRUE] (CBOR major type

--- a/index.bs
+++ b/index.bs
@@ -2859,7 +2859,7 @@ The subsections below define the data types used for conveying [=WebAuthn extens
 
 Note: [=Authenticator extension outputs=] are conveyed as a part of [=Authenticator data=] (see [Table 1](#table-authData)).
 
-Note: The types defined below&mdash;{{AuthenticationExtensionsClientInputs}}, {{AuthenticationExtensionsClientOutputs}}, and {{AuthenticationExtensionsAuthenticatorInputs}}&mdash;are applicable to both [=registration extensions=] and [=authentication extensions=]. The "Authentication..." portion of their names should be regarded as meaning "WebAuthentication..."
+Note: The types defined below &mdash; {{AuthenticationExtensionsClientInputs}} and {{AuthenticationExtensionsClientOutputs}} &mdash; are applicable to both [=registration extensions=] and [=authentication extensions=]. The "Authentication..." portion of their names should be regarded as meaning "WebAuthentication..."
 
 
 ### Authentication Extensions Client Inputs (dictionary {{AuthenticationExtensionsClientInputs}}) ### {#iface-authentication-extensions-client-inputs}
@@ -2880,15 +2880,6 @@ This is a dictionary containing the [=client extension input=] values for zero o
 </xmp>
 
 This is a dictionary containing the [=client extension output=] values for zero or more [=WebAuthn Extensions=].
-
-
-### Authentication Extensions Authenticator Inputs (typedef {{AuthenticationExtensionsAuthenticatorInputs}}) ### {#iface-authentication-extensions-authenticator-inputs}
-
-<xmp class="idl">
-    typedef record<DOMString, DOMString> AuthenticationExtensionsAuthenticatorInputs;
-</xmp>
-
-This is a dictionary containing the [=authenticator extension input=] values for zero or more [=WebAuthn Extensions=].
 
 
 ## Supporting Data Structures ## {#sctn-supporting-data-structures}

--- a/index.bs
+++ b/index.bs
@@ -864,7 +864,7 @@ below and in [[#index-defined-elsewhere]].
     as defined in [[!FIDO-CTAP]].
 
 : CDDL
-:: This specification describes the syntax of all [=CBOR=]-encoded data using the CBOR Data Definition Language (CDDL) [[!RFC8610]].
+:: This specification describes the syntax of all [=CBOR=]-encoded data using the CBOR Data Definition Language (<dfn>CDDL</dfn>) [[!RFC8610]].
 
 : COSE
 :: CBOR Object Signing and Encryption (COSE) [[!RFC8152]].  The IANA COSE Algorithms registry established by this specification is also used.
@@ -2880,6 +2880,28 @@ This is a dictionary containing the [=client extension input=] values for zero o
 </xmp>
 
 This is a dictionary containing the [=client extension output=] values for zero or more [=WebAuthn Extensions=].
+
+
+### Authentication Extensions Authenticator Inputs (CDDL type `extensionInputs`) ### {#iface-authentication-extensions-authenticator-inputs}
+
+```
+extensionInputs = { * $$extensionInput .within ( tstr => any ) }
+```
+
+The [=CDDL=] type `extensionInputs` defines a [=CBOR=] map
+containing the [=authenticator extension input=] values for zero or more [=WebAuthn Extensions=].
+
+This type is not exposed to the [=[RP]=], but is used by the [=client=] and [=authenticator=].
+
+
+### Authentication Extensions Authenticator Outputs (CDDL type `extensionOutputs`) ### {#iface-authentication-extensions-authenticator-outputs}
+
+```
+extensionOutputs = { * $$extensionOutput .within ( tstr => any ) }
+```
+
+The [=CDDL=] type `extensionOutputs` defines a [=CBOR=] map
+containing the [=authenticator extension output=] values for zero or more [=WebAuthn Extensions=].
 
 
 ## Supporting Data Structures ## {#sctn-supporting-data-structures}
@@ -5244,9 +5266,28 @@ as taking a Boolean client argument, set to [TRUE] to signify that the extension
 
 Extensions that only affect client processing need not specify [=authenticator extension input=]. Extensions that have
 authenticator processing MUST specify the method of computing the [=authenticator extension input=] from the [=client extension
-input=]. For extensions that do not require input parameters and are defined as taking a Boolean [=client extension input=]
-value set to [TRUE], this method SHOULD consist of passing an [=authenticator extension input=] value of [TRUE] (CBOR major type
+input=],
+and MUST define extensions for the [=CDDL=] types
+<code>[[#iface-authentication-extensions-authenticator-inputs|extensionInputs]]</code>
+and <code>[[#iface-authentication-extensions-authenticator-outputs|extensionOutputs]]</code>
+by defining an additional choice for the `$$extensionInput` and `$$extensionOutput` groups.
+Extensions that do not require input parameters, and are thus defined as taking a Boolean [=client extension input=]
+value set to [TRUE],
+SHOULD define the [=authenticator extension input=] also as the constant Boolean value [TRUE] (CBOR major type
 7, value 21).
+
+The following example defines that an extension with [=extension identifier|identifier=] `webauthnExample_foobar`
+takes an unsigned integer as [=authenticator extension input=],
+and returns an array of at least one byte string as [=authenticator extension output=]:
+
+<pre class="example">
+    $$extensionInput //= (
+      webauthnExample_foobar: uint
+    )
+    $$extensionOutput //= (
+      webauthnExample_foobar: [+ bytes]
+    )
+</pre>
 
 Note: Extensions should aim to define authenticator arguments that are as small as possible. Some authenticators communicate
     over low-bandwidth links such as Bluetooth Low-Energy or NFC.
@@ -5501,6 +5542,12 @@ This extension enables use of a user verification method.
 : Authenticator extension input
 :: The Boolean value [TRUE], encoded in CBOR (major type 7, value 21).
 
+    ```
+    $$extensionInput //= (
+      uvm: true,
+    )
+    ```
+
 : Authenticator extension processing
 :: The [=authenticator=] sets the [=authenticator extension output=] to be one or more user verification methods indicating the method(s) used
     by the user to authorize the operation, as defined below. This extension can be added to attestation objects and assertions.
@@ -5510,7 +5557,10 @@ This extension enables use of a user verification method.
     using the CBOR syntax defined below:
 
     ```
-    uvmFormat = [ 1*3 uvmEntry ]
+    $$extensionOutput //= (
+      uvm: [ 1*3 uvmEntry ],
+    )
+
     uvmEntry = [
                    userVerificationMethod: uint .size 4,
                    keyProtectionType: uint .size 2,

--- a/index.bs
+++ b/index.bs
@@ -2886,25 +2886,29 @@ This is a dictionary containing the [=client extension input=] values for zero o
 This is a dictionary containing the [=client extension output=] values for zero or more [=WebAuthn Extensions=].
 
 
-### Authentication Extensions Authenticator Inputs (CDDL type `extensionInputs`) ### {#iface-authentication-extensions-authenticator-inputs}
+### Authentication Extensions Authenticator Inputs (CDDL type `AuthenticationExtensionsAuthenticatorInputs`) ### {#iface-authentication-extensions-authenticator-inputs}
 
 ```
-extensionInputs = { * $$extensionInput .within ( tstr => any ) }
+AuthenticationExtensionsAuthenticatorInputs = {
+  * $$extensionInput .within ( tstr => any )
+}
 ```
 
-The [=CDDL=] type `extensionInputs` defines a [=CBOR=] map
+The [=CDDL=] type `AuthenticationExtensionsAuthenticatorInputs` defines a [=CBOR=] map
 containing the [=authenticator extension input=] values for zero or more [=WebAuthn Extensions=].
 
 This type is not exposed to the [=[RP]=], but is used by the [=client=] and [=authenticator=].
 
 
-### Authentication Extensions Authenticator Outputs (CDDL type `extensionOutputs`) ### {#iface-authentication-extensions-authenticator-outputs}
+### Authentication Extensions Authenticator Outputs (CDDL type `AuthenticationExtensionsAuthenticatorOutputs`) ### {#iface-authentication-extensions-authenticator-outputs}
 
 ```
-extensionOutputs = { * $$extensionOutput .within ( tstr => any ) }
+AuthenticationExtensionsAuthenticatorOutputs = {
+  * $$extensionOutput .within ( tstr => any )
+}
 ```
 
-The [=CDDL=] type `extensionOutputs` defines a [=CBOR=] map
+The [=CDDL=] type `AuthenticationExtensionsAuthenticatorOutputs` defines a [=CBOR=] map
 containing the [=authenticator extension output=] values for zero or more [=WebAuthn Extensions=].
 
 
@@ -5272,8 +5276,8 @@ Extensions that only affect client processing need not specify [=authenticator e
 authenticator processing MUST specify the method of computing the [=authenticator extension input=] from the [=client extension
 input=],
 and MUST define extensions for the [=CDDL=] types
-<code>[[#iface-authentication-extensions-authenticator-inputs|extensionInputs]]</code>
-and <code>[[#iface-authentication-extensions-authenticator-outputs|extensionOutputs]]</code>
+<code>[[#iface-authentication-extensions-authenticator-inputs|AuthenticationExtensionsAuthenticatorInputs]]</code>
+and <code>[[#iface-authentication-extensions-authenticator-outputs|AuthenticationExtensionsAuthenticatorOutputs]]</code>
 by defining an additional choice for the `$$extensionInput` and `$$extensionOutput` [=group sockets=].
 Extensions that do not require input parameters, and are thus defined as taking a Boolean [=client extension input=]
 value set to [TRUE],

--- a/index.bs
+++ b/index.bs
@@ -293,6 +293,10 @@ spec: RFC5280; urlPrefix: https://tools.ietf.org/html/rfc5280
     type: dfn
         text: SubjectPublicKeyInfo; url: section-4.1.2.7
 
+spec: RFC8610; urlPrefix: https://tools.ietf.org/html/rfc8610
+    type: dfn
+        text: group sockets; url: section-3.9
+
 </pre> <!-- class=anchors -->
 
 <!-- L128 spec:webappsec-credential-management-1; type:dictionary; for:/; text:CredentialRequestOptions -->
@@ -5270,7 +5274,7 @@ input=],
 and MUST define extensions for the [=CDDL=] types
 <code>[[#iface-authentication-extensions-authenticator-inputs|extensionInputs]]</code>
 and <code>[[#iface-authentication-extensions-authenticator-outputs|extensionOutputs]]</code>
-by defining an additional choice for the `$$extensionInput` and `$$extensionOutput` groups.
+by defining an additional choice for the `$$extensionInput` and `$$extensionOutput` [=group sockets=].
 Extensions that do not require input parameters, and are thus defined as taking a Boolean [=client extension input=]
 value set to [TRUE],
 SHOULD define the [=authenticator extension input=] also as the constant Boolean value [TRUE] (CBOR major type


### PR DESCRIPTION
This replaces the unused WebIDL type AuthenticationExtensionsAuthenticatorInputs with formally defined CDDL extensions point for authenticator extension in/outputs. It doesn't precisely encode that entry keys must be extension identifiers, but the client counterparts also don't, and the prose definition does state this requirement and illustrate it with an example.

Fixes #1435.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1440.html" title="Last updated on Jun 25, 2020, 2:23 PM UTC (26f7da8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1440/2824aa4...26f7da8.html" title="Last updated on Jun 25, 2020, 2:23 PM UTC (26f7da8)">Diff</a>