### PR TITLE
Explicitly restrict NONE aaguid to none attestation only

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3326,7 +3326,8 @@ Each authenticator stores a <dfn for=authenticator>credentials map</dfn>, a [=ma
 Additionally, each authenticator has an AAGUID, which is a 128-bit identifier indicating the type (e.g. make and model) of the
 authenticator. The AAGUID MUST be chosen by the manufacturer to be identical across all substantially identical authenticators
 made by that manufacturer, and different (with high probability) from the AAGUIDs of all other types of authenticators.
-The AAGUID for a given type of authenticator SHOULD be randomly generated to ensure this. The [=[RP]=] MAY use the AAGUID to infer certain
+The AAGUID for a given type of authenticator SHOULD be randomly generated to ensure this. The NONE AAGUID(00000000-0000-0000-0000-000000000000
+) is reserved for NONE attestation, and SHALL not be used for other types of attestation. The [=[RP]=] MAY use the AAGUID to infer certain
 properties of the authenticator, such as certification level and strength of key protection, using information from other sources.
 
 The primary function of the authenticator is to provide [=WebAuthn signatures=], which are bound to various contextual data. These


### PR DESCRIPTION
AAGUID 00000000-0000-0000-0000-000000000000 must not be reused by any other attestation.

Apple has recently fixed that (Thank you Jiewen), so we should be explicit with intent of that AAGUID.

Ref:
https://github.com/WebKit/WebKit/blob/b133f3082ab5f5c409915ef3aafaa2ee15196d6d/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
https://bugs.webkit.org/show_bug.cgi?id=217945

cc: @sbweeden


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1588.html" title="Last updated on Mar 25, 2021, 9:06 AM UTC (8e2194b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1588/9ce4288...8e2194b.html" title="Last updated on Mar 25, 2021, 9:06 AM UTC (8e2194b)">Diff</a>