### PR TITLE
mmiller-improve-terminology

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -919,7 +919,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     portions of the [=attestation object=] to the [=[RP]=] is described by [=attestation conveyance=].
 
 : <dfn>Attestation Certificate</dfn>
-:: A X.509 Certificate for the <dfn>attestation key pair</dfn> used by an [=authenticator=] to attest to its manufacture
+:: An X.509 Certificate for the <dfn>attestation key pair</dfn> used by an [=authenticator=] to attest to its manufacture
     and capabilities. At [=registration=] time, the [=authenticator=] uses the <dfn>attestation private key</dfn> to sign
     the [=[RP]=]-specific [=credential public key=] (and additional data) that it generates and returns via the
     [=authenticatorMakeCredential=] operation. [=[RPS]=] use the <dfn>attestation public key</dfn> conveyed in the [=attestation

--- a/index.bs
+++ b/index.bs
@@ -910,10 +910,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 # Terminology # {#sctn-terminology}
 
 : <dfn>Attestation</dfn>
-:: Generally, <em>attestation</em> is a statement serving to bear witness, confirm, or authenticate.
-    In the WebAuthn context, [=attestation=] is employed to <em>attest</em> to the <em>provenance</em> of an [=authenticator=]
-    and the data it emits; including, for example: [=credential IDs=], [=credential key pairs=], signature counters, etc. An
-    [=attestation statement=] is conveyed in an [=attestation object=] during [=registration=]. See also [[#sctn-attestation]]
+:: Generally, <em>attestation</em> is a statement that serves to bear witness, confirm, or authenticate.
+    In the WebAuthn context, [=attestation=] is employed to provide verifiable evidence as to the origin of an [=authenticator=]
+    and the data it emits. This includes such things as [=credential IDs=], [=credential key pairs=], [=signature counters=], etc.
+
+    An [=attestation statement=] is provided within an [=attestation object=] during a [=registration=] ceremony. See also [[#sctn-attestation]]
     and [Figure 6](#fig-attStructs). Whether or how the [=client=] conveys the [=attestation statement=] and [=AAGUID=]
     portions of the [=attestation object=] to the [=[RP]=] is described by [=attestation conveyance=].
 

--- a/index.bs
+++ b/index.bs
@@ -34,6 +34,7 @@ Former Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
 !Contributors: <a href="mailto:cbrand@google.com">Christiaan Brand</a> (Google)
 !Contributors: <a href="mailto:agl@google.com">Adam Langley</a> (Google)
 !Contributors: <a href="mailto:mandyam@qti.qualcomm.com">Giridhar Mandyam</a> (Qualcomm)
+!Contributors: <a href="mailto:mattmil3@cisco.com">Matthew Miller</a> (Cisco)
 !Contributors: <a href="mailto:nsatragno@google.com">Nina Satragno</a> (Google)
 !Contributors: <a href="mailto:nick.steele@gemini.com">Nick Steele</a> (Gemini)
 !Contributors: <a href="mailto:jiewen_tan@apple.com">Jiewen Tan</a> (Apple)


### PR DESCRIPTION
This PR is my effort to start a conversation on how the beginning of the spec might be reorganized to gradually introduce newcomers to the spec and establish specialized vocabulary before using it in the meat of the document. I've made the following changes:

1. **Use Cases** and **Sample API Usage Scenarios** were raised a header level
2. **Use Cases** now immediately follows **Introduction** to hook readers by demonstrating the capabilities of API with the existing straight-forward scenarios
3. **Dependencies** and **Terminology** follow **Use Cases** to define much of the specialized vocabulary that will be used throughout the rest of the document.
3. **Conformance** now comes after **Dependencies** and **Terminology** as it makes heavy use of vocabulary that is (now) defined beforehand.
4. **Sample API Usage Scenarios** is now the second-to-last section of the document, above **Acknowledgements**, so that everything before it describes "what WebAuthn is", then ends with "here is how you might practically use it".
5. I also fixed a bit of grammar, and a definition that used "attest" to describe "attestation" (you can't use a word to describe itself! 😂)

After all of this reorganization the document flows something like this:

- Introduction
- Specific Vocabulary
- Core Concepts
- Recommendations and Considerations
- Sample Usage

## Context

After an enlightening conversation earlier this week with @equalsJeffH, I came to understand that I've been misusing key terminology and causing confusion in some of my replies to issues, discussions in WG meetings, etc...

While I work on that, I started thinking back to _how_ I came to incorrectly use terms like "attestation" when I really meant "registration", or "assertion" when I really meant "authentication". I think part of it might have been how overwhelming the spec was as a newcomer. The **Terminology** section of the spec never really jumped out at me until recently (sorry @equalsJeffH 😅), and the spec is quick to start using vocabulary in the first couple of sections that aren't defined until a couple of sections later. This all got me thinking about how the spec might be better organized, so I took it as a chance to contribute to the spec in a material way.

I have a hunch this proposed reorganization might be way too drastic - as it's my first PR as a WAWG member I'm still feeling things out. Regardless of the fate of this PR I think there's an opportunity to improve the flow of the spec to benefit readers of all familiarity levels that's worth talking about.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1615.html" title="Last updated on Jun 14, 2021, 6:33 PM UTC (6ab9d71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1615/ff7c715...6ab9d71.html" title="Last updated on Jun 14, 2021, 6:33 PM UTC (6ab9d71)">Diff</a>