### PR TITLE
Add Virtual Authenticator support for CTAP 2.1

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5926,7 +5926,7 @@ Each stored [=virtual authenticator=] has the following properties:
 :: An non-null string made using up to 48 characters from the `unreserved` production defined in Appendix A of [[RFC3986]]
     that uniquely identifies the [=Virtual Authenticator=].
 : |protocol|
-:: The protocol the [=Virtual Authenticator=] speaks: one of  `"ctap1/u2f"`, `"ctap2"` or `"ctap2_1"`  [[FIDO-CTAP]].
+:: The protocol the [=Virtual Authenticator=] speaks: one of `"ctap1/u2f"`, `"ctap2"` or `"ctap2_1"` [[FIDO-CTAP]].
 : |transport|
 :: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
     authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].

--- a/index.bs
+++ b/index.bs
@@ -5926,7 +5926,7 @@ Each stored [=virtual authenticator=] has the following properties:
 :: An non-null string made using up to 48 characters from the `unreserved` production defined in Appendix A of [[RFC3986]]
     that uniquely identifies the [=Virtual Authenticator=].
 : |protocol|
-:: The protocol the [=Virtual Authenticator=] speaks: either `ctap2` or `ctap1/u2f` [[FIDO-CTAP]].
+:: The protocol the [=Virtual Authenticator=] speaks: one of  `"ctap1/u2f"`, `"ctap2"` or `"ctap2_1"`  [[FIDO-CTAP]].
 : |transport|
 :: The {{AuthenticatorTransport}} simulated. If the |transport| is set to {{AuthenticatorTransport/internal}}, the
     authenticator simulates [=platform attachment=]. Otherwise, it simulates [=cross-platform attachment=].
@@ -5991,7 +5991,7 @@ The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=
             <tr>
                 <td>|protocol|</td>
                 <td>string</td>
-                <td>`"ctap1/u2f"`, `"ctap2"`</td>
+                <td>`"ctap1/u2f"`, `"ctap2"`, `"ctap2_1"`</td>
                 <td>None</td>
             </tr>
             <tr>


### PR DESCRIPTION
Fixes #1505


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 28, 2020, 5:32 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkreichgauer%2Fwebauthn%2F320b6f0592595c9557c61fcc8cd29f68eae99d08%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webauthn%231506.)._
</details>
