### PR TITLE
Fix ambiguous {{appidExclude}} link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5490,7 +5490,7 @@ During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a popu
         1. Just after [establishing the RP ID](#CreateCred-DetermineRpId) perform these steps:
             1. Let |facetId| be the result of passing the caller's [=origin=] to the FIDO algorithm
                 for [=determining the FacetID of a calling application=].
-            1. Let |appId| be the value of the extension input {{appidExclude}}.
+            1. Let |appId| be the value of the extension input {{AuthenticationExtensionsClientInputs/appidExclude}}.
             1. Pass |facetId| and |appId| to the FIDO algorithm for [=determining if a caller's
                 FacetID is authorized for an AppID=]. If the latter algorithm rejects |appId| then
                 return a "{{SecurityError}}" {{DOMException}} and terminate the


### PR DESCRIPTION
Fixes Bikeshed warning:
```
LINK ERROR: Multiple possible 'idl' local refs for 'appidExclude'.
Randomly chose one of them; other instances might get a different random choice.
{{appidExclude}}
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1455.html" title="Last updated on Jul 15, 2020, 8:22 PM UTC (82ea2af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1455/b1c6965...82ea2af.html" title="Last updated on Jul 15, 2020, 8:22 PM UTC (82ea2af)">Diff</a>