### PR TITLE
Make largeBlobs explicit during create.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5865,7 +5865,7 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
 ::
        1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present:
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
-       1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value `true`:
+       1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value [TRUE]:
            1. If the [=assertion=] operation is successful, attempt to read any data associated with the asserted credential.
            1. If successful, set {{AuthenticationExtensionsLargeBlobOutputs/blob}} to the result.
        1. If {{AuthenticationExtensionsLargeBlobInputs/write}} is present, {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element, and {{AuthenticationExtensionsLargeBlobInputs/read}} is not present, or has the value `false`:

--- a/index.bs
+++ b/index.bs
@@ -5838,7 +5838,7 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
     dictionary AuthenticationExtensionsLargeBlobInputs {
         DOMString support;
         boolean read;
-        ArrayBuffer write;
+        BufferSource write;
     };
     </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -5810,7 +5810,7 @@ This [=client extension|client=] [=registration extension=] and [=authentication
 
 Note: [=[RPS]=] can assume that the opaque data will be compressed when being written to a space-limited device and so need not compress it themselves.
 
-Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension does not add an ability to write blobs in the [=registration extension|registration=] context.
+Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension does not add an ability to write blobs in the [=registration extension|registration=] context. However, [=[RPS]=] SHOULD use the [=registration extension=] when creating the credential if they wish to later use the [=authentication extension=].
 
 Since certificates are sizable relative to the storage capabilities of typical authenticators, user agents SHOULD consider what indications and confirmations are suitable to best guide the user in allocating this limited resource and prevent abuse.
 
@@ -5858,7 +5858,7 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
        1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value “required”:
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
            1. When creating the credential, prior to evaluating the [=authenticator attachment modality=], [=iteration/continue=] (i.e. ignore the authenticator) if the authenticator is not capable of storing large blobs.
-       1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value “preferred”:
+       1. Otherwise:
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE] if the authenticator that created the fresh credential supports large blobs and [FALSE] otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])

--- a/index.bs
+++ b/index.bs
@@ -5887,7 +5887,7 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
 
     <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsLargeBlobOutputs">
         :   <dfn>supported</dfn>
-        ::  [TRUE] if, and only if, the created credential supports storing large blobs. Only present after [=registration extension|registration=].
+        ::  [TRUE] if, and only if, the created credential supports storing large blobs. Only present in [=registration extension|registration=] outputs.
 
         :   <dfn>blob</dfn>
         ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid if {{AuthenticationExtensionsLargeBlobInputs/read}} was `true`.

--- a/index.bs
+++ b/index.bs
@@ -5857,9 +5857,10 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
        1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value {{LargeBlobSupport/required}}:
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
-           1. When creating the credential, prior to evaluating the [=authenticator attachment modality=], [=iteration/continue=] (i.e. ignore the authenticator) if the authenticator is not capable of storing large blobs.
+               Note: This is in anticipation of an authenticator capable of storing large blobs becoming available. It occurs during extension processing in Step 11 of {{PublicKeyCredential/[[Create]]()}}. The {{AuthenticationExtensionsLargeBlobOutputs}} will be abandoned if no satisfactory authenticator becomes available.
+           1. If a [=create/candidate authenticator=] becomes available (Step 19 of {{PublicKeyCredential/[[Create]]()}}), then before evaluating any <code>|options|</code>, [=iteration/continue=] (i.e. ignore the [=create/candidate authenticator=] ) if the [=create/candidate authenticator=] is not capable of storing large blobs.
        1. Otherwise (i.e. {{AuthenticationExtensionsLargeBlobInputs/support}} is absent or has the value {{LargeBlobSupport/preferred}}):
-           1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE] if the [=create/selected authenticator=] supports large blobs and [FALSE] otherwise.
+           1. If an [=create/selected authenticator|authenticator is selected=], then if the [=create/selected authenticator=] supports large blobs, set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE], and [FALSE] otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])
 ::
@@ -5869,7 +5870,7 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
        1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value [TRUE]:
            1. Initialize the [=client extension output=], {{AuthenticationExtensionsClientOutputs/largeBlob}}.
-           1. If the [=assertion=] operation is successful, attempt to read any data associated with the asserted credential.
+           1. If any authenticator indicates success (in {{PublicKeyCredential/[[DiscoverFromExternalSource]]()}}), attempt to read any largeBlob data associated with the asserted credential.
            1. If successful, set {{AuthenticationExtensionsLargeBlobOutputs/blob}} to the result.
 
               Note: if the read is not successful, {{AuthenticationExtensionsClientOutputs/largeBlob}} will be present in {{AuthenticationExtensionsClientOutputs}} but the {{AuthenticationExtensionsLargeBlobOutputs/blob}} member will not be present.

--- a/index.bs
+++ b/index.bs
@@ -1799,7 +1799,7 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
             details.
 
         :   If any |authenticator| indicates success,
-        ::  1.  [=set/Remove=] |authenticator| from |issuedRequests|.
+        ::  1.  [=set/Remove=] |authenticator| from |issuedRequests|. This authenticator is now the <dfn for="create">selected authenticator</dfn>.
 
             1.  Let |credentialCreationData| be a [=struct=] whose [=items=] are:
 
@@ -5858,17 +5858,25 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
        1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value {{LargeBlobSupport/required}}:
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
            1. When creating the credential, prior to evaluating the [=authenticator attachment modality=], [=iteration/continue=] (i.e. ignore the authenticator) if the authenticator is not capable of storing large blobs.
-       1. Otherwise:
+       1. Otherwise (i.e. {{AuthenticationExtensionsLargeBlobInputs/support}} is absent or has the value {{LargeBlobSupport/preferred}}):
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE] if the [=create/selected authenticator=] supports large blobs and [FALSE] otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])
 ::
        1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present:
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
+       1. If both {{AuthenticationExtensionsLargeBlobInputs/read}} and {{AuthenticationExtensionsLargeBlobInputs/write}} are present:
+           1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
        1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value [TRUE]:
+           1. Initialize the [=client extension output=], {{AuthenticationExtensionsClientOutputs/largeBlob}}.
            1. If the [=assertion=] operation is successful, attempt to read any data associated with the asserted credential.
            1. If successful, set {{AuthenticationExtensionsLargeBlobOutputs/blob}} to the result.
-       1. If {{AuthenticationExtensionsLargeBlobInputs/write}} is present, {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element, and {{AuthenticationExtensionsLargeBlobInputs/read}} is not present, or has the value `false`:
+
+              Note: if the read is not successful, {{AuthenticationExtensionsClientOutputs/largeBlob}} will be present in {{AuthenticationExtensionsClientOutputs}} but the {{AuthenticationExtensionsLargeBlobOutputs/blob}} member will not be present.
+
+       1. If {{AuthenticationExtensionsLargeBlobInputs/write}} is present:
+           1. If {{PublicKeyCredentialRequestOptions/allowCredentials}} does not contain exactly one element:
+               1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
            1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to store the contents of {{AuthenticationExtensionsLargeBlobInputs/write}} on the [=authenticator=], associated with the indicated credential.
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/written}} to `true` if successful and `false` otherwise.
 

--- a/index.bs
+++ b/index.bs
@@ -1644,6 +1644,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
 
+            1. This |authenticator| is now the <dfn for="create">candidate authenticator</dfn>.
+
             1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}</code> is present:
 
                   1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
@@ -5857,10 +5859,12 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
        1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value {{LargeBlobSupport/required}}:
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
+
                Note: This is in anticipation of an authenticator capable of storing large blobs becoming available. It occurs during extension processing in Step 11 of {{PublicKeyCredential/[[Create]]()}}. The {{AuthenticationExtensionsLargeBlobOutputs}} will be abandoned if no satisfactory authenticator becomes available.
-           1. If a [=create/candidate authenticator=] becomes available (Step 19 of {{PublicKeyCredential/[[Create]]()}}), then before evaluating any <code>|options|</code>, [=iteration/continue=] (i.e. ignore the [=create/candidate authenticator=] ) if the [=create/candidate authenticator=] is not capable of storing large blobs.
+
+           1. If a [=create/candidate authenticator=] becomes available (Step 19 of {{PublicKeyCredential/[[Create]]()}}) then, before evaluating any <code>|options|</code>, [=iteration/continue=] (i.e. ignore the [=create/candidate authenticator=]) if the [=create/candidate authenticator=] is not capable of storing large blobs.
        1. Otherwise (i.e. {{AuthenticationExtensionsLargeBlobInputs/support}} is absent or has the value {{LargeBlobSupport/preferred}}):
-           1. If an [=create/selected authenticator|authenticator is selected=], then if the [=create/selected authenticator=] supports large blobs, set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE], and [FALSE] otherwise.
+           1. If an [=create/selected authenticator|authenticator is selected=] and the [=create/selected authenticator=] supports large blobs, set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE], and [FALSE] otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])
 ::

--- a/index.bs
+++ b/index.bs
@@ -5855,11 +5855,11 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
 ::
        1. If {{AuthenticationExtensionsLargeBlobInputs/read}} or {{AuthenticationExtensionsLargeBlobInputs/write}} is present:
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
-       1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value “required”:
+       1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value {{LargeBlobSupport/required}}:
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
            1. When creating the credential, prior to evaluating the [=authenticator attachment modality=], [=iteration/continue=] (i.e. ignore the authenticator) if the authenticator is not capable of storing large blobs.
        1. Otherwise:
-           1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE] if the authenticator that created the fresh credential supports large blobs and [FALSE] otherwise.
+           1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE] if the [=create/selected authenticator=] supports large blobs and [FALSE] otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])
 ::

--- a/index.bs
+++ b/index.bs
@@ -5806,11 +5806,11 @@ Note: If PRF results are obtained during [=registration=] then the [=[RP]=] MUST
 
 ## Large blob storage extension (<dfn>largeBlob</dfn>) ## {#sctn-large-blob-extension}
 
-This [=client extension|client=] [=authentication extension=] allows a [=[RP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[RPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[RP]=] might wish to issue certificates rather than run a centralised authentication service.
+This [=client extension|client=] [=registration extension=] and [=authentication extension=] allows a [=[RP]=] to store opaque data associated with a credential. Since [=authenticators=] can only store small amounts of data, and most [=[RPS]=] are online services that can store arbitrary amounts of state for a user, this is only useful in specific cases. For example, the [=[RP]=] might wish to issue certificates rather than run a centralised authentication service.
 
 Note: [=[RPS]=] can assume that the opaque data will be compressed when being written to a space-limited device and so need not compress it themselves.
 
-Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension is not defined in the [=registration extension|registration=] context.
+Since a certificate system needs to sign over the public key of the credential, and that public key is only available after creation, this extension does not add an ability to write blobs in the [=registration extension|registration=] context.
 
 Since certificates are sizable relative to the storage capabilities of typical authenticators, user agents SHOULD consider what indications and confirmations are suitable to best guide the user in allocating this limited resource and prevent abuse.
 
@@ -5820,7 +5820,7 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
 :: `largeBlob`
 
 : Operation applicability
-:: [=authentication extension|Authentication=]
+:: [=registration extension|Registration=] and [=authentication extension|authentication=]
 
 : Client extension input
 ::  <xmp class="idl">
@@ -5828,22 +5828,43 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
         AuthenticationExtensionsLargeBlobInputs largeBlob;
     };
 
+    enum LargeBlobSupport {
+      "required",
+      "preferred",
+    };
+
     dictionary AuthenticationExtensionsLargeBlobInputs {
+        DOMString support;
         boolean read;
         ArrayBuffer write;
     };
     </xmp>
 
     <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsLargeBlobInputs">
+        :   <dfn>support</dfn>
+        ::  A DOMString that takes one of the values of {{LargeBlobSupport}}. (See [[#sct-domstring-backwards-compatibility]].) Only valid during [=registration extension|registration=].
+
         :   <dfn>read</dfn>
-        ::  A boolean that indicates that the [=[RP]=] would like to fetch the previously-written blob associated with the asserted credential.
+        ::  A boolean that indicates that the [=[RP]=] would like to fetch the previously-written blob associated with the asserted credential. Only valid during [=authentication extension|authentication=].
 
         :   <dfn>write</dfn>
-        ::  An opaque byte string that the [=[RP]=] wishes to store with the existing credential.
+        ::  An opaque byte string that the [=[RP]=] wishes to store with the existing credential. Only valid during [=authentication extension|authentication=].
     </div>
+
+: Client extension processing ([=registration extension|registration=])
+::
+       1. If {{AuthenticationExtensionsLargeBlobInputs/read}} or {{AuthenticationExtensionsLargeBlobInputs/write}} is present:
+           1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
+       1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value “required”:
+           1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
+           1. When creating the credential, prior to evaluating the [=authenticator attachment modality=], [=iteration/continue=] (i.e. ignore the authenticator) if the authenticator is not capable of storing large blobs.
+       1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present and has the value “preferred”:
+           1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE] if the authenticator that created the fresh credential supports large blobs and [FALSE] otherwise.
 
 : Client extension processing ([=authentication extension|authentication=])
 ::
+       1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present:
+           1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
        1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value `true`:
            1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to read any data associated with the asserted credential.
            1. If successful, set {{AuthenticationExtensionsLargeBlobOutputs/blob}} to the result.
@@ -5858,12 +5879,16 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
     };
 
     dictionary AuthenticationExtensionsLargeBlobOutputs {
+        boolean supported;
         ArrayBuffer blob;
         boolean written;
     };
     </xmp>
 
     <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsLargeBlobOutputs">
+        :   <dfn>supported</dfn>
+        ::  [TRUE] if, and only if, the created credential supports storing large blobs. Only present after [=registration extension|registration=].
+
         :   <dfn>blob</dfn>
         ::  The opaque byte string that was associated with the credential identified by {{PublicKeyCredential/rawId}}. Only valid if {{AuthenticationExtensionsLargeBlobInputs/read}} was `true`.
 

--- a/index.bs
+++ b/index.bs
@@ -5866,7 +5866,7 @@ Note: In order to interoperate, user agents storing large blobs on authenticator
        1. If {{AuthenticationExtensionsLargeBlobInputs/support}} is present:
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
        1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value `true`:
-           1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to read any data associated with the asserted credential.
+           1. If the [=assertion=] operation is successful, attempt to read any data associated with the asserted credential.
            1. If successful, set {{AuthenticationExtensionsLargeBlobOutputs/blob}} to the result.
        1. If {{AuthenticationExtensionsLargeBlobInputs/write}} is present, {{PublicKeyCredentialRequestOptions/allowCredentials}} contains exactly one element, and {{AuthenticationExtensionsLargeBlobInputs/read}} is not present, or has the value `false`:
            1. If the [[#sctn-getAssertion|assertion]] operation is successful, attempt to store the contents of {{AuthenticationExtensionsLargeBlobInputs/write}} on the [=authenticator=], associated with the indicated credential.


### PR DESCRIPTION
Once largeBlobKey (at CTAP2) became something that the authenticator
could derive I had hoped that we could simplify the WebAuthn level
extension and not have a creation extension. Instead, user agents could
just always create a largeBlobKey in contexts where the extension could
be used.

However 100% (i.e. both) people who have looked at this now though that
was non-obvious and so it's probably Too Cute and should be More
Explicit. Also, it's been suggested that it would be a waste of a
resident credential if the RP needed to store a blob and only found out
after at assertion time that it wouldn't work.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1470.html" title="Last updated on Sep 28, 2020, 9:01 PM UTC (5a7f641)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1470/faa8de8...agl:5a7f641.html" title="Last updated on Sep 28, 2020, 9:01 PM UTC (5a7f641)">Diff</a>