### PR TITLE
Additional polish for PR #1621

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2588,7 +2588,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     ::  This member lists the key types and signature algorithms the [=[RP]=] supports,
         ordered from most preferred to least preferred.
         The [=client=] and [=authenticator=] make a best-effort to create a credential of the most preferred type possible.
-        If none of the listed types can be created, the [=registration ceremony=] fails.
+        If none of the listed types can be created, the {{CredentialsContainer/create()}} operation fails.
 
     :   <dfn>timeout</dfn>
     ::  This OPTIONAL member specifies a time, in milliseconds, that the [=[RP]=] is willing to wait for the call to complete. This is
@@ -2598,7 +2598,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     ::  The [=[RP]=] SHOULD use this OPTIONAL member to list any existing [=credentials=] mapped to this [=user account=]
         (as identified by {{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}).
         This ensures that the new credential is not [=created on=] an [=authenticator=]
-        that [=contains=] an existing credential mapped to this [=user account=].
+        that already [=contains=] a credential mapped to this [=user account=].
         If it would be, the [=client=] is requested to instead guide the user to use a different [=authenticator=],
         or return an error if that fails.
 
@@ -2761,13 +2761,13 @@ attributes.
     :   <dfn>authenticatorAttachment</dfn>
     ::  If this member is present, eligible [=authenticators=] are filtered to be only those authenticators attached with the specified
         [[#enum-attachment|authenticator attachment modality]] (see also [[#sctn-authenticator-attachment-modality]]).
-        If this member is absent, then the [=[RP]=] is saying that any attachment modality is acceptable.
+        If this member is absent, then any attachment modality is acceptable.
         The value SHOULD be a member of {{AuthenticatorAttachment}} but [=client platforms=] MUST ignore unknown values,
         treating an unknown value as if the [=map/exist|member does not exist=].
 
         See also the {{PublicKeyCredential/authenticatorAttachment}} member of {{PublicKeyCredential}},
         which can tell what [=authenticator attachment modality=] was used
-        in a successful [=registration ceremony|registration=] or [=authentication ceremony=].
+        in a successful {{CredentialsContainer/create()}} or {{CredentialsContainer/get()}} operation.
 
     :   <dfn>residentKey</dfn>
     ::  Specifies the extent to which the [=[RP]=] desires to create a [=client-side discoverable credential=]. For historical reasons the naming retains the deprecated “resident” terminology. The value SHOULD be a member of {{ResidentKeyRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=]. If no value is given then the effective value is {{ResidentKeyRequirement/required}} if {{requireResidentKey}} is [TRUE] or {{ResidentKeyRequirement/discouraged}} if it is [FALSE] or absent.
@@ -2955,6 +2955,8 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
             the [=client=] will automatically ignore non-eligible credentials
             if {{PublicKeyCredentialRequestOptions/userVerification}} is set to {{UserVerificationRequirement/required}}.
 
+            See also the [[#sctn-credential-id-privacy-leak]] privacy consideration.
+
           - If the [=user account=] to authenticate is not already identified,
             then the [=[RP]=] MAY leave this member [=list/empty=] or unspecified.
             In this case, only [=discoverable credentials=] will be utilized in this [=authentication ceremony=],
@@ -2976,8 +2978,8 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
         See {{UserVerificationRequirement}} for the description of {{AuthenticatorSelectionCriteria/userVerification}}'s values and semantics.
 
     :   <dfn>extensions</dfn>
-    ::  This OPTIONAL member contains [=client extension inputs=] requesting additional processing by the [=client=] and [=authenticator=].
-        The extensions framework is defined in [[#sctn-extensions]].
+    ::  The [=[RP]=] MAY use this OPTIONAL member to provide [=client extension inputs=]
+        requesting additional processing by the [=client=] and [=authenticator=].
         Some extensions are defined in [[#sctn-defined-extensions]];
         consult the IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] established by [[!RFC8809]] for an up-to-date list
         of registered [=WebAuthn Extensions=].
@@ -3299,7 +3301,7 @@ It mirrors some fields of the {{PublicKeyCredential}} object returned by
         [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values.
 
         This mirrors the <code>{{PublicKeyCredential/response}}.{{AuthenticatorAttestationResponse/getTransports()}}</code> method
-        of a {{PublicKeyCredential}} structure created during a [=registration ceremony=].
+        of a {{PublicKeyCredential}} structure created by a {{CredentialsContainer/create()}} operation.
         When [[#sctn-registering-a-new-credential|registering a new credential]],
         the [=[RP]=] SHOULD store the value returned from {{AuthenticatorAttestationResponse/getTransports()}}.
         When creating a {{PublicKeyCredentialDescriptor}} for that credential,

--- a/index.bs
+++ b/index.bs
@@ -936,7 +936,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [=user verification=].
 
     The WebAuthn [=authentication ceremony=] is defined in [[#sctn-verifying-assertion]],
-    and is initiated by the [=[RP]=] calling <code>{{CredentialsContainer/get()|navigator.credentials.get()}}</code>
+    and is initiated by the [=[RP]=] invoking a <code>{{CredentialsContainer/get()|navigator.credentials.get()}}</code> operation
     with a {{CredentialRequestOptions/publicKey}} argument.
     See [[#sctn-api]] for an introductory overview and [[#sctn-sample-authentication]] for implementation examples.
 
@@ -1120,7 +1120,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         :   <dfn>rpId</dfn>
         ::  The [=Relying Party Identifier=], for the [=[RP]=] this [=public key credential source=] is [=scoped=] to.
             This is determined by the <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
-            parameter of the [=registration ceremony=].
+            parameter of the {{CredentialsContainer/create()}} operation.
 
         :   <dfn>userHandle</dfn>
         ::  The [=user handle=] associated when this [=public key credential source=] was created. This [=struct/item=] is
@@ -1180,7 +1180,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     After a successful [=registration ceremony=], the user can be authenticated by an [=authentication ceremony=].
 
     The WebAuthn [=registration ceremony=] is defined in [[#sctn-registering-a-new-credential]],
-    and is initiated by the [=[RP]=] calling <code>{{CredentialsContainer/create()|navigator.credentials.create()}}</code>
+    and is initiated by the [=[RP]=] invoking a <code>{{CredentialsContainer/create()|navigator.credentials.create()}}</code> operation
     with a {{CredentialCreationOptions/publicKey}} argument.
     See [[#sctn-api]] for an introductory overview and [[#sctn-sample-registration]] for implementation examples.
 

--- a/index.bs
+++ b/index.bs
@@ -930,7 +930,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 : <dfn>Authentication</dfn>
 : <dfn>Authentication Ceremony</dfn>
-:: The [=ceremony=] where a user, and the user's [=client=] (containing at least one [=authenticator=]) work in
+:: The [=ceremony=] where a user, and the user's [=client platform=] (containing or connected to at least one [=authenticator=]) work in
     concert to cryptographically prove to a [=[RP]=] that the user controls the [=credential private key=] of a
     previously-registered [=public key credential=] (see [=Registration=]). Note that this includes a [=test of user presence=] or
     [=user verification=].

--- a/index.bs
+++ b/index.bs
@@ -2618,6 +2618,8 @@ optionally evidence of [=user consent=] to a specific transaction.
     ::  The [=[RP]=] MAY use this OPTIONAL member to provide [=client extension inputs=]
         requesting additional processing by the [=client=] and [=authenticator=].
         For example, the [=[RP]=] may request that the client returns additional information about the [=credential=] that was created.
+
+        The extensions framework is defined in [[#sctn-extensions]].
         Some extensions are defined in [[#sctn-defined-extensions]];
         consult the IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] established by [[!RFC8809]] for an up-to-date list
         of registered [=WebAuthn Extensions=].
@@ -2980,6 +2982,8 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
     :   <dfn>extensions</dfn>
     ::  The [=[RP]=] MAY use this OPTIONAL member to provide [=client extension inputs=]
         requesting additional processing by the [=client=] and [=authenticator=].
+
+        The extensions framework is defined in [[#sctn-extensions]].
         Some extensions are defined in [[#sctn-defined-extensions]];
         consult the IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] established by [[!RFC8809]] for an up-to-date list
         of registered [=WebAuthn Extensions=].


### PR DESCRIPTION
- Use terms "create()/get() operation" more instead of ceremony
- Align "extensions" description between create() and get() options
- Reference #sctn-credential-id-privacy-leak in allowCredentials description
- Tweak wordings a bit

This would merge into PR #1621.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1674.html" title="Last updated on Nov 4, 2021, 4:28 PM UTC (42db62a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1674/05d05fc...42db62a.html" title="Last updated on Nov 4, 2021, 4:28 PM UTC (42db62a)">Diff</a>