### PR TITLE
fix eduPerson reference, again

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7298,10 +7298,10 @@ for their contributions as our W3C Team Contacts.
   },
 
   "EduPersonObjectClassSpec": {
-    "publisher": ["Internet2 Middleware Architecture Committee for Education, Directory Working Group (MACE-Dir)"],
-    "title": "EduPerson Object Class Specification (200604a)",
-    "href": "http://software.internet2.edu/eduperson/",
-    "date": "March 15, 2016"
+    "publisher": "Research and Education FEDerations group - REFEDS.org",
+    "title": "EduPerson",
+    "href": "https://refeds.org/eduperson",
+    "date": "on-going"
   }
 
 }

--- a/index.bs
+++ b/index.bs
@@ -7301,7 +7301,7 @@ for their contributions as our W3C Team Contacts.
     "publisher": "Research and Education FEDerations group - REFEDS.org",
     "title": "EduPerson",
     "href": "https://refeds.org/eduperson",
-    "date": "on-going"
+    "date": "ongoing"
   }
 
 }


### PR DESCRIPTION
Amusingly enough (sigh), just after we were discussing this during our call a few minutes ago, JBradley (@ve7jtb) found out that, no, really, the actual latest-and-greatest eduPerson schema can be found at:

https://refeds.org/eduperson


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1573.html" title="Last updated on Feb 17, 2021, 9:01 PM UTC (04919d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1573/635b391...04919d7.html" title="Last updated on Feb 17, 2021, 9:01 PM UTC (04919d7)">Diff</a>