### PR TITLE
Update description of residentKey

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2658,8 +2658,8 @@ attributes.
 <xmp class="idl">
     dictionary AuthenticatorSelectionCriteria {
         DOMString                    authenticatorAttachment;
-        boolean                      requireResidentKey = false;
         DOMString                    residentKey;
+        boolean                      requireResidentKey = false;
         DOMString                    userVerification = "preferred";
     };
 </xmp>
@@ -2669,20 +2669,13 @@ attributes.
     ::  If this member is present, eligible authenticators are filtered to only authenticators attached with the
         specified [[#enum-attachment]]. The value SHOULD be a member of {{AuthenticatorAttachment}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=].
 
-    :   <dfn>requireResidentKey</dfn>
-    ::  Note: This member is retained for backwards compatibility with WebAuthn Level 1 but is deprecated in favour of {{residentKey}}.
-        {{requireResidentKey}} is ignored if the caller supplies {{residentKey}} and the latter is understood by the [=client=].
-        Otherwise, {{requireResidentKey}}'s value is used. Note that {{requireResidentKey}}'s value defaults to [FALSE].
-
-        If used in absence of {{residentKey}}, it describes the [=[RP]=]'s requirements regarding [=client-side discoverable credentials=].
-        If {{requireResidentKey}} is set to [TRUE], the authenticator MUST create a [=client-side discoverable public key credential source=]
-        when creating a [=public key credential=].
-
     :   <dfn>residentKey</dfn>
-    ::  Note: This member supersedes {{requireResidentKey}}. If both are present and the [=client=] understands {{residentKey}}, then
-        {{residentKey}} is used and {{requireResidentKey}} is ignored.
+    ::  Specifies the extent to which the [=[RP]=] desires to create a [=client-side discoverable credential=]. For historical reasons the naming retains the deprecated “resident” terminology. The value SHOULD be a member of {{ResidentKeyRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=]. If no value is given then the effective value is {{ResidentKeyRequirement/required}} if {{requireResidentKey}} is [TRUE] or {{ResidentKeyRequirement/discouraged}} if it is [FALSE] or absent.
 
-        The value SHOULD be a member of {{ResidentKeyRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=]. See {{ResidentKeyRequirement}} for the description of {{residentKey}}'s values and semantics.
+        See {{ResidentKeyRequirement}} for the description of {{residentKey}}'s values and semantics.
+
+    :   <dfn>requireResidentKey</dfn>
+    ::  This member is retained for backwards compatibility with WebAuthn Level 1 and, for historical reasons, its naming retains the deprecated “resident” terminology for [=discoverable credentials=]. [=[RPS]=] SHOULD set it to [TRUE] if, and only if, {{residentKey}} is set to {{ResidentKeyRequirement/required}}.
 
     :   <dfn>userVerification</dfn>
     ::  This member describes the [=[RP]=]'s requirements regarding [=user verification=] for the
@@ -2742,6 +2735,8 @@ This enumeration's values describe the [=[RP]=]'s requirements for [=client-side
     ::  This value indicates the [=[RP]=] prefers creating a [=server-side credential=], but will accept a
         [=client-side discoverable credential=].
 
+        Note: A [=[RP]=] cannot require that a created credential is a [=server-side credential=] and the [=credProps|Credential Properties Extension=] may not return a value for the {{CredentialPropertiesOutput/rk}} property. Because of this, it may be the case that it does not know if a credential is a [=server-side credential=] or not and thus does not know whether creating a second credential with the same [=user handle=] will evict the first.
+
     :   <dfn>preferred</dfn>
     ::  This value indicates the [=[RP]=] strongly prefers creating a [=client-side discoverable credential=], but will accept a
         [=server-side credential=]. For example, user agents SHOULD guide the user through setting up [=user verification=] if needed to create a [=client-side discoverable credential=] in this case. This takes precedence over the setting of {{PublicKeyCredentialCreationOptions/userVerification}}.
@@ -2751,7 +2746,7 @@ This enumeration's values describe the [=[RP]=]'s requirements for [=client-side
         if a [=client-side discoverable credential=] cannot be created.
 </div>
 
-Note: [=[RPS]=] can determine whether or not the authenticator created a [=client-side discoverable credential=] by inspecting the [=credProps|Credential Properties Extension=]'s return value in light of
+Note: [=[RPS]=] can seek information on whether or not the authenticator created a [=client-side discoverable credential=] by inspecting the [=credProps|Credential Properties Extension=]'s return value in light of
 the value provided for <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>.
 This is useful when values of {{ResidentKeyRequirement/discouraged}} or {{ResidentKeyRequirement/preferred}} are used for
 <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>, because in those cases it is possible for an
@@ -5697,6 +5692,8 @@ At this time, one [=credential property=] is defined: the [=resident key credent
             If {{rk}} is [TRUE], the credential is a [=discoverable credential=];
             if {{rk}} is [FALSE], the credential is a [=server-side credential=].
             If {{rk}} is not present, it is not known whether the credential is a [=discoverable credential=] or a [=server-side credential=].
+
+            Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the user agent. Because of this, user agents may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE].
     </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -2744,7 +2744,7 @@ This enumeration's values describe the [=[RP]=]'s requirements for [=client-side
 
     :   <dfn>preferred</dfn>
     ::  This value indicates the [=[RP]=] strongly prefers creating a [=client-side discoverable credential=], but will accept a
-        [=server-side credential=]. For example, user agents SHOULD guide the user through setting up [=user verification=] if needed to create a [=client-side discoverable credential=] in this case. This takes precedence over the setting of {{PublicKeyCredentialRequestOptions/userVerification}}.
+        [=server-side credential=]. For example, user agents SHOULD guide the user through setting up [=user verification=] if needed to create a [=client-side discoverable credential=] in this case. This takes precedence over the setting of {{PublicKeyCredentialCreationOptions/userVerification}}.
 
     :   <dfn>required</dfn>
     ::  This value indicates the [=[RP]=] requires a [=client-side discoverable credential=], and is prepared to receive an error

--- a/index.bs
+++ b/index.bs
@@ -5689,11 +5689,11 @@ At this time, one [=credential property=] is defined: the [=resident key credent
             (i.e., <dfn dfn-type="dfn">client-side discoverable credential property</dfn>),
             is a Boolean value indicating whether the {{PublicKeyCredential}} returned as a result of a [=registration ceremony=]
             is a [=client-side discoverable credential=].
-            If {{rk}} is [TRUE], the credential is a [=discoverable credential=];
+            If {{rk}} is [TRUE], the credential is a [=discoverable credential=].
             if {{rk}} is [FALSE], the credential is a [=server-side credential=].
             If {{rk}} is not present, it is not known whether the credential is a [=discoverable credential=] or a [=server-side credential=].
 
-            Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the user agent. Because of this, user agents may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE].
+            Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the user agent. Because of this, user agents may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE]. [=[RPS]=] should assume that, if the `credProps` extension is supported, then user agents will endeavour to populate the {{rk}} property. Therefore a missing {{rk}} indicates that the user agent believes that the created credential is mostly likely a [=non-discoverable credential=].
     </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -2743,8 +2743,8 @@ This enumeration's values describe the [=[RP]=]'s requirements for [=client-side
         [=client-side discoverable credential=].
 
     :   <dfn>preferred</dfn>
-    ::  This value indicates the [=[RP]=] prefers creating a [=client-side discoverable credential=], but will accept a
-        [=server-side credential=].
+    ::  This value indicates the [=[RP]=] strongly prefers creating a [=client-side discoverable credential=], but will accept a
+        [=server-side credential=]. For example, user agents SHOULD guide the user through setting up [=user verification=] if needed to create a [=client-side discoverable credential=] in this case. This takes precedence over the setting of {{PublicKeyCredentialRequestOptions/userVerification}}.
 
     :   <dfn>required</dfn>
     ::  This value indicates the [=[RP]=] requires a [=client-side discoverable credential=], and is prepared to receive an error

--- a/index.bs
+++ b/index.bs
@@ -5693,7 +5693,7 @@ At this time, one [=credential property=] is defined: the [=resident key credent
             if {{rk}} is [FALSE], the credential is a [=server-side credential=].
             If {{rk}} is not present, it is not known whether the credential is a [=discoverable credential=] or a [=server-side credential=].
 
-            Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the user agent. Because of this, user agents may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE]. [=[RPS]=] should assume that, if the `credProps` extension is supported, then user agents will endeavour to populate the {{rk}} property. Therefore a missing {{rk}} indicates that the user agent believes that the created credential is mostly likely a [=non-discoverable credential=].
+            Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the [=client platform=]. Because of this, [=client platforms=] may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE]. [=[RPS]=] should assume that, if the `credProps` extension is supported, then [=client platforms=] will endeavour to populate the {{rk}} property. Therefore a missing {{rk}} indicates that the created credential is most likely a [=non-discoverable credential=].
     </div>
 
 


### PR DESCRIPTION
This change emphasises |residentKey| over |requireResidentKey| and updates some wording to note that the naming is historic. It adds a note to highlight one implication of the fact that RPs cannot always know whether a created credential is discoverable or not. Lastly it adds a remark in the credProps extension about why the |rk| field may be often omitted by user agents.
    
Fixes #1459, #1457.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1467.html" title="Last updated on Aug 24, 2020, 6:54 PM UTC (5690b57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1467/f018e59...agl:5690b57.html" title="Last updated on Aug 24, 2020, 6:54 PM UTC (5690b57)">Diff</a>