### PR TITLE
Change variable name: uvpaaAvailable → uvpaAvailable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -622,9 +622,9 @@ a [=user-verifying platform authenticator=].
     if (!window.PublicKeyCredential) { /* Client not capable of the API. Handle error. */ }
 
     PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-        .then(function (uvpaaAvailable) {
+        .then(function (uvpaAvailable) {
             // If there is a user-verifying platform authenticator
-            if (uvpaaAvailable) {
+            if (uvpaAvailable) {
                 // Render some RP-specific UI and get a Promise for a Boolean value
                 return askIfUserWantsToCreateCredential();
             }


### PR DESCRIPTION
`uvpaaAvailable` would mean "user-verifying platform authenticator available available"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgarron/webauthn/pull/1500.html" title="Last updated on Oct 16, 2020, 1:28 AM UTC (1f99415)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1500/3d38cab...lgarron:1f99415.html" title="Last updated on Oct 16, 2020, 1:28 AM UTC (1f99415)">Diff</a>