### PR TITLE
Abstracting the concept of Privacy CA/Attestation CA into Anonymization CA

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4272,7 +4272,7 @@ under [=[RP]=] policy.
 :: In this case, the [=authenticator=] works with a cloud-operated [=Anonymization CA=] owned by its manufacturer to dynamically generate per-[=credential=] [=attestation certificates=] on the CA such that no identification information of the [=authenticator=] will be revealed to [=[RPS]=] in the [=attestation statement=].
 
     Note: [=Attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=AttCA=] or [=AnonCA=] use the same data structure
-        as [=attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=Basic=], so the three attestation types
+        as those of [=attestation type|type=] [=Basic=], so the three attestation types
         are, in general, distinguishable only with externally provided knowledge regarding the contents of the [=attestation
         certificates=] conveyed in the [=attestation statement=].
 

--- a/index.bs
+++ b/index.bs
@@ -2778,7 +2778,7 @@ Note: The {{AttestationConveyancePreference}} enumeration is deliberately not re
     :   <dfn>none</dfn>
     ::  This value indicates that the [=[RP]=] is not interested in [=authenticator=] [=attestation=]. For example, in order to
         potentially avoid having to obtain [=user consent=] to relay identifying information to the [=[RP]=], or to save a
-        roundtrip to an [=Attestation CA=].
+        roundtrip to an [=Attestation CA=] or [=Anonymization CA=].
 
         This is the default value.
 
@@ -4264,10 +4264,13 @@ calling {{CredentialsContainer/create()|navigator.credentials.create()}} they se
     Note: This concept typically leads to multiple attestation certificates. The attestation certificate requested most recently
         is called "active".
 
-    Note: [=Attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=AttCA=] use the same data structure
-    as [=attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=Basic=], so the two attestation types
-    are, in general, distinguishable only with externally provided knowledge regarding the contents of the [=attestation
-    certificates=] conveyed in the [=attestation statement=].
+: <dfn>Anonymization CA</dfn> (<dfn>AnonCA</dfn>)
+:: In this case, the [=authenticator=] works with a cloud-operated [=Anonymization CA=] owned by its manufacturer to dynamically generate per-[=credential=] [=attestation certificates=] on the CA such that no identification information of the [=authenticator=] will be revealed to [=[RPS]=] in the [=attestation statement=].
+
+    Note: [=Attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=AttCA=] or [=AnonCA=] use the same data structure
+        as [=attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=Basic=], so the three attestation types
+        are, in general, distinguishable only with externally provided knowledge regarding the contents of the [=attestation
+        certificates=] conveyed in the [=attestation statement=].
 
 : No attestation statement (<dfn>None</dfn>)
 :: In this case, no attestation information is available. See also [[#sctn-none-attestation]].
@@ -6717,7 +6720,7 @@ instead of revealing the biometric data itself to the [=[RP]=].
 
 ### Attestation Privacy ### {#sctn-attestation-privacy}
 
-[=Attestation certificates=] and [=attestation key pairs=] and can be used to track users
+[=Attestation certificates=] and [=attestation key pairs=] can be used to track users
 or link various online identities of the same user together.
 This can be mitigated in several ways, including:
 
@@ -6733,16 +6736,14 @@ This can be mitigated in several ways, including:
     sufficiently large groups. This may serve as guidance about suitable batch sizes.
 
 - A [=[WAA]=] may be capable of dynamically generating different [=attestation key pairs=] (and requesting related
-    [=attestation certificate|certificates=]) per-[=origin=]
-    (similar to the [=Attestation CA=] approach). For example, an [=authenticator=] can ship with a
+    [=attestation certificate|certificates=]) per-[=credential=] as described in the [=Anonymization CA=] approach. For example, an [=authenticator=] can ship with a
     master [=attestation private key=] (and [=attestation certificate|certificate=]),
-    and combined with a cloud-operated <dfn>Anonymization CA</dfn>,
-    can dynamically generate per-[=origin=] [=attestation key pairs=] and [=attestation certificates=].
+    and combined with a cloud-operated [=Anonymization CA=],
+    can dynamically generate per-[=credential=] [=attestation key pairs=] and [=attestation certificates=].
 
     Note: In various places outside this specification, the term "Privacy CA" is used to refer to what is termed here
         as an [=Anonymization CA=]. Because the Trusted Computing Group (TCG) also used the term "Privacy CA" to refer to what
-        the TCG now refers to as an [=Attestation CA=] (ACA) [[!TCG-CMCProfile-AIKCertEnroll]], and the envisioned functionality
-        of an [=Anonymization CA=] is not firmly established, we are using the term [=Anonymization CA=] here to try to mitigate
+        the TCG now refers to as an [=Attestation CA=] (ACA) [[!TCG-CMCProfile-AIKCertEnroll]], we are using the term [=Anonymization CA=] here to try to mitigate
         confusion in the specific context of this specification.
 
 

--- a/index.bs
+++ b/index.bs
@@ -4269,7 +4269,7 @@ under [=[RP]=] policy.
         is called "active".
 
 : <dfn>Anonymization CA</dfn> (<dfn>AnonCA</dfn>)
-:: In this case, the [=authenticator=] works with a cloud-operated [=Anonymization CA=] owned by its manufacturer to dynamically generate per-[=credential=] [=attestation certificates=] on the CA such that no identification information of the [=authenticator=] will be revealed to [=[RPS]=] in the [=attestation statement=].
+:: In this case, the [=authenticator=] works with a cloud-operated [=Anonymization CA=] owned by its manufacturer to dynamically generate per-[=credential=] [=attestation certificates=] on the CA such that no identification information of an individual [=authenticator=] will be revealed to [=[RPS]=] in the [=attestation statement=].
 
     Note: [=Attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=AttCA=] or [=AnonCA=] use the same data structure
         as those of [=attestation type|type=] [=Basic=], so the three attestation types

--- a/index.bs
+++ b/index.bs
@@ -4269,7 +4269,7 @@ under [=[RP]=] policy.
         is called "active".
 
 : <dfn>Anonymization CA</dfn> (<dfn>AnonCA</dfn>)
-:: In this case, the [=authenticator=] works with a cloud-operated [=Anonymization CA=] owned by its manufacturer to dynamically generate per-[=credential=] [=attestation certificates=] on the CA such that no identification information of an individual [=authenticator=] will be revealed to [=[RPS]=] in the [=attestation statement=].
+:: In this case, the [=authenticator=] uses an [=Anonymization CA=] which dynamically generates per-[=credential=] [=attestation certificates=] such that the [=attestation statements=] presented to [=[RPS]=] do not provide uniquely identifiable information, e.g., that might be used for tracking purposes.
 
     Note: [=Attestation statements=] conveying [=attestations=] of [=attestation type|type=] [=AttCA=] or [=AnonCA=] use the same data structure
         as those of [=attestation type|type=] [=Basic=], so the three attestation types


### PR DESCRIPTION
This patch defines Anonymous CA which only gathers abstract common facts from Privacy CA/Attestation CA like technology such that different authenticator vendors can refer to it without refering to the TCG definition.

This PR is to fix #1422.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alanwaketan/webauthn/pull/1474.html" title="Last updated on Oct 28, 2020, 7:08 PM UTC (702abf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1474/3d38cab...alanwaketan:702abf6.html" title="Last updated on Oct 28, 2020, 7:08 PM UTC (702abf6)">Diff</a>