### PR TITLE
Add security consideration on detecting non-WebAuthn accounts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6562,6 +6562,27 @@ devices=].
 different [=public key credential|credentials=] are [=bound credential|bound=] to different [=authenticators=].
 
 
+### Unprotected account detection ### {#sctn-unprotected-account-detection}
+
+[INFORMATIVE]
+
+This security consideration applies to [=[RPS]=] that support [=authentication ceremonies=]
+with a non-[=list/empty=] {{PublicKeyCredentialRequestOptions/allowCredentials}} argument as the first authentication step.
+For example, if using authentication with [=server-side credentials=] as the first authentication step.
+
+In this case the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument risks leaking information
+about which user accounts have WebAuthn credentials registered and which do not,
+which may be a signal of account protection strength.
+For example, say an attacker can initiate an [=authentication ceremony=] by providing only a username,
+and the [=[RP]=] responds with an empty {{PublicKeyCredentialRequestOptions/allowCredentials}} for some users
+and a non-empty {{PublicKeyCredentialRequestOptions/allowCredentials}} for other users.
+The attacker can then conclude that the former user accounts
+likely do not require a WebAuthn [=assertion=] for successful authentication,
+and thus focus an attack on those likely weaker accounts.
+
+This issue is similar to the one described in [[#sctn-username-enumeration]]
+and [[#sctn-credential-id-privacy-leak]], and can be mitigated in similar ways.
+
 
 # Privacy Considerations # {#sctn-privacy-considerations}
 
@@ -6806,8 +6827,8 @@ leakage due to such an attack:
         ceremony by invoking {{CredentialsContainer/get()|navigator.credentials.get()}} using a syntactically valid
         {{PublicKeyCredentialRequestOptions}} object that is populated with plausible imaginary values.
 
-        This approach could also be used to mitigate privacy leakage via {{PublicKeyCredentialRequestOptions/allowCredentials}};
-        see [[#sctn-credential-id-privacy-leak]].
+        This approach could also be used to mitigate information leakage via {{PublicKeyCredentialRequestOptions/allowCredentials}};
+        see [[#sctn-unprotected-account-detection]] and [[#sctn-credential-id-privacy-leak]].
 
         Note: The username may be "provided" in various [=[RP]=]-specific fashions: login form, session cookie, etc.
 

--- a/index.bs
+++ b/index.bs
@@ -6574,9 +6574,9 @@ In this case the {{PublicKeyCredentialRequestOptions/allowCredentials}} argument
 about which user accounts have WebAuthn credentials registered and which do not,
 which may be a signal of account protection strength.
 For example, say an attacker can initiate an [=authentication ceremony=] by providing only a username,
-and the [=[RP]=] responds with an empty {{PublicKeyCredentialRequestOptions/allowCredentials}} for some users
-and a non-empty {{PublicKeyCredentialRequestOptions/allowCredentials}} for other users.
-The attacker can then conclude that the former user accounts
+and the [=[RP]=] responds with an non-empty {{PublicKeyCredentialRequestOptions/allowCredentials}} for some users,
+and with failure or a password challenge for other users.
+The attacker can then conclude that the latter user accounts
 likely do not require a WebAuthn [=assertion=] for successful authentication,
 and thus focus an attack on those likely weaker accounts.
 


### PR DESCRIPTION
Fixes #1475.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1480.html" title="Last updated on Sep 10, 2020, 5:21 PM UTC (84cf69e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1480/b4148f2...84cf69e.html" title="Last updated on Sep 10, 2020, 5:21 PM UTC (84cf69e)">Diff</a>