### PR TITLE
Update "feature policy" refs to new name "permissions policy" (#1473)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -162,7 +162,7 @@ spec: RFC8230; urlPrefix: https://tools.ietf.org/html/rfc8230
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
         urlPrefix: dom.html
-            for: Document; url: concept-document-feature-policy; text: feature policy
+            for: Document; url: concept-document-permissions-policy; text: permissions policy
         urlPrefix: browsers.html
             text: browsing context; url: browsing-context
         urlPrefix: origin.html
@@ -1475,8 +1475,8 @@ This [=internal method=] accepts three arguments:
         [=same-origin with its ancestors=]. It is [FALSE] if caller is cross-origin.
 
         Note: Invocation of this [=internal method=] indicates that it was allowed by
-        [=feature policy=], which is evaluated at the [[!CREDENTIAL-MANAGEMENT-1]] level.
-        See [[#sctn-feature-policy]].
+        [=permissions policy=], which is evaluated at the [[!CREDENTIAL-MANAGEMENT-1]] level.
+        See [[#sctn-permissions-policy]].
 
 </dl>
 
@@ -1940,8 +1940,8 @@ This [=internal method=] accepts three arguments:
         [=same-origin with its ancestors=]. It is [FALSE] if caller is cross-origin.
 
         Note: Invocation of this [=internal method=] indicates that it was allowed by
-        [=feature policy=], which is evaluated at the [[!CREDENTIAL-MANAGEMENT-1]] level.
-        See [[#sctn-feature-policy]].
+        [=permissions policy=], which is evaluated at the [[!CREDENTIAL-MANAGEMENT-1]] level.
+        See [[#sctn-permissions-policy]].
 </dl>
 
 Note: <strong>This algorithm is synchronous:</strong> the {{Promise}} resolution/rejection is handled by
@@ -2323,7 +2323,7 @@ This method has no arguments and returns a Boolean value.
     };
 </xmp>
 
-Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=feature policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-feature-policy]].
+Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=permissions policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-permissions-policy]].
 
 </div>
 
@@ -3246,19 +3246,19 @@ Note: The {{UserVerificationRequirement}} enumeration is deliberately not refere
 </div>
 
 
-## Feature Policy integration ## {#sctn-feature-policy}
+## Permissions Policy integration ## {#sctn-permissions-policy}
 
 This specification defines one [=policy-controlled features=] identified by
 the feature-identifier token "<code><dfn data-lt="publickey-credentials-get-feature" export>publickey-credentials-get</dfn></code>".
-Its [=default allowlist=] is '<code>self</code>'. [[!Feature-Policy]]
+Its [=default allowlist=] is '<code>self</code>'. [[!Permissions-Policy]]
 
-A {{Document}}'s [=Document/feature policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
+A {{Document}}'s [=Document/permissions policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
 [=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via
 <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code>.
 If disabled in any document, no content in the document will be [=allowed to use=]
 the foregoing methods: attempting to do so will [return an error](https://www.w3.org/2001/tag/doc/promises-guide#errors).
 
-Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual feature policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=] do not have such access since they are invoked [=in parallel=] (by algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]]).
+Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual permissions policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=] do not have such access since they are invoked [=in parallel=] (by algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]]).
 
 
 


### PR DESCRIPTION
Before
------

```
LINK ERROR: No 'idl' refs found for 'userVerification' with for='['PublicKeyCredentialCreationOptions']'.
{{PublicKeyCredentialCreationOptions/userVerification}}
✔  Successfully generated, with 1 linking errors
```

After
-----

```
LINK ERROR: No 'idl' refs found for 'userVerification' with for='['PublicKeyCredentialCreationOptions']'.
{{PublicKeyCredentialCreationOptions/userVerification}}
WARNING: No 'sctn-feature-policy' ID found, skipping MDN features that would target it.
✔  Successfully generated, with 1 linking errors
```

The extra warning comes from a reference to the old anchor in the `mdn/webauth` cache, it's not due to any change in this spec:

https://github.com/tabatkins/bikeshed-data/blob/e142c0bd2c803105f927509f0cefc95dd132ed62/data/mdn/webauthn.json#L2065


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jcayzac/webauthn/pull/1476.html" title="Last updated on Sep 10, 2020, 6:22 AM UTC (22a75ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1476/383971f...jcayzac:22a75ec.html" title="Last updated on Sep 10, 2020, 6:22 AM UTC (22a75ec)">Diff</a>