### PR TITLE
Fix a link to userVerification parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2745,7 +2745,7 @@ This enumeration's values describe the [=[RP]=]'s requirements for [=client-side
 
     :   <dfn>preferred</dfn>
     ::  This value indicates the [=[RP]=] strongly prefers creating a [=client-side discoverable credential=], but will accept a
-        [=server-side credential=]. For example, user agents SHOULD guide the user through setting up [=user verification=] if needed to create a [=client-side discoverable credential=] in this case. This takes precedence over the setting of {{PublicKeyCredentialCreationOptions/userVerification}}.
+        [=server-side credential=]. For example, user agents SHOULD guide the user through setting up [=user verification=] if needed to create a [=client-side discoverable credential=] in this case. This takes precedence over the setting of {{AuthenticatorSelectionCriteria/userVerification}}.
 
     :   <dfn>required</dfn>
     ::  This value indicates the [=[RP]=] requires a [=client-side discoverable credential=], and is prepared to receive an error


### PR DESCRIPTION
Fixes:
```
LINK ERROR: No 'idl' refs found for 'userVerification' with for='['PublicKeyCredentialCreationOptions']'.
{{PublicKeyCredentialCreationOptions/userVerification}}
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1507.html" title="Last updated on Oct 28, 2020, 9:50 PM UTC (4897221)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1507/87ca0fe...4897221.html" title="Last updated on Oct 28, 2020, 9:50 PM UTC (4897221)">Diff</a>