### PR TITLE
Virtual authenticators extension support

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5469,7 +5469,7 @@ Instead, in step three, the comparison on the host is relaxed to accept hosts on
 : Authenticator extension output
 :: None.
 
-## FIDO <dfn>AppID Exclusion</dfn> Extension (appidExclude) ## {#sctn-appid-exclude-extension}
+## FIDO AppID Exclusion Extension (appidExclude) ## {#sctn-appid-exclude-extension}
 
 This registration extension allows [=[WRPS]=] to exclude authenticators that contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
 
@@ -5933,38 +5933,20 @@ Additionally, [=extension capabilities=] are defined for every [=authenticator e
         </thead>
         <tbody>
             <tr>
-                <td>FIDO AppID Extension Support</td>
-                <td>`"webauthn:appid"`</td>
-                <td>boolean</td>
-                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=AppID=] extension.</td>
-            </tr>
-            <tr>
-                <td>FIDO AppID Exclusion Extension Support</td>
-                <td>`"webauthn:appidExclude"`</td>
-                <td>boolean</td>
-                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=AppID Exclusion=] extension.</td>
-            </tr>
-            <tr>
                 <td>User Verification Method Extension Support</td>
-                <td>`"webauthn:uvm"`</td>
+                <td>`"webauthn:extension:uvm"`</td>
                 <td>boolean</td>
                 <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=User Verification Method=] extension.</td>
             </tr>
             <tr>
-                <td>Credential Properties Extension Support</td>
-                <td>`"webauthn:credProps"`</td>
-                <td>boolean</td>
-                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=credProps=] extension.</td>
-            </tr>
-            <tr>
                 <td>Pseudo-Random Function Extension Support</td>
-                <td>`"webauthn:prf"`</td>
+                <td>`"webauthn:extension:prf"`</td>
                 <td>boolean</td>
                 <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=prf=] extension.</td>
             </tr>
             <tr>
                 <td>Large Blob Storage Extension Support</td>
-                <td>`"webauthn:largeBlob"`</td>
+                <td>`"webauthn:extension:largeBlob"`</td>
                 <td>boolean</td>
                 <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=largeBlob=] extension.</td>
             </tr>
@@ -6015,8 +5997,12 @@ Each stored [=virtual authenticator=] has the following properties:
 : |extensions|
 :: A string array containing the [=extension identifiers=] supported by the [=Virtual Authenticator=].
 
-[=Virtual authenticators=] MUST support all [=authenticator extensions=] present in its |extensions| array.
-They MUST NOT support any [=authenticator extension=] not present in its |extensions| array.
+    A [=Virtual authenticator=] MUST support all [=authenticator extensions=] present in its |extensions| array.
+    It MUST NOT support any [=authenticator extension=] not present in its |extensions| array.
+: |uvm|
+:: A {{UvmEntries}} array to be set as the [=authenticator extension output=] when processing the [=User Verification Method=] extension.
+
+   Note: This property has no effect if the [=Virtual Authenticator=] does not support the [=User Verification Method=] extension.
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
@@ -6093,6 +6079,12 @@ The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=
                 <td>|extensions|</td>
                 <td>string array</td>
                 <td>An array containing [=extension identifiers=]</td>
+                <td>Empty array</td>
+            </tr>
+            <tr>
+                <td>|uvm|</td>
+                <td>{{UvmEntries}}</td>
+                <td>Up to 3 [=User Verification Method=] entries</td>
                 <td>Empty array</td>
             </tr>
         </tbody>
@@ -6229,6 +6221,14 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>The initial value for a [=signature counter=] associated to the [=public key credential source=].</td>
                 <td>number</td>
             </tr>
+            <tr>
+                <td>|largeBlob|</td>
+                <td>
+                    The [=large, per-credential blob=] associated to the [=public key credential source=], encoded using [=Base64url Encoding=].
+                    This property may not be defined.
+                </td>
+                <td>string</td>
+            </tr>
         </tbody>
     </table>
 </figure>
@@ -6260,6 +6260,11 @@ The [=remote end steps=] are:
  1. Let |authenticator| be the [=Virtual Authenticator=] matched by |authenticatorId|.
  1. If |isResidentCredential| is [TRUE] and the |authenticator|'s |hasResidentKey| property is [FALSE], return a
      [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. If the |authenticator| supports the [=largeBlob=] extension and the |parameters|' |largeBlob| feature is defined:
+     1. Let |largeBlob| be the result of decoding [=Base64url Encoding=] on the |parameters|' |largeBlob| property.
+     1. If |largeBlob| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Otherwise:
+     1. Let |largeBlob| be `null`.
  1. Let |credential| be a new [=Client-side discoverable Public Key Credential Source=] if |isResidentCredential| is [TRUE]
      or a [=Server-side Public Key Credential Source=] otherwise whose items are:
     : [=public key credential source/type=]
@@ -6274,6 +6279,7 @@ The [=remote end steps=] are:
     :: |userHandle|
  1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'
      |signCount| or `0` if |signCount| is `null`.
+ 1. If |largeBlob| is not `null`, set the [=large, per-credential blob=] associated to the |credential| to |largeBlob|.
  1. Store the |credential| and |counter| in the database of the |authenticator|.
  1. Return [=success=].
 

--- a/index.bs
+++ b/index.bs
@@ -5919,7 +5919,8 @@ When [=matching capabilities=], the extension-specific steps to match `"webauthn
 
 ### <dfn>Authenticator Extension Capabilities</dfn> ### {#sctn-authenticator-extension-capabilities}
 
-Additionally, [=extension capabilities=] are defined for every [=authenticator extension=] defined in this specification:
+Additionally, [=extension capabilities=] are defined for every [=authenticator extension=]
+(i.e. those defining [=authenticator extension processing=]) defined in this specification:
 
 <figure id="table-virtualAuthenticatorsExtensionsWebdriverCapability" class="table">
     <table class="data">
@@ -6002,7 +6003,7 @@ Each stored [=virtual authenticator=] has the following properties:
 : |uvm|
 :: A {{UvmEntries}} array to be set as the [=authenticator extension output=] when processing the [=User Verification Method=] extension.
 
-   Note: This property has no effect if the [=Virtual Authenticator=] does not support the [=User Verification Method=] extension.
+    Note: This property has no effect if the [=Virtual Authenticator=] does not support the [=User Verification Method=] extension.
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 

--- a/index.bs
+++ b/index.bs
@@ -284,6 +284,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
         text: session; url: dfn-session
         text: success; url: dfn-success
         text: trying; url: dfn-try
+        text: unsupported operation; url: dfn-unsupported-operation
         text: validating capabilities; url: dfn-validate-capabilities
 
 spec: UTR29
@@ -5468,7 +5469,7 @@ Instead, in step three, the comparison on the host is relaxed to accept hosts on
 : Authenticator extension output
 :: None.
 
-## FIDO AppID Exclusion Extension (appidExclude) ## {#sctn-appid-exclude-extension}
+## FIDO <dfn>AppID Exclusion</dfn> Extension (appidExclude) ## {#sctn-appid-exclude-extension}
 
 This registration extension allows [=[WRPS]=] to exclude authenticators that contain specified credentials that were created with the legacy FIDO U2F JavaScript API [[FIDOU2FJavaScriptAPI]].
 
@@ -5554,7 +5555,7 @@ During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a popu
 : Authenticator extension output
 :: None.
 
-## User Verification Method Extension (uvm) ## {#sctn-uvm-extension}
+## <dfn>User Verification Method</dfn> Extension (uvm) ## {#sctn-uvm-extension}
 
 This extension enables use of a user verification method.
 
@@ -5916,6 +5917,74 @@ When [=matching capabilities=], the extension-specific steps to match `"webauthn
         the match is unsuccessful.
     2. Otherwise, the match is successful.
 
+### <dfn>Authenticator Extension Capabilities</dfn> ### {#sctn-authenticator-extension-capabilities}
+
+Additionally, [=extension capabilities=] are defined for every [=authenticator extension=] defined in this specification:
+
+<figure id="table-virtualAuthenticatorsExtensionsWebdriverCapability" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Capability</th>
+                <th>Key</th>
+                <th>Value Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>FIDO AppID Extension Support</td>
+                <td>`"webauthn:appid"`</td>
+                <td>boolean</td>
+                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=AppID=] extension.</td>
+            </tr>
+            <tr>
+                <td>FIDO AppID Exclusion Extension Support</td>
+                <td>`"webauthn:appidExclude"`</td>
+                <td>boolean</td>
+                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=AppID Exclusion=] extension.</td>
+            </tr>
+            <tr>
+                <td>User Verification Method Extension Support</td>
+                <td>`"webauthn:uvm"`</td>
+                <td>boolean</td>
+                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=User Verification Method=] extension.</td>
+            </tr>
+            <tr>
+                <td>Credential Properties Extension Support</td>
+                <td>`"webauthn:credProps"`</td>
+                <td>boolean</td>
+                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=credProps=] extension.</td>
+            </tr>
+            <tr>
+                <td>Pseudo-Random Function Extension Support</td>
+                <td>`"webauthn:prf"`</td>
+                <td>boolean</td>
+                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=prf=] extension.</td>
+            </tr>
+            <tr>
+                <td>Large Blob Storage Extension Support</td>
+                <td>`"webauthn:largeBlob"`</td>
+                <td>boolean</td>
+                <td>Indicates whether the [=endpoint node=] WebAuthn WebDriver implementation supports the [=largeBlob=] extension.</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+When [=validating capabilities=], the extension-specific substeps to validate an [=authenticator extension capability=] `key` with `value` are the following:
+
+    1. If `value` is not a [=boolean=] return a [=WebDriver Error=] with [=WebDriver error code=] [=invalid argument=].
+    2. Otherwise, let `deserialized` be set to `value`.
+
+When [=matching capabilities=], the extension-specific steps to match an [=authenticator extension capability=] `key` with `value` are the following:
+
+    1. If `value` is [TRUE] and the [=endpoint node=] WebAuthn WebDriver implementation does not support the [=authenticator extension=] identified by the `key`,
+        the match is unsuccessful.
+    2. Otherwise, the match is successful.
+
+User-Agents implementing defined [=authenticator extensions=] SHOULD implement the corresponding [=authenticator extension capability=].
+
 ## <dfn>Virtual Authenticators</dfn> ## {#sctn-automation-virtual-authenticators}
 
 These WebDriver [=extension commands=] create and interact with [=Virtual Authenticators=]: software implementations of the
@@ -5943,6 +6012,11 @@ Each stored [=virtual authenticator=] has the following properties:
     [=User Verification=] will always succeed. If set to [FALSE], it will fail.
 
     Note: This property has no effect if |hasUserVerification| is set to [FALSE].
+: |extensions|
+:: A string array containing the [=extension identifiers=] supported by the [=Virtual Authenticator=].
+
+[=Virtual authenticators=] MUST support all [=authenticator extensions=] present in its |extensions| array.
+They MUST NOT support any [=authenticator extension=] not present in its |extensions| array.
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
@@ -6015,6 +6089,12 @@ The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=
                 <td>[TRUE], [FALSE]</td>
                 <td>[FALSE]</td>
             </tr>
+            <tr>
+                <td>|extensions|</td>
+                <td>string array</td>
+                <td>An array containing [=extension identifiers=]</td>
+                <td>Empty array</td>
+            </tr>
         </tbody>
     </table>
 </figure>
@@ -6039,6 +6119,9 @@ The [=remote end steps=] are:
  1. For each property in [=Authenticator Configuration=]:
     1. If `key` is not a defined property of |authenticator|, return a [=WebDriver error=] with [=WebDriver error code=]
         [=invalid argument=].
+ 1. For each |extension| in |authenticator|.|extensions|:
+    1. If |extension| is not an [=extension identifier=] supported by the [=endpoint node=] WebAuthn WebDriver implementation,
+        return a [=WebDriver error=] with [=WebDriver error code=] [=unsupported operation=].
  1. Generate a valid unique [=authenticatorId=].
  1. [=Set a property=] `authenticatorId` to |authenticatorId| on |authenticator|.
  1. Store |authenticator| in the [=Virtual Authenticator Database=].


### PR DESCRIPTION
Add support for authenticator extensions on WebDriver virtual authenticators.

This comes in the form of:
* A capability for each extension signalling support.
* An option to toggle which extensions are supported by a given virtual authenticator.

Fixes #1471


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nsatragno/webauthn/pull/1472.html" title="Last updated on Sep 2, 2020, 3:52 PM UTC (ea9ad16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1472/ad8d1d0...nsatragno:ea9ad16.html" title="Last updated on Sep 2, 2020, 3:52 PM UTC (ea9ad16)">Diff</a>