### PR TITLE
Install Bikeshed from PyPI instead of Git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,12 @@ cache: pip
 before_install:
 - chmod 755 ./.deploy-output.sh
 install:
-- pip install --upgrade setuptools        
-- pip install pygments cssselect html5lib lxml
-- git clone --depth=100 --branch=main https://github.com/tabatkins/bikeshed.git ./bikeshed
-- pip install --editable ./bikeshed
+- pip install bikeshed
 - |
   if "${USE_BIKESHED_CACHE}"; then
     # Use cached copy of bikeshed data files to give consistent builds
-    #- bikeshed update
-    cp -R .spec-data/* ./bikeshed/bikeshed/spec-data
-    cp -R .bikeshed-include/* ./bikeshed/bikeshed/boilerplate/webauthn
+    rsync -aP --delete .spec-data/ "${VIRTUAL_ENV}"/lib/python3.7/site-packages/bikeshed/spec-data/
+    rsync -aP --delete .bikeshed-include/ "${VIRTUAL_ENV}"/lib/python3.7/site-packages/bikeshed/boilerplate/webauthn/
   fi
 script: 'bikeshed spec'
 after_success:


### PR DESCRIPTION
I hope this works?

As noted by @equalsJeffH in https://github.com/w3c/webauthn/pull/1602#issuecomment-832293328 :

> PR #1607's build is failing with this error message:
> 
> > `pkg_resources.DistributionNotFound: The 'typing-extensions<3.8,>=3.7.4.1' distribution was not found and is required by widlparser`

and

>"you're using the old clone+install --editable instructions, when Bikeshed has been published to PyPI for a while now. You can try replacing that with just pip install bikeshed, or you can try moving to the github-actions system shown in https://github.com/WICG/webusb/blob/main/.github/workflows/pr-push.yml."

This keeps the build still on Travis for now, but doesn't preclude migrating to GitHub Actions later.