### PR TITLE
Fix link to EduPersonObjectClassSpec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7300,8 +7300,8 @@ for their contributions as our W3C Team Contacts.
   "EduPersonObjectClassSpec": {
     "publisher": ["Internet2 Middleware Architecture Committee for Education, Directory Working Group (MACE-Dir)"],
     "title": "EduPerson Object Class Specification (200604a)",
-    "href": "https://www.internet2.edu/media/medialibrary/2013/09/04/internet2-mace-dir-eduperson-200604.html",
-    "date": "May 15, 2007"
+    "href": "http://software.internet2.edu/eduperson/",
+    "date": "March 15, 2016"
   }
 
 }


### PR DESCRIPTION
This updates the reference link to EduPersonObjectClassSpec in a hopefully future-proof way by linking to the directory in which various versions of the EduPersonObjectClassSpec reside.

fixes #1544


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1561.html" title="Last updated on Feb 4, 2021, 8:02 PM UTC (3d8ba8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1561/e6791c0...3d8ba8e.html" title="Last updated on Feb 4, 2021, 8:02 PM UTC (3d8ba8e)">Diff</a>