### PR TITLE
 Switch h2#subtitle to h2#profile-and-date

### DIFF
--- a/.bikeshed-include/header.include
+++ b/.bikeshed-include/header.include
@@ -12,7 +12,7 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE] [LEVEL]</h1>
-    <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
+    <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
       <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   </header>
   <div data-fill-with="spec-metadata"></div>


### PR DESCRIPTION
Tab agreed to update the id of the `<h2>` to get more consistency between the docs. See https://github.com/w3c/specberus/issues/838

He did the same for the specs managed in the bikeshed repo: https://github.com/tabatkins/bikeshed/commit/43dd92777ec70e3026ff39c9c98935bb418ff958