### PR TITLE
Define 1023 bytes to be the maximum credential ID length.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4123,7 +4123,7 @@ object=] for a given credential. Its format is shown in <a href="#table-attested
         <tr>
             <td><dfn>credentialIdLength</dfn></td>
             <td>2</td>
-            <td>Byte length <strong>L</strong> of [=credentialId=], 16-bit unsigned big-endian integer. Value MUST be &lt; 1024.</td>
+            <td>Byte length <strong>L</strong> of [=credentialId=], 16-bit unsigned big-endian integer. Value MUST be &le; 1023.</td>
         </tr>
         <tr>
             <td><dfn>credentialId</dfn></td>


### PR DESCRIPTION
The value 1024 has been picked to be a nice round number that seems
larger than any reasonable credential ID should need to be.

(I think several of the step references were _previously_ incorrect and
have attempted to fix them here. Thus step number changes are not
expected to be simply updates reflecting the new step.)

Fixes #1617


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agl/webauthn/pull/1664.html" title="Last updated on Sep 29, 2021, 11:29 PM UTC (7888d10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1664/38f9f72...agl:7888d10.html" title="Last updated on Sep 29, 2021, 11:29 PM UTC (7888d10)">Diff</a>