### PR TITLE
Remove user handle "MAY be null" statement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2638,7 +2638,7 @@ credential.
         {{PublicKeyCredentialUserEntity/displayName}} nor {{PublicKeyCredentialEntity/name}} members. See Section 6.1 of [[!RFC8266]].
 
         The [=user handle=] MUST NOT contain [PII] about the user, such as a username or e-mail address;
-        see [[#sctn-user-handle-privacy]] for details. The [=user handle=] MUST NOT be empty, though it MAY be null.
+        see [[#sctn-user-handle-privacy]] for details. The [=user handle=] MUST NOT be empty.
 
         Note: the [=user handle=] <i>ought not</i> be a constant value across different accounts, even for [=non-discoverable credentials=], because some authenticators always create [=discoverable credentials=]. Thus a constant [=user handle=] would prevent a user from using such an authenticator with more than one account at the [=[RP]=].
 


### PR DESCRIPTION
As far as we can tell, the statement "...though it MAY be null" clause of the statement:
> [...] The user handle MUST NOT be empty, though it MAY be null.

..is incorrect and ought to be removed.

cf. https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#dom-publickeycredentialuserentity-id

fixes #1598


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1600.html" title="Last updated on Apr 21, 2021, 9:59 PM UTC (965a18f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1600/d3b1124...965a18f.html" title="Last updated on Apr 21, 2021, 9:59 PM UTC (965a18f)">Diff</a>