### PR TITLE
Add transport used during authentication to assertion payload

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2207,6 +2207,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 :   <code><dfn for="assertionCreationData">signatureResult</dfn></code>
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
+                :   <code><dfn for="assertionCreationData">transportResult</dfn></code>
+                ::  whose value is the transport used to communicate to the [=authenticator=]. Values SHOULD be members of {{AuthenticatorTransport}}. If the user agent does not have any transport information, set the value to 
+                    null.
+
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
                 ::  If the [=authenticator=] returned a [=user handle=], set the value of [=userHandleResult=] to be the bytes of
                     the returned [=user handle=]. Otherwise, set the value of [=userHandleResult=] to null.
@@ -2241,6 +2245,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         :   {{AuthenticatorAssertionResponse/signature}}
                         ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                             <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
+
+                        :   {{AuthenticatorAssertionResponse/transport}}
+                        ::  If <code>|assertionCreationData|.[=assertionCreationData/transportResult=]</code> is null, set this
+                            field to null. Otherwise, set this field to a new {{DOMString}}, containing the value of
+                            <code>|assertionCreationData|.[=assertionCreationData/transportResult=]</code>.
 
                         :   {{AuthenticatorAssertionResponse/userHandle}}
                         ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this
@@ -2429,6 +2438,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
+        [SameObject] readonly attribute DOMString?       transport;
         [SameObject] readonly attribute ArrayBuffer?     userHandle;
     };
 </xmp>
@@ -2444,6 +2454,10 @@ optionally evidence of [=user consent=] to a specific transaction.
 
     :   <dfn>signature</dfn>
     ::  This attribute contains the raw signature returned from the authenticator. See [[#sctn-op-get-assertion]].
+
+    :   <dfn>transport</dfn>
+    ::  This attribute contains the transport used to communicate to the [=authenticator=], or `null` if the user agent does not have any transport information.
+        See [[#sctn-op-get-assertion]].
 
     :   <dfn>userHandle</dfn>
     ::  This attribute contains the [=user handle=] returned from the authenticator, or null if the authenticator did not return a


### PR DESCRIPTION
This spec change adds the transport used during authentication to the assertion payload returned from the browser to the RP.

Fixes: #1666 

Also discussed in #1637 