### PR TITLE
ensure basic attestation type allows for self-signed attestation certs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4249,10 +4249,10 @@ under [=[RP]=] policy.
 
 : <dfn>Basic Attestation</dfn> (<dfn>Basic</dfn>)
 :: In the case of basic attestation [[UAFProtocol]], the authenticator's [=attestation key pair=] is specific to an
-    authenticator model.  Thus, authenticators of the same model often share the same [=attestation key pair=]. See
+    authenticator "model", i.e., a "batch" of authenticators.  Thus, authenticators of the same, or similar, model often share the same [=attestation key pair=]. See
     [[#sctn-attestation-privacy]] for further information.
 
-    [=Basic attestation=] is sometimes also called <dfn>batch attestation</dfn>.
+    [=Basic attestation=] is also referred to as <dfn>batch attestation</dfn>.
 
 : <dfn>Self Attestation</dfn> (<dfn>Self</dfn>)
 :: In the case of [=self attestation=], also known as surrogate basic attestation [[UAFProtocol]], the Authenticator does not have
@@ -4697,7 +4697,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
     :: A byte string containing the [=attestation signature=].
 
     : x5c
-    :: The elements of this array contain |attestnCert| and its certificate chain, each encoded in X.509 format. The attestation
+    :: The elements of this array contain |attestnCert| and its certificate chain (if any), each encoded in X.509 format. The attestation
         certificate |attestnCert| MUST be the first element in the array.
 
     : attestnCert
@@ -4711,7 +4711,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
 
         1. If [=Basic=] or [=AttCA=] [=attestation=] is in use, the authenticator produces the |sig| by concatenating |authenticatorData| and
             |clientDataHash|, and signing the result using an [=attestation private key=] selected through an authenticator-specific
-            mechanism. It sets |x5c| to the certificate chain of the [=attestation public key=] and |alg| to the algorithm of the
+            mechanism. It sets |x5c|'s first element to |attestnCert|'s value, and includes the related certificate chain (if any) in further |x5c| elelment. It sets |alg| to the algorithm of the
             attestation private key.
 
         1. If [=self attestation=] is in use, the authenticator produces |sig| by concatenating |authenticatorData| and |clientDataHash|,

--- a/index.bs
+++ b/index.bs
@@ -4459,6 +4459,8 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
         - Otherwise, use the X.509 certificates returned as the [=attestation trust path=] from the [=verification procedure=]
             to verify that the attestation public key correctly chains up to an acceptable root certificate.
 
+            Note: The attestation certificate and the root certificate obtained above in step 20 can be the same certificate.
+
 1. Check that the <code>[=credentialId=]</code> is not yet registered to any other user. If registration
     is requested for a credential that is already registered to a different user, the [=[RP]=] SHOULD
     fail this [=registration ceremony=], or it MAY decide to accept the registration, e.g. while deleting the older registration.

--- a/index.bs
+++ b/index.bs
@@ -4711,7 +4711,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
 
         1. If [=Basic=] or [=AttCA=] [=attestation=] is in use, the authenticator produces the |sig| by concatenating |authenticatorData| and
             |clientDataHash|, and signing the result using an [=attestation private key=] selected through an authenticator-specific
-            mechanism. It sets |x5c|'s first element to |attestnCert|'s value, and includes the related certificate chain (if any) in further |x5c| elelment. It sets |alg| to the algorithm of the
+            mechanism. It sets |x5c|'s first element to |attestnCert|'s value, and includes the related certificate chain (if any) in further |x5c| element. It sets |alg| to the algorithm of the
             attestation private key.
 
         1. If [=self attestation=] is in use, the authenticator produces |sig| by concatenating |authenticatorData| and |clientDataHash|,

--- a/index.bs
+++ b/index.bs
@@ -4457,7 +4457,7 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
         - If [=None|no attestation=] was provided, verify that [=None=] attestation is acceptable under [=[RP]=] policy.
         - If [=self attestation=] was used, verify that [=self attestation=] is acceptable under [=[RP]=] policy.
         - Otherwise, use the X.509 certificates returned as the [=attestation trust path=] from the [=verification procedure=]
-            to verify that the attestation public key correctly chains up to an acceptable root certificate.
+            to verify that the attestation public key either correctly chains up to an acceptable root certificate, or is itself an acceptable certificate.
 
 
 1. Check that the <code>[=credentialId=]</code> is not yet registered to any other user. If registration

--- a/index.bs
+++ b/index.bs
@@ -4712,7 +4712,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
 
         1. If [=Basic=] or [=AttCA=] [=attestation=] is in use, the authenticator produces the |sig| by concatenating |authenticatorData| and
             |clientDataHash|, and signing the result using an [=attestation private key=] selected through an authenticator-specific
-            mechanism. It sets |x5c|'s first element to |attestnCert|'s value, and includes the related certificate chain (if any) in further |x5c| element. It sets |alg| to the algorithm of the
+            mechanism. It sets |x5c| to |attestnCert| followed by the related certificate chain (if any). It sets |alg| to the algorithm of the
             attestation private key.
 
         1. If [=self attestation=] is in use, the authenticator produces |sig| by concatenating |authenticatorData| and |clientDataHash|,

--- a/index.bs
+++ b/index.bs
@@ -4457,7 +4457,7 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
         - If [=None|no attestation=] was provided, verify that [=None=] attestation is acceptable under [=[RP]=] policy.
         - If [=self attestation=] was used, verify that [=self attestation=] is acceptable under [=[RP]=] policy.
         - Otherwise, use the X.509 certificates returned as the [=attestation trust path=] from the [=verification procedure=]
-            to verify that the attestation public key either correctly chains up to an acceptable root certificate, or is itself an acceptable certificate.
+            to verify that the attestation public key either correctly chains up to an acceptable root certificate, or is itself an acceptable certificate (i.e., it and the root certificate obtained in Step 20 may be the same).
 
 
 1. Check that the <code>[=credentialId=]</code> is not yet registered to any other user. If registration

--- a/index.bs
+++ b/index.bs
@@ -4459,7 +4459,6 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
         - Otherwise, use the X.509 certificates returned as the [=attestation trust path=] from the [=verification procedure=]
             to verify that the attestation public key correctly chains up to an acceptable root certificate.
 
-            Note: The attestation certificate and the root certificate obtained above in step 20 can be the same certificate.
 
 1. Check that the <code>[=credentialId=]</code> is not yet registered to any other user. If registration
     is requested for a credential that is already registered to a different user, the [=[RP]=] SHOULD


### PR DESCRIPTION
This PR simply cleans up the language in [8.2. Packed Attestation Statement Format](https://w3c.github.io/webauthn/#sctn-packed-attestation) such that self-signed attestation certs are implicitly allowed.

fixes #1498


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1509.html" title="Last updated on Nov 9, 2020, 6:32 PM UTC (ff28800)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1509/da36403...ff28800.html" title="Last updated on Nov 9, 2020, 6:32 PM UTC (ff28800)">Diff</a>