### PR TITLE
master -> main ?

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6873,7 +6873,7 @@ This can be mitigated in several ways, including:
 
 - A [=[WAA]=] may be capable of dynamically generating different [=attestation key pairs=] (and requesting related
     [=attestation certificate|certificates=]) per-[=credential=] as described in the [=Anonymization CA=] approach. For example, an [=authenticator=] can ship with a
-    master [=attestation private key=] (and [=attestation certificate|certificate=]),
+    main [=attestation private key=] (and [=attestation certificate|certificate=]),
     and combined with a cloud-operated [=Anonymization CA=],
     can dynamically generate per-[=credential=] [=attestation key pairs=] and [=attestation certificates=].
 


### PR DESCRIPTION
Pubrules is now flagging uses of "master" and recommending their replacement. https://w3c.github.io/manual-of-style/#inclusive
Is "main" attestation private key an appropriate substitute?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1578.html" title="Last updated on Feb 25, 2021, 3:23 PM UTC (6649508)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1578/9ce4288...6649508.html" title="Last updated on Feb 25, 2021, 3:23 PM UTC (6649508)">Diff</a>