### PR TITLE
Clarify signature format for packed attestations et al

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4305,8 +4305,8 @@ the [=authenticator=] MUST:
     ```
 
 ### Signature Formats for Packed Attestation, FIDO U2F Attestation, and Assertion Signatures ### {#sctn-signature-attestation-types}
-    - For COSEAlgorithmIdentifier -7 (ES256),  and other ECDSA-based algorithms,
-        a signature value is encoded as an ASN.1 DER Ecdsa-Sig-Value, as defined in [[RFC3279]] section 2.2.3.
+    - For COSEAlgorithmIdentifier -7 (ES256),  and other ECDSA-based algorithms, the
+        `sig` value MUST be encoded as an ASN.1 DER Ecdsa-Sig-Value, as defined in [[RFC3279]] section 2.2.3.
 
         ```
         Example:
@@ -4321,15 +4321,18 @@ the [=authenticator=] MUST:
 
         Note: As CTAP1/U2F [=authenticators=] are already producing signatures values in this format, CTAP2
         [=authenticators=] will also produce signatures values in the same format, for consistency reasons.
-        It is recommended that any new attestation formats defined not use ASN.1 encodings,
-        but instead represent signatures as equivalent fixed-length byte arrays without internal structure,
-        using the same representations as used by COSE signatures as defined in [[!RFC8152]] and [[!RFC8230]].
 
-    - For COSEAlgorithmIdentifier -257 (RS256), `sig` contains the signature generated using the
+    It is RECOMMENDED that any new attestation formats defined not use ASN.1 encodings,
+    but instead represent signatures as equivalent fixed-length byte arrays without internal structure,
+    using the same representations as used by COSE signatures as defined in [[!RFC8152]] and [[!RFC8230]]. 
+
+    The below signature format definitions satisfy this requirement and serve as examples for deriving the same for other signature algorithms not explicitly mentioned here:
+
+    - For COSEAlgorithmIdentifier -257 (RS256), `sig` MUST contain the signature generated using the
         RSASSA-PKCS1-v1_5 signature scheme defined in section 8.2.1 in [[RFC8017]] with SHA-256 as the hash function.
         The signature is not ASN.1 wrapped.
 
-    - For COSEAlgorithmIdentifier -37 (PS256), `sig` contains the signature generated using the
+    - For COSEAlgorithmIdentifier -37 (PS256), `sig` MUST contain the signature generated using the
         RSASSA-PSS signature scheme defined in section 8.1.1 in [[RFC8017]] with SHA-256 as the hash function.
         The signature is not ASN.1 wrapped.
 


### PR DESCRIPTION
This makes the existing format recommendation normative, clarifies that the existing sig format definitions are MUSTs, and notes that these are examples of how to handle sig algorithm values that are not presently listed here.

fix #1441


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1488.html" title="Last updated on Sep 30, 2020, 6:42 PM UTC (fcf2c13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1488/6156ba8...fcf2c13.html" title="Last updated on Sep 30, 2020, 6:42 PM UTC (fcf2c13)">Diff</a>