### PR TITLE
Update editors and past editors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,7 +27,6 @@ Editor: Jeff Hodges, w3cid 43843, Google, jdhodges@google.com
 Editor: J.C. Jones, w3cid 87240, Mozilla, jc@mozilla.com
 Editor: Michael B. Jones, w3cid 38745, Microsoft, mbj@microsoft.com
 Editor: Akshay Kumar, w3cid 99318, Microsoft, akshayku@microsoft.com
-Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
 Editor: Emil Lundberg, w3cid 102508, Yubico, emil@yubico.com
 Former Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
 Former Editor: Vijay Bharadwaj, w3cid 55440, Microsoft, vijay.bharadwaj@microsoft.com
@@ -35,6 +34,7 @@ Former Editor: Arnar Birgisson, w3cid 87332, Google, arnarb@google.com
 Former Editor: Alexei Czeskis, w3cid 87258, Google, aczeskis@google.com
 Former Editor: Hubert Le Van Gong, w3cid 84817, PayPal, hlevangong@paypal.com
 Former Editor: Angelo Liao, w3cid 94342, Microsoft, huliao@microsoft.com
+Former Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
 !Contributors: <a href="mailto:WebAuthn@ve7jtb.com">John Bradley</a> (Yubico)
 !Contributors: <a href="mailto:cbrand@google.com">Christiaan Brand</a> (Google)
 !Contributors: <a href="mailto:agl@google.com">Adam Langley</a> (Google)

--- a/index.bs
+++ b/index.bs
@@ -23,16 +23,16 @@ Previous Version: https://www.w3.org/TR/2019/REC-webauthn-1-20190304/
 Shortname: webauthn
 Level: 2
 Include MDN Panels: maybe
-Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
-Editor: Alexei Czeskis, w3cid 87258, Google, aczeskis@google.com
 Editor: Jeff Hodges, w3cid 43843, Google, jdhodges@google.com
 Editor: J.C. Jones, w3cid 87240, Mozilla, jc@mozilla.com
 Editor: Michael B. Jones, w3cid 38745, Microsoft, mbj@microsoft.com
 Editor: Akshay Kumar, w3cid 99318, Microsoft, akshayku@microsoft.com
 Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
 Editor: Emil Lundberg, w3cid 102508, Yubico, emil@yubico.com
+Former Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
 Former Editor: Vijay Bharadwaj, w3cid 55440, Microsoft, vijay.bharadwaj@microsoft.com
 Former Editor: Arnar Birgisson, w3cid 87332, Google, arnarb@google.com
+Former Editor: Alexei Czeskis, w3cid 87258, Google, aczeskis@google.com
 Former Editor: Hubert Le Van Gong, w3cid 84817, PayPal, hlevangong@paypal.com
 Former Editor: Angelo Liao, w3cid 94342, Microsoft, huliao@microsoft.com
 !Contributors: <a href="mailto:WebAuthn@ve7jtb.com">John Bradley</a> (Yubico)


### PR DESCRIPTION
Improves issue #1496

Dirk and Alexei have agreed to be moved to Former Editors for L2.

Also Rolf agreed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1548.html" title="Last updated on Jan 27, 2021, 8:14 PM UTC (dc9c31e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1548/a1f9066...dc9c31e.html" title="Last updated on Jan 27, 2021, 8:14 PM UTC (dc9c31e)">Diff</a>