### PR TITLE
Describe how to determine authenticator attachment from transports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1370,6 +1370,7 @@ that are returned to the caller when a new credential is created, or a new asser
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
         [SameObject] readonly attribute AuthenticatorResponse    response;
+        [SameObject] readonly attribute DOMString?               authenticatorAttachment;
         AuthenticationExtensionsClientOutputs getClientExtensionResults();
     };
 </xmp>
@@ -1388,6 +1389,12 @@ that are returned to the caller when a new credential is created, or a new asser
         {{CredentialsContainer/create()}}, this attribute's value will be an {{AuthenticatorAttestationResponse}}, otherwise,
         the {{PublicKeyCredential}} was created in response to {{CredentialsContainer/get()}}, and this attribute's value
         will be an {{AuthenticatorAssertionResponse}}.
+    
+    :   <dfn>authenticatorAttachment</dfn>
+    ::  This attribute contains the authenticatorAttachment used to communicate to the [=authenticator=], or `null` if 
+        the user agent does not have any attachment information. This attribute should be used by RPs in conjecture 
+        with isUVPAA to prompt user to register platform authenticator if it is availible and user is currently being authenticated 
+        with a cross-platform attachment. See [[#sctn-authenticator-attachment-modality]].
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
     ::  This operation returns the value of {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing
@@ -2207,9 +2214,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 :   <code><dfn for="assertionCreationData">signatureResult</dfn></code>
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
-                :   <code><dfn for="assertionCreationData">transportResult</dfn></code>
-                ::  whose value is the transport used to communicate to the [=authenticator=]. Values SHOULD be members of {{AuthenticatorTransport}}. If the user agent does not have any transport information, set the value to 
-                    null.
+                :   <code><dfn for="assertionCreationData">authenticatorAttachmentResult</dfn></code>
+                ::  whose value is the authenticator attachment type used to communicate to the [=authenticator=]. Values SHOULD be either "platform" or "cross-platform". If the user agent does not have any authenticator attachment information, 
+                    set the value to null.
 
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
                 ::  If the [=authenticator=] returned a [=user handle=], set the value of [=userHandleResult=] to be the bytes of
@@ -2246,10 +2253,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                             <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
 
-                        :   {{AuthenticatorAssertionResponse/transport}}
-                        ::  If <code>|assertionCreationData|.[=assertionCreationData/transportResult=]</code> is null, set this
+                        :   {{AuthenticatorAssertionResponse/authenticatorAttachment}}
+                        ::  If <code>|assertionCreationData|.[=assertionCreationData/authenticatorAttachmentResult=]</code> is null, set this
                             field to null. Otherwise, set this field to a new {{DOMString}}, containing the value of
-                            <code>|assertionCreationData|.[=assertionCreationData/transportResult=]</code>.
+                            <code>|assertionCreationData|.[=assertionCreationData/authenticatorAttachmentResult=]</code>.
 
                         :   {{AuthenticatorAssertionResponse/userHandle}}
                         ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this
@@ -2438,7 +2445,6 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
-        [SameObject] readonly attribute DOMString?       transport;
         [SameObject] readonly attribute ArrayBuffer?     userHandle;
     };
 </xmp>
@@ -2454,10 +2460,6 @@ optionally evidence of [=user consent=] to a specific transaction.
 
     :   <dfn>signature</dfn>
     ::  This attribute contains the raw signature returned from the authenticator. See [[#sctn-op-get-assertion]].
-
-    :   <dfn>transport</dfn>
-    ::  This attribute contains the transport used to communicate to the [=authenticator=], or `null` if the user agent does not have any transport information.
-        See [[#sctn-op-get-assertion]].
 
     :   <dfn>userHandle</dfn>
     ::  This attribute contains the [=user handle=] returned from the authenticator, or null if the authenticator did not return a
@@ -3975,6 +3977,10 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
 
 1. If any error occurred while generating the [=assertion signature=], return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
+
+1. Let |authenticatorAttachment| be <code>platform</code> or <code>cross-platform</code> based on the transport returned by authenticator following successful authentication. 
+    If transport is <code>null</code>, set |authenticatorAttachment| to null. If transport is <code>internal</code>, then set |authenticatorAttachment| to <code>platform</code>. 
+    Otherwise, set |authenticatorAttachment| to <code>cross-platform</code>.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/

--- a/index.bs
+++ b/index.bs
@@ -2429,6 +2429,40 @@ To remove the need to parse CBOR at all in many cases, {{AuthenticatorAttestatio
 
 Note: {{AuthenticatorAttestationResponse/getPublicKey()}} and {{AuthenticatorAttestationResponse/getAuthenticatorData()}} were only added in level two of this spec. [=[RPS]=] SHOULD use feature detection before using these functions by testing the value of `'getPublicKey' in AuthenticatorAttestationResponse.prototype`. [=[RPS]=] that require this function to exist may not interoperate with older user-agents.
 
+
+#### Determining Authenticator Attachment Options from Credential Transports #### {#sctn-attachments-from-transports}
+
+[INFORMATIVE]
+
+After creating a [=credential=], the [=[RP]=] may wish to know the [=authenticator attachment modality=] of the credential's [=managing authenticator=].
+This can be done by inspecting the result of calling {{getTransports()}}.
+
+If the result of {{getTransports()}}
+
+<dl class="switch">
+    : is [=list/empty=],
+    :: the [=authenticator attachment modality|attachment modality=] of the credential and its [=managing authenticator=] is unknown.
+
+    : [=list/contains=] only {{AuthenticatorTransport/internal}},
+    :: the credential is a [=platform credential=].
+
+    : is not [=list/empty=] and does not [=list/contain=] {{AuthenticatorTransport/internal}},
+    :: the credential is a [=roaming credential=].
+
+    : [=list/contains=] both {{AuthenticatorTransport/internal}} and other values,
+    :: the credential can be used as a [=platform credential=] under some circumstances and a [=roaming credential=] under some circumstances.
+        Both attachment options may or may not be available at the same time.
+
+        For example, a credential [=created on=] a mobile phone may be available as a [=platform credential=]
+        when the [=client device=] is that mobile phone,
+        and as a [=roaming credential=] when the [=client device=] is a laptop computer that can reach the mobile phone via Bluetooth.
+</dl>
+
+Note that an [=authenticator's=] [=authenticator attachment modality|attachment modality=] could change over time.
+For example, a mobile phone might at one time only support [=platform attachment=]
+but later receive updates to support [=cross-platform attachment=] as well.
+
+
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}
 
 The {{AuthenticatorAssertionResponse}} interface represents an [=authenticator=]'s response to a client's request for

--- a/index.bs
+++ b/index.bs
@@ -1392,7 +1392,7 @@ that are returned to the caller when a new credential is created, or a new asser
     
     :   <dfn>authenticatorAttachment</dfn>
     ::  The value SHOULD be a member of {{AuthenticatorAttachment}} used to communicate to the [=authenticator=], and Relying Parties SHOULD treat unknown values as if the value were null.
-        This attribute may be used by RPs in conjunction with {{isUserVerifyingPlatformAuthenticatorAvailable}} to prompt user to register a platform authenticator if it is available and the user is currently being authenticated 
+        This attribute may be used by RPs in conjunction with {{isUserVerifyingPlatformAuthenticatorAvailable}} to prompt the user to register a platform authenticator if it is available and the user is currently being authenticated 
         with a cross-platform attachment. See [[#sctn-authenticator-attachment-modality]].
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
@@ -1865,8 +1865,8 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
 
                     :   {{PublicKeyCredential/authenticatorAttachment}}
                     ::  The value of the authenticator attachment type used to communicate to the [=authenticator=]. 
-                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport returned 
-                        by authenticator following successful registration. If the user agent does not
+                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport used 
+                        by authenticator during registration. If the user agent does not
                         have any authenticator attachment information, set the value to null.
 
                     :   {{PublicKeyCredential/response}}
@@ -2240,8 +2240,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                     :   {{PublicKeyCredential/authenticatorAttachment}}
                     ::  The value of the authenticator attachment type used to communicate to the [=authenticator=]. 
-                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport returned 
-                        by authenticator following successful authentication. If the user agent does not
+                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport used 
+                        by authenticator during authentication. If the user agent does not
                         have any authenticator attachment information, set the value to null.
 
                     :   {{PublicKeyCredential/response}}

--- a/index.bs
+++ b/index.bs
@@ -1394,7 +1394,7 @@ that are returned to the caller when a new credential is created, or a new asser
     ::  This attribute reports the [=authenticator attachment modality=] in effect at the time this {{PublicKeyCredential}} was created.
         The attribute’s value SHOULD be a member of {{AuthenticatorAttachment}}. [=[RPS]=] SHOULD treat unknown values as if the value were null.
 
-        Note: If, as the result of a [=registration ceremony|registration=] or [=authentication ceremony=], {{AuthenticatorAttachment}}'s value is "cross-platform" and concurrently {{isUserVerifyingPlatformAuthenticatorAvailable}} returns [TRUE], then the user employed a [=roaming authenticator=] for this [=ceremony=] while there is an available [=platform authenticator=]. Thus the [=[RP]=] has the opportunity to prompt the user to register the available [=platform authenticator=], which may enable more streamlined user experience flows.
+        Note: If, as the result of a [=registration ceremony|registration=] or [=authentication ceremony=], {{PublicKeyCredential/authenticatorAttachment}}'s value is "cross-platform" and concurrently {{isUserVerifyingPlatformAuthenticatorAvailable}} returns [TRUE], then the user employed a [=roaming authenticator=] for this [=ceremony=] while there is an available [=platform authenticator=]. Thus the [=[RP]=] has the opportunity to prompt the user to register the available [=platform authenticator=], which may enable more streamlined user experience flows.
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
     ::  This operation returns the value of {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing

--- a/index.bs
+++ b/index.bs
@@ -1391,9 +1391,10 @@ that are returned to the caller when a new credential is created, or a new asser
         will be an {{AuthenticatorAssertionResponse}}.
     
     :   <dfn>authenticatorAttachment</dfn>
-    ::  The value SHOULD be a member of {{AuthenticatorAttachment}} used to communicate to the [=authenticator=], and Relying Parties SHOULD treat unknown values as if the value were null.
-        This attribute may be used by RPs in conjunction with {{isUserVerifyingPlatformAuthenticatorAvailable}} to prompt the user to register a platform authenticator if it is available and the user is currently being authenticated 
-        with a cross-platform attachment. See [[#sctn-authenticator-attachment-modality]].
+    ::  This attribute reports the [=authenticator attachment modality=] in effect at the time this {{PublicKeyCredential}} was created.
+        The attribute’s value SHOULD be a member of {{AuthenticatorAttachment}}. [=[RPS]=] SHOULD treat unknown values as if the value were null.
+
+        Note: If, as the result of a [=registration ceremony|registration=] or [=authentication ceremony=], {{AuthenticatorAttachment}}'s value is "cross-platform" and concurrently {{isUserVerifyingPlatformAuthenticatorAvailable}} returns [TRUE], then the user employed a [=roaming authenticator=] for this [=ceremony=] while there is an available [=platform authenticator=]. Thus the [=[RP]=] has the opportunity to prompt the user to register the available [=platform authenticator=], which may enable more streamlined user experience flows.
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
     ::  This operation returns the value of {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing
@@ -1864,10 +1865,7 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                     ::  |id|
 
                     :   {{PublicKeyCredential/authenticatorAttachment}}
-                    ::  The value of the authenticator attachment type used to communicate to the [=authenticator=]. 
-                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport used 
-                        by authenticator during registration. If the user agent does not
-                        have any authenticator attachment information, set the value to null.
+                    ::  A {{DOMString}} whose value SHOULD be a member of {{AuthenticatorAttachment}}, based on the [[#enum-transport|transport]] used by the [=authenticator=] during the [=registration ceremony=], as determined per [[#sctn-attachments-from-transports]].
 
                     :   {{PublicKeyCredential/response}}
                     ::  A new {{AuthenticatorAttestationResponse}} object associated with |global| whose fields are:
@@ -2239,10 +2237,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         <code>|assertionCreationData|.[=credentialIdResult=]</code>.
 
                     :   {{PublicKeyCredential/authenticatorAttachment}}
-                    ::  The value of the authenticator attachment type used to communicate to the [=authenticator=]. 
-                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport used 
-                        by authenticator during authentication. If the user agent does not
-                        have any authenticator attachment information, set the value to null.
+                    ::  A {{DOMString}} whose value SHOULD be a member of {{AuthenticatorAttachment}}, based on the [[#enum-transport|transport]] used by the [=authenticator=] during the [=authentication ceremony=], as determined per [[#sctn-attachments-from-transports]].
 
                     :   {{PublicKeyCredential/response}}
                     ::  A new {{AuthenticatorAssertionResponse}} object associated with |global| whose fields are:

--- a/index.bs
+++ b/index.bs
@@ -2430,38 +2430,24 @@ To remove the need to parse CBOR at all in many cases, {{AuthenticatorAttestatio
 Note: {{AuthenticatorAttestationResponse/getPublicKey()}} and {{AuthenticatorAttestationResponse/getAuthenticatorData()}} were only added in level two of this spec. [=[RPS]=] SHOULD use feature detection before using these functions by testing the value of `'getPublicKey' in AuthenticatorAttestationResponse.prototype`. [=[RPS]=] that require this function to exist may not interoperate with older user-agents.
 
 
-#### Determining Authenticator Attachment Options from Credential Transports #### {#sctn-attachments-from-transports}
+#### Determining Authenticator Attachment from Credential Transports #### {#sctn-attachments-from-transports}
 
-[INFORMATIVE]
+As a part of creating a {{PublicKeyCredential}} object, as the result of a  [=registration ceremony|registration=] or [=authentication ceremony=], the [=client platform=] determines the [=authenticator attachment modality=] and reports it in {{PublicKeyCredential/authenticatorAttachment}}. This section defines how to make that determination.
 
-After creating a [=credential=], the [=[RP]=] may wish to know the [=authenticator attachment modality=] of the credential's [=managing authenticator=].
-This can be done by inspecting the result of calling {{getTransports()}}.
-
-If the result of {{getTransports()}}
-
+If the client platform
 <dl class="switch">
-    : is [=list/empty=],
-    :: the [=authenticator attachment modality|attachment modality=] of the credential and its [=managing authenticator=] is unknown.
+    : cannot determine the {{transports}} used or the transport is not a member of {{AuthenticatorTransport}}, then
+    :: the [=authenticator attachment modality=] is unknown, and the value of {{PublicKeyCredential/authenticatorAttachment}} MUST be set to null.
 
-    : [=list/contains=] only {{AuthenticatorTransport/internal}},
-    :: the credential is a [=platform credential=].
+    : used an {{AuthenticatorTransport/internal}} transport, then
+    :: {{PublicKeyCredential/authenticatorAttachment}} MUST be set to "platform".
 
-    : is not [=list/empty=] and does not [=list/contain=] {{AuthenticatorTransport/internal}},
-    :: the credential is a [=roaming credential=].
+    : used a {{transports|transport}} that is a member of {{transports}} other than {{AuthenticatorTransport/internal}},
+    :: {{PublicKeyCredential/authenticatorAttachment}} MUST be set to "cross-platform".
 
-    : [=list/contains=] both {{AuthenticatorTransport/internal}} and other values,
-    :: the credential can be used as a [=platform credential=] under some circumstances and a [=roaming credential=] under some circumstances.
-        Both attachment options may or may not be available at the same time.
-
-        For example, a credential [=created on=] a mobile phone may be available as a [=platform credential=]
-        when the [=client device=] is that mobile phone,
-        and as a [=roaming credential=] when the [=client device=] is a laptop computer that can reach the mobile phone via Bluetooth.
-</dl>
-
-Note that an [=authenticator's=] [=authenticator attachment modality|attachment modality=] could change over time.
+Note: An [=authenticator's=] [=authenticator attachment modality|attachment modality=] could change over time.
 For example, a mobile phone might at one time only support [=platform attachment=]
 but later receive updates to support [=cross-platform attachment=] as well.
-
 
 ### Web Authentication Assertion (interface <dfn interface>AuthenticatorAssertionResponse</dfn>) ### {#iface-authenticatorassertionresponse}
 

--- a/index.bs
+++ b/index.bs
@@ -2207,6 +2207,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 :   <code><dfn for="assertionCreationData">signatureResult</dfn></code>
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
+                :   <code><dfn for="assertionCreationData">transportResult</dfn></code>
+                ::  whose value is the transport used to communicate to the [=authenticator=]. Values SHOULD be members of {{AuthenticatorTransport}}. If the user agent does not have any transport information, set the value to 
+                    null.
+
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
                 ::  If the [=authenticator=] returned a [=user handle=], set the value of [=userHandleResult=] to be the bytes of
                     the returned [=user handle=]. Otherwise, set the value of [=userHandleResult=] to null.
@@ -2241,6 +2245,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         :   {{AuthenticatorAssertionResponse/signature}}
                         ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                             <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
+
+                        :   {{AuthenticatorAssertionResponse/transport}}
+                        ::  If <code>|assertionCreationData|.[=assertionCreationData/transportResult=]</code> is null, set this
+                            field to null. Otherwise, set this field to a new {{DOMString}}, containing the value of
+                            <code>|assertionCreationData|.[=assertionCreationData/transportResult=]</code>.
 
                         :   {{AuthenticatorAssertionResponse/userHandle}}
                         ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this
@@ -2429,6 +2438,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     interface AuthenticatorAssertionResponse : AuthenticatorResponse {
         [SameObject] readonly attribute ArrayBuffer      authenticatorData;
         [SameObject] readonly attribute ArrayBuffer      signature;
+        [SameObject] readonly attribute DOMString?       transport;
         [SameObject] readonly attribute ArrayBuffer?     userHandle;
     };
 </xmp>
@@ -2444,6 +2454,10 @@ optionally evidence of [=user consent=] to a specific transaction.
 
     :   <dfn>signature</dfn>
     ::  This attribute contains the raw signature returned from the authenticator. See [[#sctn-op-get-assertion]].
+
+    :   <dfn>transport</dfn>
+    ::  This attribute contains the transport used to communicate to the [=authenticator=], or `null` if the user agent does not have any transport information.
+        See [[#sctn-op-get-assertion]].
 
     :   <dfn>userHandle</dfn>
     ::  This attribute contains the [=user handle=] returned from the authenticator, or null if the authenticator did not return a

--- a/index.bs
+++ b/index.bs
@@ -1391,9 +1391,8 @@ that are returned to the caller when a new credential is created, or a new asser
         will be an {{AuthenticatorAssertionResponse}}.
     
     :   <dfn>authenticatorAttachment</dfn>
-    ::  This attribute contains the {{AuthenticatorAttachment}} used to communicate to the [=authenticator=], or `null` if 
-        the user agent does not have any attachment information. This attribute may be used by RPs in conjecture 
-        with `isUserVerifyingPlatformAuthenticatorAvailable()` to prompt user to register a platform authenticator if it is available and the user is currently being authenticated 
+    ::  The value SHOULD be a member of {{AuthenticatorAttachment}} used to communicate to the [=authenticator=], and Relying Parties SHOULD treat unknown values as if the value were null.
+        This attribute may be used by RPs in conjunction with {{isUserVerifyingPlatformAuthenticatorAvailable}} to prompt user to register a platform authenticator if it is available and the user is currently being authenticated 
         with a cross-platform attachment. See [[#sctn-authenticator-attachment-modality]].
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
@@ -1864,6 +1863,12 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                     :   {{PublicKeyCredential/[[identifier]]}}
                     ::  |id|
 
+                    :   {{PublicKeyCredential/authenticatorAttachment}}
+                    ::  The value of the authenticator attachment type used to communicate to the [=authenticator=]. 
+                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport returned 
+                        by authenticator following successful registration. If the user agent does not
+                        have any authenticator attachment information, set the value to null.
+
                     :   {{PublicKeyCredential/response}}
                     ::  A new {{AuthenticatorAttestationResponse}} object associated with |global| whose fields are:
 
@@ -2214,10 +2219,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 :   <code><dfn for="assertionCreationData">signatureResult</dfn></code>
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
-                :   <code><dfn for="assertionCreationData">authenticatorAttachmentResult</dfn></code>
-                ::  whose value is the authenticator attachment type used to communicate to the [=authenticator=]. Values SHOULD be members of the {{AuthenticatorAttachment}} enum. If the user agent does not have any authenticator attachment information, 
-                    set the value to null.
-
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
                 ::  If the [=authenticator=] returned a [=user handle=], set the value of [=userHandleResult=] to be the bytes of
                     the returned [=user handle=]. Otherwise, set the value of [=userHandleResult=] to null.
@@ -2234,9 +2235,14 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 1.  Let |pubKeyCred| be a new {{PublicKeyCredential}} object associated with |global| whose fields are:
 
                     :   {{PublicKeyCredential/[[identifier]]}}
-
                     ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                         <code>|assertionCreationData|.[=credentialIdResult=]</code>.
+
+                    :   {{PublicKeyCredential/authenticatorAttachment}}
+                    ::  The value of the authenticator attachment type used to communicate to the [=authenticator=]. 
+                        Values SHOULD be members of the {{AuthenticatorAttachment}} enum based on the transport returned 
+                        by authenticator following successful authentication. If the user agent does not
+                        have any authenticator attachment information, set the value to null.
 
                     :   {{PublicKeyCredential/response}}
                     ::  A new {{AuthenticatorAssertionResponse}} object associated with |global| whose fields are:
@@ -2252,9 +2258,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         :   {{AuthenticatorAssertionResponse/signature}}
                         ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                             <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
-
-                        :   {{PublicKeyCredential/authenticatorAttachment}}
-                        ::  The value of <code>|assertionCreationData|.[=assertionCreationData/authenticatorAttachmentResult=]</code>.
 
                         :   {{AuthenticatorAssertionResponse/userHandle}}
                         ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this
@@ -3975,10 +3978,6 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
 
 1. If any error occurred while generating the [=assertion signature=], return an error code equivalent to "{{UnknownError}}" and
     terminate the operation.
-
-1. Let |authenticatorAttachment| be <code>platform</code> or <code>cross-platform</code> based on the transport returned by authenticator following successful authentication. 
-    If transport is <code>null</code>, set |authenticatorAttachment| to null. If transport is <code>internal</code>, then set |authenticatorAttachment| to <code>platform</code>. 
-    Otherwise, set |authenticatorAttachment| to <code>cross-platform</code>.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/

--- a/index.bs
+++ b/index.bs
@@ -1391,9 +1391,9 @@ that are returned to the caller when a new credential is created, or a new asser
         will be an {{AuthenticatorAssertionResponse}}.
     
     :   <dfn>authenticatorAttachment</dfn>
-    ::  This attribute contains the authenticatorAttachment used to communicate to the [=authenticator=], or `null` if 
-        the user agent does not have any attachment information. This attribute should be used by RPs in conjecture 
-        with isUVPAA to prompt user to register platform authenticator if it is availible and user is currently being authenticated 
+    ::  This attribute contains the {{AuthenticatorAttachment}} used to communicate to the [=authenticator=], or `null` if 
+        the user agent does not have any attachment information. This attribute may be used by RPs in conjecture 
+        with `isUserVerifyingPlatformAuthenticatorAvailable()` to prompt user to register a platform authenticator if it is available and the user is currently being authenticated 
         with a cross-platform attachment. See [[#sctn-authenticator-attachment-modality]].
 
     :   {{PublicKeyCredential/getClientExtensionResults()}}
@@ -2215,7 +2215,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is the bytes of the signature value returned by the [=authenticator=].
 
                 :   <code><dfn for="assertionCreationData">authenticatorAttachmentResult</dfn></code>
-                ::  whose value is the authenticator attachment type used to communicate to the [=authenticator=]. Values SHOULD be either "platform" or "cross-platform". If the user agent does not have any authenticator attachment information, 
+                ::  whose value is the authenticator attachment type used to communicate to the [=authenticator=]. Values SHOULD be members of the {{AuthenticatorAttachment}} enum. If the user agent does not have any authenticator attachment information, 
                     set the value to null.
 
                 :   <code><dfn for="assertionCreationData">userHandleResult</dfn></code>
@@ -2253,10 +2253,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
                         ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
                             <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
 
-                        :   {{AuthenticatorAssertionResponse/authenticatorAttachment}}
-                        ::  If <code>|assertionCreationData|.[=assertionCreationData/authenticatorAttachmentResult=]</code> is null, set this
-                            field to null. Otherwise, set this field to a new {{DOMString}}, containing the value of
-                            <code>|assertionCreationData|.[=assertionCreationData/authenticatorAttachmentResult=]</code>.
+                        :   {{PublicKeyCredential/authenticatorAttachment}}
+                        ::  The value of <code>|assertionCreationData|.[=assertionCreationData/authenticatorAttachmentResult=]</code>.
 
                         :   {{AuthenticatorAssertionResponse/userHandle}}
                         ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this


### PR DESCRIPTION
This would merge into PR #1621.

Addresses https://github.com/w3c/webauthn/pull/1621#discussion_r709721573 . Since there wasn't a description of _how_ to determine authenticator/credential attachment from transports, this adds that as a new section similar to [§5.2.1.1. Easily accessing credential data](https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#sctn-public-key-easy).

I'm submitting this as a separate (meta-) PR for visibility, because of the new section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1670.html" title="Last updated on Oct 1, 2021, 11:18 AM UTC (183d059)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1670/38f9f72...183d059.html" title="Last updated on Oct 1, 2021, 11:18 AM UTC (183d059)">Diff</a>