### PR TITLE
Update RP ID definition to allow URL syntax or arbitrary strings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1174,7 +1174,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Relying Party Identifier</dfn>
 : <dfn>RP ID</dfn>
-:: In the context of the [=web authentication api|WebAuthn API=], a [=relying party identifier=] MUST be a [=valid domain string=] identifying the [=[WRP]=] on whose behalf a given [=registration=] or
+:: In the context of the [=web authentication api|WebAuthn API=], a [=relying party identifier=] is a [=valid domain string=] identifying the [=[WRP]=] on whose behalf a given [=registration=] or
     [=authentication|authentication ceremony=] is being performed. A [=public key credential=] can only be used for
     [=authentication=] with the same entity (as identified by [=RP ID=]) it was registered with.
 
@@ -1200,11 +1200,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         These restrictions on origin values apply to [=WebAuthn Clients=].
     </div>
 
-    Other specifications mimicking the [=web authentication api|WebAuthn API=] to enable WebAuthn [=public key credentials=] on non-Web platforms (e.g. native mobile applications), MAY define different rules for binding a caller to a [=Relying Party Identifier=].
-
-    Such specifications MAY also define their own [=RP ID=] syntax, e.g., arbitrary URLs [[!URL]], or even arbitrary strings. [=Public key credentials=] created with such non-[=valid domain string=] [=RP ID=]s MUST be [=non-discoverable credentials=].
-
-    Such rules are outside the scope of this specification.
+    Other specifications mimicking the [=web authentication api|WebAuthn API=] to enable WebAuthn [=public key credentials=] on non-Web platforms (e.g. native mobile applications), MAY define different rules for binding a caller to a [=Relying Party Identifier=]. Though, the [=RP ID=] syntaxes MUST conform to either [=valid domain strings=] or URIs [[!RFC3986]] [[!URL]].
 
 : <dfn>Server-side Public Key Credential Source</dfn>
 : <dfn>Server-side Credential</dfn>

--- a/index.bs
+++ b/index.bs
@@ -2328,10 +2328,9 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 </xmp>
 <div dfn-type="attribute" dfn-for="AuthenticatorResponse">
     :   <dfn>clientDataJSON</dfn>
-    ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=] passed to the
-        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}. The 
-        [=client data=] is never shared directly with the authenticator, but rather a [[=hash of the serialized client data=]]
-        is provided to it.
+    ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=], the [=hash of the serialized client data|hash of which=] is passed to the
+        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} (i.e., the 
+        [=client data=] itself is not sent to the authenticator).
 </div>
 
 ### Information About Public Key Credential (interface <dfn interface>AuthenticatorAttestationResponse</dfn>) ### {#iface-authenticatorattestationresponse}

--- a/index.bs
+++ b/index.bs
@@ -2330,7 +2330,7 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
     :   <dfn>clientDataJSON</dfn>
     ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=] passed to the
         authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}. The 
-        [=client data=] is never shared directly with the authenticator, but rather a [[#collectedclientdata-hash-of-the-serialized-client-data|hash of the client data]]
+        [=client data=] is never shared directly with the authenticator, but rather a [[=hash of the serialized client data=]]
         is provided to it.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1806,7 +1806,7 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in <code>{{AuthenticatorResponse/clientDataJSON}}.clientExtensions</code>.
+                    [=client extension=] in |options|.{{PublicKeyCredentialCreationOptions/extensions}}.
 
 
             1.  Let |constructCredentialAlg| be an algorithm that takes a [=global object=]
@@ -2200,7 +2200,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in <code>{{AuthenticatorResponse/clientDataJSON}}.clientExtensions</code>.
+                    [=client extension=] in |options|.{{PublicKeyCredentialRequestOptions/extensions}}.
 
             1.  Let |constructAssertionAlg| be an algorithm that takes a [=global object=]
                 |global|, and whose steps are:

--- a/index.bs
+++ b/index.bs
@@ -1171,7 +1171,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Relying Party Identifier</dfn>
 : <dfn>RP ID</dfn>
-:: In the context of the [=web authentication api|WebAuthn API=], a [=relying party identifier=] is a [=valid domain string=] identifying the [=[WRP]=] on whose behalf a given [=registration=] or
+:: In the context of the [=web authentication api|WebAuthn API=], a [=relying party identifier=] MUST be a [=valid domain string=] identifying the [=[WRP]=] on whose behalf a given [=registration=] or
     [=authentication|authentication ceremony=] is being performed. A [=public key credential=] can only be used for
     [=authentication=] with the same entity (as identified by [=RP ID=]) it was registered with.
 

--- a/index.bs
+++ b/index.bs
@@ -1171,7 +1171,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Relying Party Identifier</dfn>
 : <dfn>RP ID</dfn>
-:: A [=valid domain string=] that identifies the [=[WRP]=] on whose behalf a given [=registration=] or
+:: In the context of the [=web authentication api|WebAuthn API=], a [=relying party identifier=] is a [=valid domain string=] identifying the [=[WRP]=] on whose behalf a given [=registration=] or
     [=authentication|authentication ceremony=] is being performed. A [=public key credential=] can only be used for
     [=authentication=] with the same entity (as identified by [=RP ID=]) it was registered with.
 
@@ -1194,8 +1194,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         Please note that this is a greater relaxation of "same-origin" restrictions than what
         [=document.domain=]'s setter provides.
 
-        These restrictions on origin values apply to [=WebAuthn Clients=]. If other specifications mimic the [=Web Authentication API=] to make WebAuthn [=credentials=] usable on other platforms (e.g. native mobile applications), they might have different rules for binding a caller to a [=Relying Party Identifier=]. Such rules are outside the scope of this specification.
+        These restrictions on origin values apply to [=WebAuthn Clients=].
     </div>
+
+    Other specifications mimicing the [=web authentication api|WebAuthn API=] to enable WebAuthn [=public key credentials=] on non-Web platforms (e.g. native mobile applications), MAY define different rules for binding a caller to a [=Relying Party Identifier=].
+
+    Such specifications MAY also define their own [=RP ID=] syntax, e.g., arbitrary URLs [[!URL]], or even arbitrary strings.
+
+    Such rules are outside the scope of this specification.
 
 : <dfn>Server-side Public Key Credential Source</dfn>
 : <dfn>Server-side Credential</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1090,7 +1090,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     users, in contrast to identifiers that are, for example, randomly generated sequences of bits [[EduPersonObjectClassSpec]].
 
 : <dfn>Non-Discoverable Credential</dfn>
-:: This is a [=credential=] whose [=credential ID=] must be provided in {{publickeycredentialrequestoptions/allowCredentials}} when calling {{CredentialsContainer/get()|navigator.credentials.get()}} because it is not client-side discoverable. See also [=server-side credentials=].
+:: This is a [=credential=] whose [=credential ID=] must be provided in {{publickeycredentialrequestoptions/allowCredentials}} when calling {{CredentialsContainer/get()|navigator.credentials.get()}} because it is not [=client-side discoverable credential|client-side discoverable=]. See also [=server-side credentials=].
 
 : <dfn>Public Key Credential Source</dfn>
 :: A [=credential source=] ([[CREDENTIAL-MANAGEMENT-1]]) used by an [=authenticator=] to generate [=authentication assertions=]. A [=public key credential source=] consists of a [=struct=] with the following [=struct/items=]:

--- a/index.bs
+++ b/index.bs
@@ -1037,7 +1037,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     which requires that the [=authenticator=] is given both the [=RP ID=] and the [=credential ID=]
     but does not require [=client-side=] storage of the [=public key credential source=].
 
-    See also: [=client-side credential storage modality=].
+    See also: [=client-side credential storage modality=] and [=non-discoverable credential=].
 
     Note: [=Client-side discoverable credentials=] are also usable in [=authentication ceremonies=] where [=credential ID=]s are given,
     i.e., when calling {{CredentialsContainer/get()|navigator.credentials.get()}}
@@ -1088,6 +1088,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Human Palatability</dfn>
 :: An identifier that is [=human palatability|human-palatable=] is intended to be rememberable and reproducible by typical human
     users, in contrast to identifiers that are, for example, randomly generated sequences of bits [[EduPersonObjectClassSpec]].
+
+: <dfn>Non-Discoverable Credential</dfn>
+:: This is a [=credential=] whose [=credential ID=] must be provided in {{publickeycredentialrequestoptions/allowCredentials}} when calling {{CredentialsContainer/get()|navigator.credentials.get()}} because it is not client-side discoverable. See also [=server-side credentials=].
 
 : <dfn>Public Key Credential Source</dfn>
 :: A [=credential source=] ([[CREDENTIAL-MANAGEMENT-1]]) used by an [=authenticator=] to generate [=authentication assertions=]. A [=public key credential source=] consists of a [=struct=] with the following [=struct/items=]:
@@ -1225,7 +1228,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     which instead does not require the user to first be identified in order to provide the user's [=credential ID=]s
     to a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
-    See also: [=server-side credential storage modality=].
+    See also: [=server-side credential storage modality=] and [=non-discoverable credential=].
 
 : <dfn>Test of User Presence</dfn>
 :: A [=test of user presence=] is a simple form of [=authorization gesture=] and technical process where a user interacts with

--- a/index.bs
+++ b/index.bs
@@ -1090,7 +1090,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     users, in contrast to identifiers that are, for example, randomly generated sequences of bits [[EduPersonObjectClassSpec]].
 
 : <dfn>Non-Discoverable Credential</dfn>
-:: This is a [=credential=] whose [=credential ID=] must be provided in {{publickeycredentialrequestoptions/allowCredentials}} when calling {{CredentialsContainer/get()|navigator.credentials.get()}} because it is not [=client-side discoverable credential|client-side discoverable=]. See also [=server-side credentials=].
+:: This is a [=credential=] whose [=credential ID=] must be provided in {{PublicKeyCredentialRequestOptions/allowCredentials}} when calling {{CredentialsContainer/get()|navigator.credentials.get()}} because it is not [=client-side discoverable credential|client-side discoverable=]. See also [=server-side credentials=].
 
 : <dfn>Public Key Credential Source</dfn>
 :: A [=credential source=] ([[CREDENTIAL-MANAGEMENT-1]]) used by an [=authenticator=] to generate [=authentication assertions=]. A [=public key credential source=] consists of a [=struct=] with the following [=struct/items=]:

--- a/index.bs
+++ b/index.bs
@@ -1200,7 +1200,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         These restrictions on origin values apply to [=WebAuthn Clients=].
     </div>
 
-    Other specifications mimicing the [=web authentication api|WebAuthn API=] to enable WebAuthn [=public key credentials=] on non-Web platforms (e.g. native mobile applications), MAY define different rules for binding a caller to a [=Relying Party Identifier=].
+    Other specifications mimicking the [=web authentication api|WebAuthn API=] to enable WebAuthn [=public key credentials=] on non-Web platforms (e.g. native mobile applications), MAY define different rules for binding a caller to a [=Relying Party Identifier=].
 
     Such specifications MAY also define their own [=RP ID=] syntax, e.g., arbitrary URLs [[!URL]], or even arbitrary strings. [=Public key credentials=] created with such non-[=valid domain string=] [=RP ID=]s MUST be [=non-discoverable credentials=].
 

--- a/index.bs
+++ b/index.bs
@@ -1202,7 +1202,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
     Other specifications mimicing the [=web authentication api|WebAuthn API=] to enable WebAuthn [=public key credentials=] on non-Web platforms (e.g. native mobile applications), MAY define different rules for binding a caller to a [=Relying Party Identifier=].
 
-    Such specifications MAY also define their own [=RP ID=] syntax, e.g., arbitrary URLs [[!URL]], or even arbitrary strings.
+    Such specifications MAY also define their own [=RP ID=] syntax, e.g., arbitrary URLs [[!URL]], or even arbitrary strings. [=Public key credentials=] created with such non-[=valid domain string=] [=RP ID=]s MUST be [=non-discoverable credentials=].
 
     Such rules are outside the scope of this specification.
 

--- a/index.bs
+++ b/index.bs
@@ -2329,7 +2329,9 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 <div dfn-type="attribute" dfn-for="AuthenticatorResponse">
     :   <dfn>clientDataJSON</dfn>
     ::  This attribute contains a [[#clientdatajson-serialization|JSON-compatible serialization]] of the [=client data=] passed to the
-        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}.
+        authenticator by the client in its call to either {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}}. The 
+        [=client data=] is never shared directly with the authenticator, but rather a [[#collectedclientdata-hash-of-the-serialized-client-data|hash of the client data]]
+        is provided to it.
 </div>
 
 ### Information About Public Key Credential (interface <dfn interface>AuthenticatorAttestationResponse</dfn>) ### {#iface-authenticatorattestationresponse}


### PR DESCRIPTION
This updates the RP ID definition to clearly state that in the context of the WebAuthn API, an RP ID _is_  a valid domain string, and also note that in the context of other specifications, an RP ID MAY be a valid domain string or a URI.  See discussion below and in issue #1406.

fixes #1406


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1452.html" title="Last updated on Jul 15, 2020, 8:18 PM UTC (d517898)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1452/3963483...d517898.html" title="Last updated on Jul 15, 2020, 8:18 PM UTC (d517898)">Diff</a>