### PR TITLE
Update CTAP reference.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7253,12 +7253,11 @@ for their contributions as our W3C Team Contacts.
   },
 
   "FIDO-CTAP": {
-    "authors": ["M. Antoine", "V. Bharadwaj", "C. Brand", "A. Czeskis", "J. Ehrensvärd", "J. Hodges", "M. B. Jones", "A. Kumar",
-        "R. Lindemann", "M. J. Ploch", "A. Powers", "J. Verrept"],
+    "authors": ["J. Bradley", "J. Hodges", "M. B. Jones", "A. Kumar", "R. Lindemann", "J. Verrept"],
     "title": "Client to Authenticator Protocol",
-    "href": "https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html",
-    "status": "FIDO Alliance Implementation Draft",
-    "date": "27 February 2018"
+    "href": "https://fidoalliance.org/specs/fido-v2.1-rd-20210309/fido-client-to-authenticator-protocol-v2.1-rd-20210309.html",
+    "status": "FIDO Alliance Review Draft",
+    "date": "9 March 2021"
   },
 
   "FIDO-UAF-AUTHNR-CMDS": {


### PR DESCRIPTION
We probably want to do this again once 2.1 is final but, for now, this
brings in three years of changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1585.html" title="Last updated on Mar 19, 2021, 7:10 PM UTC (237d6a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1585/9ce4288...agl:237d6a4.html" title="Last updated on Mar 19, 2021, 7:10 PM UTC (237d6a4)">Diff</a>