### PR TITLE
Clarify How Client Data is Sent to Authenticator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1806,7 +1806,7 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in |options|.{{PublicKeyCredentialCreationOptions/extensions}}.
+                    [=client extension=] in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
 
 
             1.  Let |constructCredentialAlg| be an algorithm that takes a [=global object=]

--- a/index.bs
+++ b/index.bs
@@ -2328,10 +2328,9 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 </xmp>
 <div dfn-type="attribute" dfn-for="AuthenticatorResponse">
     :   <dfn>clientDataJSON</dfn>
-    ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=] passed to the
-        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}. The 
-        [=client data=] is never shared directly with the authenticator, but rather a [[=hash of the serialized client data=]]
-        is provided to it.
+    ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=], the [=hash of the serialized client data|hash of which=] is passed to the
+        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} (i.e., the 
+        [=client data=] itself is not sent to the authenticator).
 </div>
 
 ### Information About Public Key Credential (interface <dfn interface>AuthenticatorAttestationResponse</dfn>) ### {#iface-authenticatorattestationresponse}

--- a/index.bs
+++ b/index.bs
@@ -2200,7 +2200,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in |options|.{{PublicKeyCredentialRequestOptions/extensions}}.
+                    [=client extension=] in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
 
             1.  Let |constructAssertionAlg| be an algorithm that takes a [=global object=]
                 |global|, and whose steps are:

--- a/index.bs
+++ b/index.bs
@@ -2330,7 +2330,7 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
     :   <dfn>clientDataJSON</dfn>
     ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=] passed to the
         authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}. The 
-        [=client data=] is never shared directly with the authenticator, but rather a [[#collectedclientdata-hash-of-the-serialized-client-data|hash of the client data]]
+        [=client data=] is never shared directly with the authenticator, but rather a [[=hash of the serialized client data=]]
         is provided to it.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1806,7 +1806,7 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in <code>{{AuthenticatorResponse/clientDataJSON}}.clientExtensions</code>.
+                    [=client extension=] in |options|.{{PublicKeyCredentialCreationOptions/extensions}}.
 
 
             1.  Let |constructCredentialAlg| be an algorithm that takes a [=global object=]
@@ -2200,7 +2200,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in <code>{{AuthenticatorResponse/clientDataJSON}}.clientExtensions</code>.
+                    [=client extension=] in |options|.{{PublicKeyCredentialRequestOptions/extensions}}.
 
             1.  Let |constructAssertionAlg| be an algorithm that takes a [=global object=]
                 |global|, and whose steps are:

--- a/index.bs
+++ b/index.bs
@@ -2329,7 +2329,9 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 <div dfn-type="attribute" dfn-for="AuthenticatorResponse">
     :   <dfn>clientDataJSON</dfn>
     ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=] passed to the
-        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}.
+        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}. The 
+        [=client data=] is never shared directly with the authenticator, but rather a [[#collectedclientdata-hash-of-the-serialized-client-data|hash of the client data]]
+        is provided to it.
 </div>
 
 ### Information About Public Key Credential (interface <dfn interface>AuthenticatorAttestationResponse</dfn>) ### {#iface-authenticatorattestationresponse}


### PR DESCRIPTION
In #1442 some questions were brought up about the format in which the client data is sent to the authenticator, hopefully this will clarify it somewhat?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1443.html" title="Last updated on Jun 29, 2020, 6:48 PM UTC (a09ef51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1443/ce240bc...a09ef51.html" title="Last updated on Jun 29, 2020, 6:48 PM UTC (a09ef51)">Diff</a>