### PR TITLE
Remove TokenBinding

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1603,8 +1603,6 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     :: The inverse of the value of the
         {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
-    : {{CollectedClientData/tokenBinding}}
-    :: The status of [=Token Binding=] between the client and the |callerOrigin|, as well as the [=Token Binding ID=] associated with |callerOrigin|, if one is available.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -2032,8 +2030,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
     :: The inverse of the value of the
         {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
-    : {{CollectedClientData/tokenBinding}}
-    :: The status of [=Token Binding=] between the client and the |callerOrigin|, as well as the [=Token Binding ID=] associated with |callerOrigin|, if one is available.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -2950,8 +2946,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
         required DOMString           type;
         required DOMString           challenge;
         required DOMString           origin;
-        boolean                      crossOrigin;
-        TokenBinding                 tokenBinding;
+        boolean                      crossOrigin;        
     };
 
     dictionary TokenBinding {
@@ -2980,9 +2975,11 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     ::  This member contains the inverse of the `sameOriginWithAncestors` argument value
         that was passed into the [=internal method=].
 
-    :   <dfn>tokenBinding</dfn>
+    :   \[RESERVED] <dfn>tokenBinding</dfn>        
     ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
-        with the [=[RP]=]. Its absence indicates that the client doesn't support token binding.
+        with the [=[RP]=]. Its absence indicates that the client doesn't support token binding
+        
+        Note: While [=Token Binding=] was present in Level 1 and Level 2 of WebAuthn, it should not be expected to be present or supported in future versions of the specification.
 
         <div dfn-type="dict-member" dfn-for="TokenBinding">
             :   <dfn>status</dfn>
@@ -4382,8 +4379,6 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
 
-1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/status}}</code> matches the state of [=Token Binding=] for the TLS connection over which the [=assertion=] was obtained. If [=Token Binding=] was used on that TLS connection, also verify that <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/id}}</code> matches the [=base64url encoding=] of the [=Token Binding ID=] for the connection.
-
 1. Let |hash| be the result of computing a hash over <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> using SHA-256.
 
 1. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the
@@ -4542,8 +4537,6 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
     the base64url encoding of <code>|options|.{{PublicKeyCredentialRequestOptions/challenge}}</code>.
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
-
-1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/status}}</code> matches the state of [=Token Binding=] for the TLS connection over which the attestation was obtained. If [=Token Binding=] was used on that TLS connection, also verify that <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/id}}</code> matches the [=base64url encoding=] of the [=Token Binding ID=] for the connection.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/

--- a/index.bs
+++ b/index.bs
@@ -176,12 +176,6 @@ spec: url; urlPrefix: https://url.spec.whatwg.org
         text: scheme; url: concept-url-scheme
         text: port; url: concept-url-port
 
-
-spec: TokenBinding; urlPrefix: https://tools.ietf.org/html/rfc8471#
-    type: dfn
-        text: Token Binding; url: section-1
-        text: Token Binding ID; url: section-3.2
-
 spec: credential-management-1; urlPrefix: https://w3c.github.io/webappsec-credential-management/
     type: dictionary
         text: CredentialCreationOptions; url: dictdef-credentialcreationoptions
@@ -1603,8 +1597,6 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     :: The inverse of the value of the
         {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
-    : {{CollectedClientData/tokenBinding}}
-    :: The status of [=Token Binding=] between the client and the |callerOrigin|, as well as the [=Token Binding ID=] associated with |callerOrigin|, if one is available.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -2031,9 +2023,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     : {{CollectedClientData/crossOrigin}}
     :: The inverse of the value of the
         {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
-        argument passed to this [=internal method=].
-    : {{CollectedClientData/tokenBinding}}
-    :: The status of [=Token Binding=] between the client and the |callerOrigin|, as well as the [=Token Binding ID=] associated with |callerOrigin|, if one is available.
+        argument passed to this [=internal method=].    
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -2951,15 +2941,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
         required DOMString           challenge;
         required DOMString           origin;
         boolean                      crossOrigin;
-        TokenBinding                 tokenBinding;
     };
-
-    dictionary TokenBinding {
-        required DOMString status;
-        DOMString id;
-    };
-
-    enum TokenBindingStatus { "present", "supported" };
 </xmp>
 
 <div dfn-type="dict-member" dfn-for="CollectedClientData">
@@ -2979,32 +2961,6 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     :   <dfn>crossOrigin</dfn>
     ::  This member contains the inverse of the `sameOriginWithAncestors` argument value
         that was passed into the [=internal method=].
-
-    :   <dfn>tokenBinding</dfn>
-    ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
-        with the [=[RP]=]. Its absence indicates that the client doesn't support token binding.
-
-        <div dfn-type="dict-member" dfn-for="TokenBinding">
-            :   <dfn>status</dfn>
-            ::  This member SHOULD be a member of {{TokenBindingStatus}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the {{CollectedClientData/tokenBinding}} [=map/exist|member does not exist=]. When known, this member is one of the following:
-
-                <div dfn-type="enum-value" dfn-for="TokenBindingStatus">
-                    :   <dfn>supported</dfn>
-                    ::  Indicates the client supports token binding, but it was not negotiated when communicating with the [=[RP]=].
-
-                    :   <dfn>present</dfn>
-                    ::  Indicates token binding was used when communicating with the [=[RP]=]. In this case, the
-                        {{TokenBinding/id}} member MUST be present.
-                </div>
-
-                Note: The {{TokenBindingStatus}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
-
-            :   <dfn>id</dfn>
-            ::  This member MUST be present if {{TokenBinding/status}} is {{TokenBindingStatus/present}}, and MUST be a [=base64url
-                encoding=] of the [=Token Binding ID=] that was used when communicating with the [=[RP]=].
-        </div>
-
-        Note: Obtaining a [=Token Binding ID=] is a [=client platform=]-specific operation.
 
     The {{CollectedClientData}} structure is used by the client to compute the following quantities:
 
@@ -4382,8 +4338,6 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
 
-1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/status}}</code> matches the state of [=Token Binding=] for the TLS connection over which the [=assertion=] was obtained. If [=Token Binding=] was used on that TLS connection, also verify that <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/id}}</code> matches the [=base64url encoding=] of the [=Token Binding ID=] for the connection.
-
 1. Let |hash| be the result of computing a hash over <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> using SHA-256.
 
 1. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the
@@ -4542,8 +4496,6 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
     the base64url encoding of <code>|options|.{{PublicKeyCredentialRequestOptions/challenge}}</code>.
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
-
-1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/status}}</code> matches the state of [=Token Binding=] for the TLS connection over which the attestation was obtained. If [=Token Binding=] was used on that TLS connection, also verify that <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/id}}</code> matches the [=base64url encoding=] of the [=Token Binding ID=] for the connection.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
@@ -7109,14 +7061,6 @@ for their contributions as our W3C Team Contacts.
     "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c055194_ISOIEC_2382-37_2012.zip",
     "status": "International Standard: ISO/IEC 2382-37:2012(E) First Edition",
     "date": "15 December 2012"
-  },
-
-  "TokenBinding": {
-    "authors": ["A. Popov", "M. Nystroem", "D. Balfanz", "J. Hodges"],
-    "title": "The Token Binding Protocol Version 1.0",
-    "href": "https://tools.ietf.org/html/rfc8471",
-    "status": "IETF Proposed Standard",
-    "date": "October, 2018"
   },
 
   "EduPersonObjectClassSpec": {

--- a/index.bs
+++ b/index.bs
@@ -176,6 +176,12 @@ spec: url; urlPrefix: https://url.spec.whatwg.org
         text: scheme; url: concept-url-scheme
         text: port; url: concept-url-port
 
+
+spec: TokenBinding; urlPrefix: https://tools.ietf.org/html/rfc8471#
+    type: dfn
+        text: Token Binding; url: section-1
+        text: Token Binding ID; url: section-3.2
+
 spec: credential-management-1; urlPrefix: https://w3c.github.io/webappsec-credential-management/
     type: dictionary
         text: CredentialCreationOptions; url: dictdef-credentialcreationoptions
@@ -1597,6 +1603,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     :: The inverse of the value of the
         {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
+    : {{CollectedClientData/tokenBinding}}
+    :: The status of [=Token Binding=] between the client and the |callerOrigin|, as well as the [=Token Binding ID=] associated with |callerOrigin|, if one is available.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -2023,7 +2031,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
     : {{CollectedClientData/crossOrigin}}
     :: The inverse of the value of the
         {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
-        argument passed to this [=internal method=].    
+        argument passed to this [=internal method=].
+    : {{CollectedClientData/tokenBinding}}
+    :: The status of [=Token Binding=] between the client and the |callerOrigin|, as well as the [=Token Binding ID=] associated with |callerOrigin|, if one is available.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -2941,7 +2951,15 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
         required DOMString           challenge;
         required DOMString           origin;
         boolean                      crossOrigin;
+        TokenBinding                 tokenBinding;
     };
+
+    dictionary TokenBinding {
+        required DOMString status;
+        DOMString id;
+    };
+
+    enum TokenBindingStatus { "present", "supported" };
 </xmp>
 
 <div dfn-type="dict-member" dfn-for="CollectedClientData">
@@ -2961,6 +2979,32 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     :   <dfn>crossOrigin</dfn>
     ::  This member contains the inverse of the `sameOriginWithAncestors` argument value
         that was passed into the [=internal method=].
+
+    :   <dfn>tokenBinding</dfn>
+    ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
+        with the [=[RP]=]. Its absence indicates that the client doesn't support token binding.
+
+        <div dfn-type="dict-member" dfn-for="TokenBinding">
+            :   <dfn>status</dfn>
+            ::  This member SHOULD be a member of {{TokenBindingStatus}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the {{CollectedClientData/tokenBinding}} [=map/exist|member does not exist=]. When known, this member is one of the following:
+
+                <div dfn-type="enum-value" dfn-for="TokenBindingStatus">
+                    :   <dfn>supported</dfn>
+                    ::  Indicates the client supports token binding, but it was not negotiated when communicating with the [=[RP]=].
+
+                    :   <dfn>present</dfn>
+                    ::  Indicates token binding was used when communicating with the [=[RP]=]. In this case, the
+                        {{TokenBinding/id}} member MUST be present.
+                </div>
+
+                Note: The {{TokenBindingStatus}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+
+            :   <dfn>id</dfn>
+            ::  This member MUST be present if {{TokenBinding/status}} is {{TokenBindingStatus/present}}, and MUST be a [=base64url
+                encoding=] of the [=Token Binding ID=] that was used when communicating with the [=[RP]=].
+        </div>
+
+        Note: Obtaining a [=Token Binding ID=] is a [=client platform=]-specific operation.
 
     The {{CollectedClientData}} structure is used by the client to compute the following quantities:
 
@@ -4338,6 +4382,8 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
 
+1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/status}}</code> matches the state of [=Token Binding=] for the TLS connection over which the [=assertion=] was obtained. If [=Token Binding=] was used on that TLS connection, also verify that <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/id}}</code> matches the [=base64url encoding=] of the [=Token Binding ID=] for the connection.
+
 1. Let |hash| be the result of computing a hash over <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code> using SHA-256.
 
 1. Perform CBOR decoding on the {{AuthenticatorAttestationResponse/attestationObject}} field of the
@@ -4496,6 +4542,8 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
     the base64url encoding of <code>|options|.{{PublicKeyCredentialRequestOptions/challenge}}</code>.
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/origin}}</code> matches the [=[RP]=]'s [=origin=].
+
+1. Verify that the value of <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/status}}</code> matches the state of [=Token Binding=] for the TLS connection over which the attestation was obtained. If [=Token Binding=] was used on that TLS connection, also verify that <code>|C|.{{CollectedClientData/tokenBinding}}.{{TokenBinding/id}}</code> matches the [=base64url encoding=] of the [=Token Binding ID=] for the connection.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
@@ -7061,6 +7109,14 @@ for their contributions as our W3C Team Contacts.
     "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c055194_ISOIEC_2382-37_2012.zip",
     "status": "International Standard: ISO/IEC 2382-37:2012(E) First Edition",
     "date": "15 December 2012"
+  },
+
+  "TokenBinding": {
+    "authors": ["A. Popov", "M. Nystroem", "D. Balfanz", "J. Hodges"],
+    "title": "The Token Binding Protocol Version 1.0",
+    "href": "https://tools.ietf.org/html/rfc8471",
+    "status": "IETF Proposed Standard",
+    "date": "October, 2018"
   },
 
   "EduPersonObjectClassSpec": {

--- a/index.bs
+++ b/index.bs
@@ -2979,7 +2979,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
         with the [=[RP]=]. Its absence indicates that the client doesn't support token binding
         
-        Note: While [=Token Binding=] was present in Level 1 and Level 2 of WebAuthn, it should not be expected to be present or supported in future versions of the specification.
+        Note: While [=Token Binding=] was present in Level 1 and Level 2 of WebAuthn, its use is not expected in Level 3. The {{CollectedClientData/tokenBinding}} field is reserved so that it will not be reused for a different purpose.
 
         <div dfn-type="dict-member" dfn-for="TokenBinding">
             :   <dfn>status</dfn>


### PR DESCRIPTION
This addresses the issues #1627 and #1623 along with what we discussed in the bi-weekly meeting. All references to `TokenBinding` have been removed from the document and IDLs, although I would be open to leaving a partial reference with a DEPRECATED flair in the ClientDataJSON section for posterity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1630.html" title="Last updated on Jul 15, 2021, 8:58 PM UTC (0ac8be0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1630/6156ba8...0ac8be0.html" title="Last updated on Jul 15, 2021, 8:58 PM UTC (0ac8be0)">Diff</a>