### PR TITLE
Fix inconsistency in RP directions for credential transports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2399,7 +2399,7 @@ during registration.
     ::  This operation returns the {{COSEAlgorithmIdentifier}} of the new credential. See [[#sctn-public-key-easy]].
 
     :   <dfn>\[[transports]]</dfn>
-    ::  This [=internal slot=] contains a sequence of zero or more unique {{DOMString}}s in lexicographical order. These values are the transports that the [=authenticator=] is believed to support, or an empty sequence if the information is unavailable. The values SHOULD be members of {{AuthenticatorTransport}} but [=[RPS]=] MUST ignore unknown values.
+    ::  This [=internal slot=] contains a sequence of zero or more unique {{DOMString}}s in lexicographical order. These values are the transports that the [=authenticator=] is believed to support, or an empty sequence if the information is unavailable. The values SHOULD be members of {{AuthenticatorTransport}} but [=[RPS]=] SHOULD accept and store unknown values.
 </div>
 
 #### Easily accessing credential data #### {#sctn-public-key-easy}
@@ -4533,9 +4533,12 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
 
     If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is present,
     the {{PublicKeyCredentialDescriptor/transports}} member of each [=list/item=] SHOULD be set to
-    the value returned by
+    the value that was returned by
     <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorAttestationResponse/getTransports()}}</code>
     when the corresponding credential was registered.
+
+    Note: Modifying or removing [=list/items=] from values returned from {{AuthenticatorAttestationResponse/getTransports()}}
+    could negatively impact user experience, or even prevent use of the corresponding credentials.
 
 1. Call {{CredentialsContainer/get()|navigator.credentials.get()}} and pass |options|
     as the <code>{{CredentialRequestOptions/publicKey}}</code> option.


### PR DESCRIPTION
Fixes #1587.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1654.html" title="Last updated on Jul 27, 2021, 4:11 PM UTC (a36e38c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1654/33b0215...a36e38c.html" title="Last updated on Jul 27, 2021, 4:11 PM UTC (a36e38c)">Diff</a>