### PR TITLE
Fix tokenBinding definition type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2988,7 +2988,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     ::  This OPTIONAL member contains the inverse of the `sameOriginWithAncestors` argument value
         that was passed into the [=internal method=].
 
-    :   \[RESERVED] <dfn>tokenBinding</dfn>        
+    :   \[RESERVED] <dfn dfn>tokenBinding</dfn>
     ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
         with the [=[RP]=]. Its absence indicates that the client doesn't support token binding
         


### PR DESCRIPTION
Parent commit was generating the error:

    FATAL ERROR: Couldn't find target dict-member 'tokenBinding':
    <span data-dict-member-info="" for="CollectedClientData/tokenBinding"></span>

This is because the surrounding `<div dfn-type="dict-member" dfn-for="CollectedClientData">` defines the definition type as `dict-member`, but no such member is defined in the `CollectedClientData` dictionary.

This change overrides the definition type to `dfn`, which is described in the [Bikeshed docs][1] as "for general terms and phrases, and a catch-all for anything else".

[1]: https://tabatkins.github.io/bikeshed/#dfn-types


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1661.html" title="Last updated on Aug 6, 2021, 3:21 PM UTC (5f45d34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1661/38ad84d...5f45d34.html" title="Last updated on Aug 6, 2021, 3:21 PM UTC (5f45d34)">Diff</a>