### PR TITLE
Note that largeBlob requires discoverable key on CTAP authenticators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5822,11 +5822,11 @@ Since certificates are sizable relative to the storage capabilities of typical a
 
 Note: In order to interoperate, user agents storing large blobs on authenticators using [[!FIDO-CTAP]] are expected to use the provisions detailed in that specification for storing [=large, per-credential blobs=].
 
-Note: [[!FIDO-CTAP]] authenticators only support this extension for [=discoverable credentials=],
+Note: [=Roaming authenticators=] that use [[!FIDO-CTAP]] as their cross-platform transport protocol only support this [=largeblob/Large Blob=] extension for [=discoverable credentials=],
 and might return an error unless
 <code>{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/residentKey}}</code>
 is set to {{ResidentKeyRequirement/preferred}} or {{ResidentKeyRequirement/required}}.
-This is not a general requirement for all kinds of authenticators.
+However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessarily restrict this extension to [=discoverable credentials=].
 
 : Extension identifier
 :: `largeBlob`

--- a/index.bs
+++ b/index.bs
@@ -5823,10 +5823,10 @@ Since certificates are sizable relative to the storage capabilities of typical a
 Note: In order to interoperate, user agents storing large blobs on authenticators using [[!FIDO-CTAP]] are expected to use the provisions detailed in that specification for storing [=large, per-credential blobs=].
 
 Note: [[!FIDO-CTAP]] authenticators only support this extension for [=discoverable credentials=],
-and might return an incompatibility error unless
+and might return an error unless
 <code>{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/residentKey}}</code>
 is set to {{ResidentKeyRequirement/preferred}} or {{ResidentKeyRequirement/required}}.
-This is not generally a requirement for all kinds of authenticators.
+This is not a general requirement for all kinds of authenticators.
 
 : Extension identifier
 :: `largeBlob`

--- a/index.bs
+++ b/index.bs
@@ -5822,6 +5822,12 @@ Since certificates are sizable relative to the storage capabilities of typical a
 
 Note: In order to interoperate, user agents storing large blobs on authenticators using [[!FIDO-CTAP]] are expected to use the provisions detailed in that specification for storing [=large, per-credential blobs=].
 
+Note: [[!FIDO-CTAP]] authenticators only support this extension for [=discoverable credentials=],
+and might return an incompatibility error unless
+<code>{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/residentKey}}</code>
+is set to {{ResidentKeyRequirement/preferred}} or {{ResidentKeyRequirement/required}}.
+This is not generally a requirement for all kinds of authenticators.
+
 : Extension identifier
 :: `largeBlob`
 


### PR DESCRIPTION
I did some interoperability tests with the `largeBlob` extension, and was confused because Chrome indicated "Your security key can't be used with this site" with `largeBlob: { support: "required" }` even though my security key should support it. It turned out to be because CTAP only supports the underlying extensions for discoverable keys. This is not a general requirement, but CTAP seems like an important enough class of authenticators to point this out.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1622.html" title="Last updated on Aug 18, 2021, 5:13 PM UTC (4bee113)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1622/ff7c715...4bee113.html" title="Last updated on Aug 18, 2021, 5:13 PM UTC (4bee113)">Diff</a>