### PR TITLE
Explicitly state that RPs cannot in general choose attestation type/format

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4097,9 +4097,8 @@ The privacy, security and operational characteristics of [=attestation=] depend 
 - The characteristics of the individual [=authenticator=], such as its construction, whether part or all of it runs in a secure
     operating environment, and so on.
 
-The [=attestation type=] and [=attestation statement format=] is chosen by the [=authenticator=];
-[=[RPS]=] may signal some limited preferences via the <code>{{PublicKeyCredentialCreationOptions/attestation}}</code> parameter,
-but cannot otherwise influence this choice.
+The [=attestation type=] and [=attestation statement format=] is chosen by the [=authenticator=] and [=client=];
+[=[RPS]=] can only signal limited [=attestation conveyance=] preferences during [=registration=].
 It is expected that most [=authenticators=] will support a small number of [=attestation types=] and [=attestation statement
 formats=], while [=[RPS]=] will decide what [=attestation types=] are acceptable to them by policy. [=[RPS]=] will also need to
 understand the characteristics of the [=authenticators=] that they trust, based on information they have about these

--- a/index.bs
+++ b/index.bs
@@ -4097,6 +4097,9 @@ The privacy, security and operational characteristics of [=attestation=] depend 
 - The characteristics of the individual [=authenticator=], such as its construction, whether part or all of it runs in a secure
     operating environment, and so on.
 
+The [=attestation type=] and [=attestation statement format=] is chosen by the [=authenticator=];
+[=[RPS]=] may signal some limited preferences via the <code>{{PublicKeyCredentialCreationOptions/attestation}}</code> parameter,
+but cannot otherwise influence this choice.
 It is expected that most [=authenticators=] will support a small number of [=attestation types=] and [=attestation statement
 formats=], while [=[RPS]=] will decide what [=attestation types=] are acceptable to them by policy. [=[RPS]=] will also need to
 understand the characteristics of the [=authenticators=] that they trust, based on information they have about these

--- a/index.bs
+++ b/index.bs
@@ -4097,7 +4097,7 @@ The privacy, security and operational characteristics of [=attestation=] depend 
 - The characteristics of the individual [=authenticator=], such as its construction, whether part or all of it runs in a secure
     operating environment, and so on.
 
-The [=attestation type=] and [=attestation statement format=] is chosen by the [=authenticator=] and [=client=];
+The [=attestation type=] and [=attestation statement format=] is chosen by the [=authenticator=];
 [=[RPS]=] can only signal limited [=attestation conveyance=] preferences during [=registration=].
 It is expected that most [=authenticators=] will support a small number of [=attestation types=] and [=attestation statement
 formats=], while [=[RPS]=] will decide what [=attestation types=] are acceptable to them by policy. [=[RPS]=] will also need to


### PR DESCRIPTION
Fixes issue #1659.

Marking this as draft for now because I'm not entirely sure this addition is worth its weight. I'd like to hear what some others think.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1660.html" title="Last updated on Aug 20, 2021, 2:45 PM UTC (d24439d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1660/38ad84d...d24439d.html" title="Last updated on Aug 20, 2021, 2:45 PM UTC (d24439d)">Diff</a>