### PR TITLE
New PublicKeyCredential methods for JSON (de)serialization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1452,10 +1452,13 @@ that are returned to the caller when a new credential is created, or a new asser
         [=client extension processing=].
 
     :   {{PublicKeyCredential/toJSON()}}
-    ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}}, a JSON-serialized representation of the instance of
-        {{PublicKeyCredential}} suitable for submission to a [=[RP]=] server as a payload with `application/json` mimetype. The [=client=] is in
-        charge of encoding any {{ArrayBuffer}} values using [=base64url encoding=] to generate strings compatible with JSON syntax. {{ArrayBuffer}}
-        values to be encoded are identified according to the detected type of the instance's `response` property.
+    ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}}, that is a JSON-serialized
+        representation of the instance of {{PublicKeyCredential}} suitable for submission to a [=[RP]=] server as a DOMString
+        payload with `application/json` mimetype. The [=client=] is in charge of
+        [serializing values to JSON as usual](https://webidl.spec.whatwg.org/#idl-tojson-operation), but must take additional
+        steps to encode any {{ArrayBuffer}} values to {{DOMString}} values using [=base64url encoding=] to ensure compatibility
+        with JSON syntax. {{ArrayBuffer}} values to be encoded are identified according to the detected type of the instance's
+        `response` property.
 
         <dl dfn-for="">
             <xmp class="idl">

--- a/index.bs
+++ b/index.bs
@@ -1407,6 +1407,7 @@ that are returned to the caller when a new credential is created, or a new asser
         [SameObject] readonly attribute AuthenticatorResponse    response;
         [SameObject] readonly attribute DOMString?               authenticatorAttachment;
         AuthenticationExtensionsClientOutputs getClientExtensionResults();
+        TBD toJSON();
     };
 </xmp>
 <dl dfn-type="attribute" dfn-for="PublicKeyCredential">
@@ -1449,6 +1450,13 @@ that are returned to the caller when a new credential is created, or a new asser
     ::  This operation returns the value of {{PublicKeyCredential/[[clientExtensionsResults]]}}, which is a [=map=] containing
         [=extension identifier=] → [=client extension output=] entries produced by the extension's
         [=client extension processing=].
+
+    :   {{PublicKeyCredential/toJSON()}}
+    ::  This operation returns a JSON-serialized representation of the instance of {{PublicKeyCredential}} suitable for submission
+        to a [=[RP]=] server as a payload with `application/json` mimetype. The [=client=] returns an object with the same structure
+        as the instance of the {{PublicKeyCredential}} with {{ArrayBuffer}} values encoded with [=base64url encoding=]. {{ArrayBuffer}}
+        values to be encoded are identified according to the detected type of the instance's `response` property, which will either be
+        {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}}.
 
     :   <dfn>\[[type]]</dfn>
     ::  The {{PublicKeyCredential}} [=interface object=]'s {{Credential/[[type]]}} [=internal slot=]'s value is the string
@@ -2396,18 +2404,6 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.
 
 Upon invocation, the [=client=] takes the provided options and returns an identically-structured object with specific strings encoded with [=base64url encoding=] decoded to {{ArrayBuffer}} values according to the corresponding type definition.
-
-</div>
-
-### Serialize Registration and Authentication ceremony responses - PublicKeyCredential's `toJSON()` Method ### {#sctn-toJSON}
-
-<div link-for-hint="WebAuthentication/toJSON">
-
-[=[WRPS]=] use this method to convert the instance of {{PublicKeyCredential}} returned from {{CredentialsContainer/create()|navigator.credentials.create()}} or {{CredentialsContainer/get()|navigator.credentials.get()}} to a JSON-serialized representations suitable for submission to a [=[RP]=] server as a payload with `application/json` mimetype.
-
-This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.
-
-Upon invocation, the [=client=] returns an object with the same structure as the instance of the {{PublicKeyCredential}} with {{ArrayBuffer}} values encoded with [=base64url encoding=]. {{ArrayBuffer}} values to be encoded are identified according to the detected type of the instance's `response` property, which will either be {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}}.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1453,7 +1453,7 @@ that are returned to the caller when a new credential is created, or a new asser
 
     :   {{PublicKeyCredential/toJSON()}}
     ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}},
-        which are [=JSON types=] mirroring {{PublicKeyCredential}}, suitable for submission to a
+        which are [=JSON type=] representations mirroring {{PublicKeyCredential}}, suitable for submission to a
         [=[RP]=] server as an `application/json` payload. The [=client=] is in charge of
         [serializing values to JSON types as usual](https://webidl.spec.whatwg.org/#idl-tojson-operation),
         but MUST take additional steps to first encode any {{ArrayBuffer}} values to {{DOMString}} values
@@ -2468,6 +2468,10 @@ also apply to any [=client extension inputs=] processed by the [=client=].
 "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in
 [[#sctn-extensions]].
 
+If the [=client=] encounters any issues parsing any of the [=JSON type=] representations then it
+MUST return an error code equivalent to "{{EncodingError}}" with a description of the incompatible
+value and terminate the operation.
+
 <xmp class="idl">
     partial interface PublicKeyCredential {
         static PublicKeyCredentialCreationOptions parseCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
@@ -2521,6 +2525,10 @@ also apply to any [=client extension inputs=] processed by the [=client=].
 {{AuthenticationExtensionsClientInputsJSON}} MAY include extensions registered in the IANA
 "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in
 [[#sctn-extensions]].
+
+If the [=client=] encounters any issues parsing any of the [=JSON type=] representations then it
+MUST return an error code equivalent to "{{EncodingError}}" with a description of the incompatible
+value and terminate the operation.
 
 <xmp class="idl">
     partial interface PublicKeyCredential {

--- a/index.bs
+++ b/index.bs
@@ -2437,21 +2437,11 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
 
 <xmp class="idl">
     partial interface PublicKeyCredential {
-        static PublicKeyCredentialCreationOptions optionsFromJSON(CreationOptionsJSON creationOptions);
+        static PublicKeyCredentialCreationOptions getCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
     };
 
     partial interface PublicKeyCredential {
-        static PublicKeyCredentialRequestOptions optionsFromJSON(RequestOptionsJSON requestOptions);
-    };
-
-    dictionary CreationOptionsJSON {
-        required DOMString                                   method = "create";
-        required PublicKeyCredentialCreationOptionsJSON      options;
-    };
-
-    dictionary RequestOptionsJSON {
-        required DOMString                                   method = "get";
-        required PublicKeyCredentialRequestOptionsJSON       options;
+        static PublicKeyCredentialRequestOptions getRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON options);
     };
 
     dictionary PublicKeyCredentialCreationOptionsJSON {

--- a/index.bs
+++ b/index.bs
@@ -2444,16 +2444,16 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 </div>
 
-### Deserialize Registration ceremony options - PublicKeyCredential's `getCreationOptionsFromJSON()` Method ### {#sctn-getCreationOptionsFromJSON}
+### Deserialize Registration ceremony options - PublicKeyCredential's `parseCreationOptionsFromJSON()` Method ### {#sctn-parseCreationOptionsFromJSON}
 
-<div link-for-hint="WebAuthentication/getCreationOptionsFromJSON">
+<div link-for-hint="WebAuthentication/parseCreationOptionsFromJSON">
 
 [=[WRPS]=] use this method to convert [=JSON type=] representations of options for
 {{CredentialsContainer/create()|navigator.credentials.create()}} into
 {{PublicKeyCredentialCreationOptions}}.
 
 Upon invocation, the [=client=] MUST convert the
-{{PublicKeyCredential/getCreationOptionsFromJSON(options)/options}} argument into a new,
+{{PublicKeyCredential/parseCreationOptionsFromJSON(options)/options}} argument into a new,
 identically-structured {{PublicKeyCredentialCreationOptions}} object, using [=base64url encoding=]
 to decode any {{DOMString}} attributes in {{PublicKeyCredentialCreationOptionsJSON}} that correspond
 to [=buffer source type=] attributes in {{PublicKeyCredentialCreationOptions}}. This conversion MUST
@@ -2465,7 +2465,7 @@ extend to any [=client extension inputs=] processed by the [=client=].
 
 <xmp class="idl">
     partial interface PublicKeyCredential {
-        static PublicKeyCredentialCreationOptions getCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
+        static PublicKeyCredentialCreationOptions parseCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
     };
 
     dictionary PublicKeyCredentialCreationOptionsJSON {
@@ -2498,16 +2498,16 @@ extend to any [=client extension inputs=] processed by the [=client=].
 
 </div>
 
-### Deserialize Authentication ceremony options - PublicKeyCredential's `getRequestOptionsFromJSON()` Methods ### {#sctn-getRequestOptionsFromJSON}
+### Deserialize Authentication ceremony options - PublicKeyCredential's `parseRequestOptionsFromJSON()` Methods ### {#sctn-parseRequestOptionsFromJSON}
 
-<div link-for-hint="WebAuthentication/getRequestOptionsFromJSON">
+<div link-for-hint="WebAuthentication/parseRequestOptionsFromJSON">
 
 [=[WRPS]=] use this method to convert [=JSON type=] representations of options for
 {{CredentialsContainer/get()|navigator.credentials.get()}} into
 {{PublicKeyCredentialRequestOptions}}.
 
 Upon invocation, the [=client=] MUST convert the
-{{PublicKeyCredential/getRequestOptionsFromJSON(options)/options}} argument into a new,
+{{PublicKeyCredential/parseRequestOptionsFromJSON(options)/options}} argument into a new,
 identically-structured {{PublicKeyCredentialRequestOptions}} object, using [=base64url encoding=]
 to decode any {{DOMString}} attributes in {{PublicKeyCredentialRequestOptionsJSON}} that correspond
 to [=buffer source type=] attributes in {{PublicKeyCredentialRequestOptions}}. This conversion MUST
@@ -2519,7 +2519,7 @@ extend to any [=client extension inputs=] processed by the [=client=].
 
 <xmp class="idl">
     partial interface PublicKeyCredential {
-        static PublicKeyCredentialRequestOptions getRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON options);
+        static PublicKeyCredentialRequestOptions parseRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON options);
     };
 
     dictionary PublicKeyCredentialRequestOptionsJSON {

--- a/index.bs
+++ b/index.bs
@@ -2453,7 +2453,7 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
         required Base64URLString                                challenge;
         required sequence<PublicKeyCredentialParameters>        pubKeyCredParams;
         unsigned long                                           timeout;
-        required sequence<PublicKeyCredentialDescriptorJSON>    excludeCredentials = [];
+        sequence<PublicKeyCredentialDescriptorJSON>    excludeCredentials = [];
         AuthenticatorSelectionCriteria                          authenticatorSelection;
         DOMString                                               attestation = "none";
         AuthenticationExtensionsClientInputsJSON                extensions;

--- a/index.bs
+++ b/index.bs
@@ -2453,6 +2453,11 @@ Upon invocation, the [=client=] must take the provided options and return an ide
 making sure to decode to {{ArrayBuffer}} those {{DOMString}} properties that are encoded with [=base64url encoding=]
 but must be {{ArrayBuffer}} values according to the definition of {{PublicKeyCredentialCreationOptions}}.
 
+{{AuthenticationExtensionsClientInputsJSON}} may include extensions registered in the IANA
+"WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in [[#sctn-extensions]].
+In either case the [=client=] must decode to {{ArrayBuffer}} those {{DOMString}} values that are encoded with
+[=base64url encoding=] but must be {{ArrayBuffer}} values according to the extension's definition.
+
 <xmp class="idl">
     partial interface PublicKeyCredential {
         static PublicKeyCredentialCreationOptions getCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
@@ -2483,17 +2488,6 @@ but must be {{ArrayBuffer}} values according to the definition of {{PublicKeyCre
     };
 
     dictionary AuthenticationExtensionsClientInputsJSON {
-        DOMString                                       appid;
-        DOMString                                       appidExclude;
-        boolean                                         uvm;
-        boolean                                         credProps;
-        AuthenticationExtensionsLargeBlobInputsJSON     largeBlob;
-    };
-
-    dictionary AuthenticationExtensionsLargeBlobInputsJSON {
-        DOMString                       support;
-        boolean                         read;
-        Base64URLString                 write;
     };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -2387,6 +2387,30 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 </div>
 
+### Deserialize Registration and Authentication ceremony options - PublicKeyCredential's `optionsFromJSON()` Method ### {#sctn-optionsFromJSON}
+
+<div link-for-hint="WebAuthentication/optionsFromJSON">
+
+[=[WRPS]=] use this method to convert JSON-compatible serialized representations of options for {{CredentialsContainer/create()|navigator.credentials.create()}} to {{PublicKeyCredentialCreationOptions}}, or JSON-compatible serialized representations of options for {{CredentialsContainer/get()|navigator.credentials.get()}} to {{PublicKeyCredentialRequestOptions}}.
+
+This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.
+
+Upon invocation, the [=client=] takes the provided options and returns an identically-structured object with specific strings encoded with [=base64url encoding=] decoded to {{ArrayBuffer}} values according to the corresponding type definition.
+
+</div>
+
+### Serialize Registration and Authentication ceremony responses - PublicKeyCredential's `toJSON()` Method ### {#sctn-toJSON}
+
+<div link-for-hint="WebAuthentication/toJSON">
+
+[=[WRPS]=] use this method to convert the instance of {{PublicKeyCredential}} returned from {{CredentialsContainer/create()|navigator.credentials.create()}} or {{CredentialsContainer/get()|navigator.credentials.get()}} to a JSON-serialized representations suitable for submission to a [=[RP]=] server as a payload with `application/json` mimetype.
+
+This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.
+
+Upon invocation, the [=client=] returns an object with the same structure as the instance of the {{PublicKeyCredential}} with {{ArrayBuffer}} values encoded with [=base64url encoding=]. {{ArrayBuffer}} values to be encoded are identified according to the detected type of the instance's `response` property, which will either be {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}}.
+
+</div>
+
 ## Authenticator Responses (interface <dfn interface>AuthenticatorResponse</dfn>) ## {#iface-authenticatorresponse}
 
 [=Authenticators=] respond to [=[RP]=] requests by returning an object derived from the

--- a/index.bs
+++ b/index.bs
@@ -2407,6 +2407,12 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 Upon invocation, the [=client=] takes the provided options and returns an identically-structured object with specific strings encoded with [=base64url encoding=] decoded to {{ArrayBuffer}} values according to the corresponding type definition.
 
+<xmp class="idl">
+    partial interface PublicKeyCredential {
+        static TBD optionsFromJSON();
+    };
+</xmp>
+
 Note: This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries to handle this
 deseraili
 

--- a/index.bs
+++ b/index.bs
@@ -1407,7 +1407,7 @@ that are returned to the caller when a new credential is created, or a new asser
         [SameObject] readonly attribute AuthenticatorResponse    response;
         [SameObject] readonly attribute DOMString?               authenticatorAttachment;
         AuthenticationExtensionsClientOutputs getClientExtensionResults();
-        TBD toJSON();
+        PublicKeyCredentialJSON toJSON();
     };
 </xmp>
 <dl dfn-type="attribute" dfn-for="PublicKeyCredential">
@@ -1457,6 +1457,37 @@ that are returned to the caller when a new credential is created, or a new asser
         as the instance of the {{PublicKeyCredential}} with {{ArrayBuffer}} values encoded with [=base64url encoding=]. {{ArrayBuffer}}
         values to be encoded are identified according to the detected type of the instance's `response` property, which will either be
         {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}}.
+
+        <xmp class="idl">
+            typedef DOMString Base64URLString;
+            typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
+
+            dictionary RegistrationResponseJSON {
+                Base64URLString id;
+                Base64URLString rawId;
+                AuthenticatorAttestationResponseJSON response;
+                DOMString type;
+            };
+
+            dictionary AuthenticationResponseJSON {
+                Base64URLString id;
+                Base64URLString rawId;
+                AuthenticatorAssertionResponseJSON response;
+                DOMString type;
+            };
+
+            dictionary AuthenticatorAttestationResponseJSON {
+                Base64URLString clientDataJSON;
+                Base64URLString attestationObject;
+            };
+
+            dictionary AuthenticatorAssertionResponseJSON {
+                Base64URLString clientDataJSON;
+                Base64URLString authenticatorData;
+                Base64URLString signature;
+                Base64URLString? userHandle;
+            };
+        </xmp>
 
         <div class="note">
         Note: This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.

--- a/index.bs
+++ b/index.bs
@@ -2455,34 +2455,37 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
     };
 
     dictionary PublicKeyCredentialCreationOptionsJSON {
-        PublicKeyCredentialRpEntity                     rp;
-        PublicKeyCredentialUserEntityJSON               user;
-        Base64URLString                                 challenge;
-        sequence<PublicKeyCredentialDescriptorJSON>     excludeCredentials = [];
-        AuthenticatorSelectionCriteria                  authenticatorSelection;
-        DOMString                                       attestation = "none";
-        AuthenticationExtensionsClientInputsJSON        extensions;
+        required PublicKeyCredentialRpEntity                    rp;
+        required PublicKeyCredentialUserEntityJSON              user;
+        required Base64URLString                                challenge;
+        required sequence<PublicKeyCredentialParameters>        pubKeyCredParams;
+        unsigned long                                           timeout;
+        required sequence<PublicKeyCredentialDescriptorJSON>    excludeCredentials = [];
+        AuthenticatorSelectionCriteria                          authenticatorSelection;
+        DOMString                                               attestation = "none";
+        AuthenticationExtensionsClientInputsJSON                extensions;
     };
 
     dictionary PublicKeyCredentialRequestOptionsJSON {
-        Base64URLString challenge;
-        unsigned long                                   timeout;
-        DOMString                                       rpId;
-        sequence<PublicKeyCredentialDescriptorJSON>     allowCredentials = [];
-        DOMString                                       userVerification = "preferred";
-        AuthenticationExtensionsClientInputsJSON        extensions;
+        required Base64URLString                                challenge;
+        unsigned long                                           timeout;
+        DOMString                                               rpId;
+        sequence<PublicKeyCredentialDescriptorJSON>             allowCredentials = [];
+        DOMString                                               userVerification = "preferred";
+        AuthenticationExtensionsClientInputsJSON                extensions;
     };
 
     dictionary PublicKeyCredentialUserEntityJSON {
-        Base64URLString         id;
-        DOMString               name;
-        DOMString               displayName;
+        required Base64URLString        id;
+        required DOMString              name;
+        required DOMString              displayName;
     };
 
     dictionary PublicKeyCredentialDescriptorJSON {
-        Base64URLString         id;
-        DOMString               type;
-        sequence<DOMString>     transports;
+        required Base64URLString        id;
+        required DOMString              type;
+        sequence<DOMString>             transports;
+    };
 
     dictionary AuthenticationExtensionsClientInputsJSON {
         DOMString                                       appid;

--- a/index.bs
+++ b/index.bs
@@ -1452,11 +1452,10 @@ that are returned to the caller when a new credential is created, or a new asser
         [=client extension processing=].
 
     :   {{PublicKeyCredential/toJSON()}}
-    ::  This operation returns a JSON-serialized representation of the instance of {{PublicKeyCredential}} suitable for submission
-        to a [=[RP]=] server as a payload with `application/json` mimetype. The [=client=] returns an object with the same structure
-        as the instance of the {{PublicKeyCredential}} with {{ArrayBuffer}} values encoded with [=base64url encoding=]. {{ArrayBuffer}}
-        values to be encoded are identified according to the detected type of the instance's `response` property, which will either be
-        {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}}.
+    ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}}, a JSON-serialized representation of the instance of
+        {{PublicKeyCredential}} suitable for submission to a [=[RP]=] server as a payload with `application/json` mimetype. The [=client=] is in
+        charge of encoding any {{ArrayBuffer}} values using [=base64url encoding=] to generate strings compatible with JSON syntax. {{ArrayBuffer}}
+        values to be encoded are identified according to the detected type of the instance's `response` property.
 
         <xmp class="idl">
             typedef DOMString Base64URLString;

--- a/index.bs
+++ b/index.bs
@@ -1458,6 +1458,10 @@ that are returned to the caller when a new credential is created, or a new asser
         values to be encoded are identified according to the detected type of the instance's `response` property, which will either be
         {{AuthenticatorAttestationResponse}} or {{AuthenticatorAssertionResponse}}.
 
+        <div class="note">
+        Note: This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.
+        </div>
+
     :   <dfn>\[[type]]</dfn>
     ::  The {{PublicKeyCredential}} [=interface object=]'s {{Credential/[[type]]}} [=internal slot=]'s value is the string
         "`public-key`".
@@ -2401,9 +2405,10 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 [=[WRPS]=] use this method to convert JSON-compatible serialized representations of options for {{CredentialsContainer/create()|navigator.credentials.create()}} to {{PublicKeyCredentialCreationOptions}}, or JSON-compatible serialized representations of options for {{CredentialsContainer/get()|navigator.credentials.get()}} to {{PublicKeyCredentialRequestOptions}}.
 
-This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.
-
 Upon invocation, the [=client=] takes the provided options and returns an identically-structured object with specific strings encoded with [=base64url encoding=] decoded to {{ArrayBuffer}} values according to the corresponding type definition.
+
+Note: This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries to handle this
+deseraili
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1488,10 +1488,6 @@ that are returned to the caller when a new credential is created, or a new asser
             };
         </xmp>
 
-        <div class="note">
-        Note: This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries.
-        </div>
-
     :   <dfn>\[[type]]</dfn>
     ::  The {{PublicKeyCredential}} [=interface object=]'s {{Credential/[[type]]}} [=internal slot=]'s value is the string
         "`public-key`".
@@ -2487,9 +2483,6 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
         sequence<DOMString>     transports;
     };
 </xmp>
-
-Note: This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries to handle this
-deserialization.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1468,16 +1468,16 @@ that are returned to the caller when a new credential is created, or a new asser
                 DOMString type;
             };
 
+            dictionary AuthenticatorAttestationResponseJSON {
+                Base64URLString clientDataJSON;
+                Base64URLString attestationObject;
+            };
+
             dictionary AuthenticationResponseJSON {
                 Base64URLString id;
                 Base64URLString rawId;
                 AuthenticatorAssertionResponseJSON response;
                 DOMString type;
-            };
-
-            dictionary AuthenticatorAttestationResponseJSON {
-                Base64URLString clientDataJSON;
-                Base64URLString attestationObject;
             };
 
             dictionary AuthenticatorAssertionResponseJSON {

--- a/index.bs
+++ b/index.bs
@@ -1455,16 +1455,21 @@ that are returned to the caller when a new credential is created, or a new asser
     ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}},
         which are [=JSON types=] mirroring {{PublicKeyCredential}}, suitable for submission to a
         [=[RP]=] server as an `application/json` payload. The [=client=] is in charge of
-        [serializing values to JSON as usual](https://webidl.spec.whatwg.org/#idl-tojson-operation),
+        [serializing values to JSON types as usual](https://webidl.spec.whatwg.org/#idl-tojson-operation),
         but MUST take additional steps to first encode any {{ArrayBuffer}} values to {{DOMString}} values
-        using [=base64url encoding=] to ensure compatibility with JSON syntax.
+        using [=base64url encoding=].
+
+        The
         {{RegistrationResponseJSON/clientExtensionResults|RegistrationResponseJSON.clientExtensionResults}} or
         {{AuthenticationResponseJSON/clientExtensionResults|AuthenticationResponseJSON.clientExtensionResults}}
-        members MUST be set to the output of {{PublicKeyCredential/getClientExtensionResults()}},
+        member MUST be set to the output of {{PublicKeyCredential/getClientExtensionResults()}},
         with any {{ArrayBuffer}} values encoded to {{DOMString}} values using
         [=base64url encoding=]. This MAY include {{ArrayBuffer}} values from extensions registered
         in the IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not
         defined in [[#sctn-extensions]].
+
+        The {{AuthenticatorAttestationResponseJSON/transports|AuthenticatorAttestationResponseJSON.transports}}
+        member MUST be set to the output of {{AuthenticatorAttestationResponse/getTransports()}}.
 </dl>
 
 <xmp class="idl">
@@ -2457,7 +2462,7 @@ Upon invocation, the [=client=] MUST convert the
 identically-structured {{PublicKeyCredentialCreationOptions}} object, using [=base64url encoding=]
 to decode any {{DOMString}} attributes in {{PublicKeyCredentialCreationOptionsJSON}} that correspond
 to [=buffer source type=] attributes in {{PublicKeyCredentialCreationOptions}}. This conversion MUST
-extend to any [=client extension inputs=] processed by the [=client=].
+also apply to any [=client extension inputs=] processed by the [=client=].
 
 {{AuthenticationExtensionsClientInputsJSON}} MAY include extensions registered in the IANA
 "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in
@@ -2511,7 +2516,7 @@ Upon invocation, the [=client=] MUST convert the
 identically-structured {{PublicKeyCredentialRequestOptions}} object, using [=base64url encoding=]
 to decode any {{DOMString}} attributes in {{PublicKeyCredentialRequestOptionsJSON}} that correspond
 to [=buffer source type=] attributes in {{PublicKeyCredentialRequestOptions}}. This conversion MUST
-extend to any [=client extension inputs=] processed by the [=client=].
+also apply to any [=client extension inputs=] processed by the [=client=].
 
 {{AuthenticationExtensionsClientInputsJSON}} MAY include extensions registered in the IANA
 "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in

--- a/index.bs
+++ b/index.bs
@@ -2469,7 +2469,7 @@ also apply to any [=client extension inputs=] processed by the [=client=].
 [[#sctn-extensions]].
 
 If the [=client=] encounters any issues parsing any of the [=JSON type=] representations then it
-MUST return an error code equivalent to "{{EncodingError}}" with a description of the incompatible
+MUST throw an "{{EncodingError}}" {{DOMException}} with a description of the incompatible
 value and terminate the operation.
 
 <xmp class="idl">
@@ -2527,7 +2527,7 @@ also apply to any [=client extension inputs=] processed by the [=client=].
 [[#sctn-extensions]].
 
 If the [=client=] encounters any issues parsing any of the [=JSON type=] representations then it
-MUST return an error code equivalent to "{{EncodingError}}" with a description of the incompatible
+MUST throw an "{{EncodingError}}" {{DOMException}} with a description of the incompatible
 value and terminate the operation.
 
 <xmp class="idl">

--- a/index.bs
+++ b/index.bs
@@ -2489,7 +2489,7 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
 </xmp>
 
 Note: This method is intended to make WebAuthn API consumption tenable without requiring the use of third-party libraries to handle this
-deseraili
+deserialization.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1425,7 +1425,7 @@ that are returned to the caller when a new credential is created, or a new asser
         {{CredentialsContainer/create()}}, this attribute's value will be an {{AuthenticatorAttestationResponse}}, otherwise,
         the {{PublicKeyCredential}} was created in response to {{CredentialsContainer/get()}}, and this attribute's value
         will be an {{AuthenticatorAssertionResponse}}.
-    
+
     :   <dfn>authenticatorAttachment</dfn>
     ::  This attribute reports the [=authenticator attachment modality=] in effect at the time the
         {{CredentialsContainer/create()|navigator.credentials.create()}} or
@@ -1452,17 +1452,19 @@ that are returned to the caller when a new credential is created, or a new asser
         [=client extension processing=].
 
     :   {{PublicKeyCredential/toJSON()}}
-    ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}}, that is a JSON-serialized
-        representation of the instance of {{PublicKeyCredential}} suitable for submission to a [=[RP]=] server as a DOMString
-        payload with `application/json` mimetype. The [=client=] is in charge of
-        [serializing values to JSON as usual](https://webidl.spec.whatwg.org/#idl-tojson-operation), but must take additional
-        steps to encode any {{ArrayBuffer}} values to {{DOMString}} values using [=base64url encoding=] to ensure compatibility
-        with JSON syntax. {{ArrayBuffer}} values to be encoded are identified according to the detected type of the instance's
-        `response` property.
-    ::  |clientExtensionResults| below should be the output of {{PublicKeyCredential/getClientExtensionResults()}}, with any
-        {{ArrayBuffer}} values encoded to {{DOMString}} values using [=base64url encoding=]. This may include {{ArrayBuffer}}
-        values from extensions registered in the IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]]
-        but not defined in [[#sctn-extensions]].
+    ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}},
+        which are [=JSON types=] mirroring {{PublicKeyCredential}}, suitable for submission to a
+        [=[RP]=] server as an `application/json` payload. The [=client=] is in charge of
+        [serializing values to JSON as usual](https://webidl.spec.whatwg.org/#idl-tojson-operation),
+        but MUST take additional steps to first encode any {{ArrayBuffer}} values to {{DOMString}} values
+        using [=base64url encoding=] to ensure compatibility with JSON syntax.
+        {{RegistrationResponseJSON/clientExtensionResults|RegistrationResponseJSON.clientExtensionResults}} or
+        {{AuthenticationResponseJSON/clientExtensionResults|AuthenticationResponseJSON.clientExtensionResults}}
+        members MUST be set to the output of {{PublicKeyCredential/getClientExtensionResults()}},
+        with any {{ArrayBuffer}} values encoded to {{DOMString}} values using
+        [=base64url encoding=]. This MAY include {{ArrayBuffer}} values from extensions registered
+        in the IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not
+        defined in [[#sctn-extensions]].
 </dl>
 
 <xmp class="idl">
@@ -2446,17 +2448,20 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 <div link-for-hint="WebAuthentication/getCreationOptionsFromJSON">
 
-[=[WRPS]=] use this method to convert JSON-compatible serialized representations of options for
-{{CredentialsContainer/create()|navigator.credentials.create()}} to {{PublicKeyCredentialCreationOptions}}.
+[=[WRPS]=] use this method to convert [=JSON type=] representations of options for
+{{CredentialsContainer/create()|navigator.credentials.create()}} into
+{{PublicKeyCredentialCreationOptions}}.
 
-Upon invocation, the [=client=] must take the provided options and return an identically-structured object,
-making sure to decode to {{ArrayBuffer}} those {{DOMString}} properties that are encoded with [=base64url encoding=]
-but must be {{ArrayBuffer}} values according to the definition of {{PublicKeyCredentialCreationOptions}}.
+Upon invocation, the [=client=] MUST convert the
+{{PublicKeyCredential/getCreationOptionsFromJSON(options)/options}} argument into a new,
+identically-structured {{PublicKeyCredentialCreationOptions}} object, using [=base64url encoding=]
+to decode any {{DOMString}} attributes in {{PublicKeyCredentialCreationOptionsJSON}} that correspond
+to [=buffer source type=] attributes in {{PublicKeyCredentialCreationOptions}}. This conversion MUST
+extend to any [=client extension inputs=] processed by the [=client=].
 
-{{AuthenticationExtensionsClientInputsJSON}} may include extensions registered in the IANA
-"WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in [[#sctn-extensions]].
-In either case the [=client=] must decode to {{ArrayBuffer}} those {{DOMString}} values that are encoded with
-[=base64url encoding=] but must be {{ArrayBuffer}} values according to the extension's definition.
+{{AuthenticationExtensionsClientInputsJSON}} MAY include extensions registered in the IANA
+"WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in
+[[#sctn-extensions]].
 
 <xmp class="idl">
     partial interface PublicKeyCredential {
@@ -2497,11 +2502,20 @@ In either case the [=client=] must decode to {{ArrayBuffer}} those {{DOMString}}
 
 <div link-for-hint="WebAuthentication/getRequestOptionsFromJSON">
 
-[=[WRPS]=] use this method to convert JSON-compatible serialized representations of options for {{CredentialsContainer/get()|navigator.credentials.get()}} to {{PublicKeyCredentialRequestOptions}}.
+[=[WRPS]=] use this method to convert [=JSON type=] representations of options for
+{{CredentialsContainer/get()|navigator.credentials.get()}} into
+{{PublicKeyCredentialRequestOptions}}.
 
-Upon invocation, the [=client=] must take the provided options and return an identically-structured object,
-making sure to decode to {{ArrayBuffer}} those {{DOMString}} properties that are encoded with [=base64url encoding=]
-but must be {{ArrayBuffer}} values according to the definition of {{PublicKeyCredentialRequestOptions}}.
+Upon invocation, the [=client=] MUST convert the
+{{PublicKeyCredential/getRequestOptionsFromJSON(options)/options}} argument into a new,
+identically-structured {{PublicKeyCredentialRequestOptions}} object, using [=base64url encoding=]
+to decode any {{DOMString}} attributes in {{PublicKeyCredentialRequestOptionsJSON}} that correspond
+to [=buffer source type=] attributes in {{PublicKeyCredentialRequestOptions}}. This conversion MUST
+extend to any [=client extension inputs=] processed by the [=client=].
+
+{{AuthenticationExtensionsClientInputsJSON}} MAY include extensions registered in the IANA
+"WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] but not defined in
+[[#sctn-extensions]].
 
 <xmp class="idl">
     partial interface PublicKeyCredential {
@@ -3223,7 +3237,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
         required DOMString           type;
         required DOMString           challenge;
         required DOMString           origin;
-        boolean                      crossOrigin;        
+        boolean                      crossOrigin;
     };
 
     dictionary TokenBinding {
@@ -3255,7 +3269,7 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     :   \[RESERVED] <dfn dfn>tokenBinding</dfn>
     ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
         with the [=[RP]=]. Its absence indicates that the client doesn't support token binding
-        
+
         Note: While [=Token Binding=] was present in Level 1 and Level 2 of WebAuthn, its use is not expected in Level 3. The {{CollectedClientData/tokenBinding}} field is reserved so that it will not be reused for a different purpose.
 
         <div dfn-type="dict-member" dfn-for="TokenBinding">

--- a/index.bs
+++ b/index.bs
@@ -2447,13 +2447,13 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
     };
 
     dictionary CreationOptionsJSON {
-        DOMString                                   method = "create";
-        PublicKeyCredentialCreationOptionsJSON      options;
+        required DOMString                                   method = "create";
+        required PublicKeyCredentialCreationOptionsJSON      options;
     };
 
     dictionary RequestOptionsJSON {
-        DOMString                                   method = "get";
-        PublicKeyCredentialRequestOptionsJSON       options;
+        required DOMString                                   method = "get";
+        required PublicKeyCredentialRequestOptionsJSON       options;
     };
 
     dictionary PublicKeyCredentialCreationOptionsJSON {

--- a/index.bs
+++ b/index.bs
@@ -1457,36 +1457,38 @@ that are returned to the caller when a new credential is created, or a new asser
         charge of encoding any {{ArrayBuffer}} values using [=base64url encoding=] to generate strings compatible with JSON syntax. {{ArrayBuffer}}
         values to be encoded are identified according to the detected type of the instance's `response` property.
 
-        <xmp class="idl">
-            typedef DOMString Base64URLString;
-            typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
+        <dl dfn-for="">
+            <xmp class="idl">
+                typedef DOMString Base64URLString;
+                typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
 
-            dictionary RegistrationResponseJSON {
-                Base64URLString id;
-                Base64URLString rawId;
-                AuthenticatorAttestationResponseJSON response;
-                DOMString type;
-            };
+                dictionary RegistrationResponseJSON {
+                    Base64URLString id;
+                    Base64URLString rawId;
+                    AuthenticatorAttestationResponseJSON response;
+                    DOMString type;
+                };
 
-            dictionary AuthenticatorAttestationResponseJSON {
-                Base64URLString clientDataJSON;
-                Base64URLString attestationObject;
-            };
+                dictionary AuthenticatorAttestationResponseJSON {
+                    Base64URLString clientDataJSON;
+                    Base64URLString attestationObject;
+                };
 
-            dictionary AuthenticationResponseJSON {
-                Base64URLString id;
-                Base64URLString rawId;
-                AuthenticatorAssertionResponseJSON response;
-                DOMString type;
-            };
+                dictionary AuthenticationResponseJSON {
+                    Base64URLString id;
+                    Base64URLString rawId;
+                    AuthenticatorAssertionResponseJSON response;
+                    DOMString type;
+                };
 
-            dictionary AuthenticatorAssertionResponseJSON {
-                Base64URLString clientDataJSON;
-                Base64URLString authenticatorData;
-                Base64URLString signature;
-                Base64URLString? userHandle;
-            };
-        </xmp>
+                dictionary AuthenticatorAssertionResponseJSON {
+                    Base64URLString clientDataJSON;
+                    Base64URLString authenticatorData;
+                    Base64URLString signature;
+                    Base64URLString? userHandle;
+                };
+            </xmp>
+        </dl>
 
     :   <dfn>\[[type]]</dfn>
     ::  The {{PublicKeyCredential}} [=interface object=]'s {{Credential/[[type]]}} [=internal slot=]'s value is the string

--- a/index.bs
+++ b/index.bs
@@ -2461,7 +2461,7 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
         sequence<PublicKeyCredentialDescriptorJSON>     excludeCredentials = [];
         AuthenticatorSelectionCriteria                  authenticatorSelection;
         DOMString                                       attestation = "none";
-        AuthenticationExtensionsClientInputs            extensions;
+        AuthenticationExtensionsClientInputsJSON        extensions;
     };
 
     dictionary PublicKeyCredentialRequestOptionsJSON {
@@ -2470,7 +2470,7 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
         DOMString                                       rpId;
         sequence<PublicKeyCredentialDescriptorJSON>     allowCredentials = [];
         DOMString                                       userVerification = "preferred";
-        AuthenticationExtensionsClientInputs            extensions;
+        AuthenticationExtensionsClientInputsJSON        extensions;
     };
 
     dictionary PublicKeyCredentialUserEntityJSON {
@@ -2483,6 +2483,19 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
         Base64URLString         id;
         DOMString               type;
         sequence<DOMString>     transports;
+
+    dictionary AuthenticationExtensionsClientInputsJSON {
+        DOMString                                       appid;
+        DOMString                                       appidExclude;
+        boolean                                         uvm;
+        boolean                                         credProps;
+        AuthenticationExtensionsLargeBlobInputsJSON     largeBlob;
+    };
+
+    dictionary AuthenticationExtensionsLargeBlobInputsJSON {
+        DOMString                       support;
+        boolean                         read;
+        Base64URLString                 write;
     };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -2439,7 +2439,52 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
 
 <xmp class="idl">
     partial interface PublicKeyCredential {
-        static TBD optionsFromJSON();
+        static PublicKeyCredentialCreationOptions optionsFromJSON(CreationOptionsJSON creationOptions);
+    };
+
+    partial interface PublicKeyCredential {
+        static PublicKeyCredentialRequestOptions optionsFromJSON(RequestOptionsJSON requestOptions);
+    };
+
+    dictionary CreationOptionsJSON {
+        DOMString                                   method = "create";
+        PublicKeyCredentialCreationOptionsJSON      options;
+    };
+
+    dictionary RequestOptionsJSON {
+        DOMString                                   method = "get";
+        PublicKeyCredentialRequestOptionsJSON       options;
+    };
+
+    dictionary PublicKeyCredentialCreationOptionsJSON {
+        PublicKeyCredentialRpEntity                     rp;
+        PublicKeyCredentialUserEntityJSON               user;
+        Base64URLString                                 challenge;
+        sequence<PublicKeyCredentialDescriptorJSON>     excludeCredentials = [];
+        AuthenticatorSelectionCriteria                  authenticatorSelection;
+        DOMString                                       attestation = "none";
+        AuthenticationExtensionsClientInputs            extensions;
+    };
+
+    dictionary PublicKeyCredentialRequestOptionsJSON {
+        Base64URLString challenge;
+        unsigned long                                   timeout;
+        DOMString                                       rpId;
+        sequence<PublicKeyCredentialDescriptorJSON>     allowCredentials = [];
+        DOMString                                       userVerification = "preferred";
+        AuthenticationExtensionsClientInputs            extensions;
+    };
+
+    dictionary PublicKeyCredentialUserEntityJSON {
+        Base64URLString         id;
+        DOMString               name;
+        DOMString               displayName;
+    };
+
+    dictionary PublicKeyCredentialDescriptorJSON {
+        Base64URLString         id;
+        DOMString               type;
+        sequence<DOMString>     transports;
     };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -2430,21 +2430,20 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 </div>
 
-### Deserialize Registration and Authentication ceremony options - PublicKeyCredential's `optionsFromJSON()` Method ### {#sctn-optionsFromJSON}
+### Deserialize Registration ceremony options - PublicKeyCredential's `getCreationOptionsFromJSON()` Method ### {#sctn-getCreationOptionsFromJSON}
 
-<div link-for-hint="WebAuthentication/optionsFromJSON">
+<div link-for-hint="WebAuthentication/getCreationOptionsFromJSON">
 
-[=[WRPS]=] use this method to convert JSON-compatible serialized representations of options for {{CredentialsContainer/create()|navigator.credentials.create()}} to {{PublicKeyCredentialCreationOptions}}, or JSON-compatible serialized representations of options for {{CredentialsContainer/get()|navigator.credentials.get()}} to {{PublicKeyCredentialRequestOptions}}.
+[=[WRPS]=] use this method to convert JSON-compatible serialized representations of options for
+{{CredentialsContainer/create()|navigator.credentials.create()}} to {{PublicKeyCredentialCreationOptions}}.
 
-Upon invocation, the [=client=] takes the provided options and returns an identically-structured object with specific strings encoded with [=base64url encoding=] decoded to {{ArrayBuffer}} values according to the corresponding type definition.
+Upon invocation, the [=client=] must take the provided options and return an identically-structured object,
+making sure to decode to {{ArrayBuffer}} those {{DOMString}} properties that are encoded with [=base64url encoding=]
+but must be {{ArrayBuffer}} values according to the definition of {{PublicKeyCredentialCreationOptions}}.
 
 <xmp class="idl">
     partial interface PublicKeyCredential {
         static PublicKeyCredentialCreationOptions getCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
-    };
-
-    partial interface PublicKeyCredential {
-        static PublicKeyCredentialRequestOptions getRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON options);
     };
 
     dictionary PublicKeyCredentialCreationOptionsJSON {
@@ -2453,18 +2452,9 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
         required Base64URLString                                challenge;
         required sequence<PublicKeyCredentialParameters>        pubKeyCredParams;
         unsigned long                                           timeout;
-        sequence<PublicKeyCredentialDescriptorJSON>    excludeCredentials = [];
+        sequence<PublicKeyCredentialDescriptorJSON>             excludeCredentials = [];
         AuthenticatorSelectionCriteria                          authenticatorSelection;
         DOMString                                               attestation = "none";
-        AuthenticationExtensionsClientInputsJSON                extensions;
-    };
-
-    dictionary PublicKeyCredentialRequestOptionsJSON {
-        required Base64URLString                                challenge;
-        unsigned long                                           timeout;
-        DOMString                                               rpId;
-        sequence<PublicKeyCredentialDescriptorJSON>             allowCredentials = [];
-        DOMString                                               userVerification = "preferred";
         AuthenticationExtensionsClientInputsJSON                extensions;
     };
 
@@ -2492,6 +2482,33 @@ Upon invocation, the [=client=] takes the provided options and returns an identi
         DOMString                       support;
         boolean                         read;
         Base64URLString                 write;
+    };
+</xmp>
+
+</div>
+
+### Deserialize Authentication ceremony options - PublicKeyCredential's `getRequestOptionsFromJSON()` Methods ### {#sctn-getRequestOptionsFromJSON}
+
+<div link-for-hint="WebAuthentication/getRequestOptionsFromJSON">
+
+[=[WRPS]=] use this method to convert JSON-compatible serialized representations of options for {{CredentialsContainer/get()|navigator.credentials.get()}} to {{PublicKeyCredentialRequestOptions}}.
+
+Upon invocation, the [=client=] must take the provided options and return an identically-structured object,
+making sure to decode to {{ArrayBuffer}} those {{DOMString}} properties that are encoded with [=base64url encoding=]
+but must be {{ArrayBuffer}} values according to the definition of {{PublicKeyCredentialRequestOptions}}.
+
+<xmp class="idl">
+    partial interface PublicKeyCredential {
+        static PublicKeyCredentialRequestOptions getRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON options);
+    };
+
+    dictionary PublicKeyCredentialRequestOptionsJSON {
+        required Base64URLString                                challenge;
+        unsigned long                                           timeout;
+        DOMString                                               rpId;
+        sequence<PublicKeyCredentialDescriptorJSON>             allowCredentials = [];
+        DOMString                                               userVerification = "preferred";
+        AuthenticationExtensionsClientInputsJSON                extensions;
     };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -1459,40 +1459,40 @@ that are returned to the caller when a new credential is created, or a new asser
         steps to encode any {{ArrayBuffer}} values to {{DOMString}} values using [=base64url encoding=] to ensure compatibility
         with JSON syntax. {{ArrayBuffer}} values to be encoded are identified according to the detected type of the instance's
         `response` property.
+</dl>
 
-        <dl dfn-for="">
-            <xmp class="idl">
-                typedef DOMString Base64URLString;
-                typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
+<xmp class="idl">
+    typedef DOMString Base64URLString;
+    typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
 
-                dictionary RegistrationResponseJSON {
-                    Base64URLString id;
-                    Base64URLString rawId;
-                    AuthenticatorAttestationResponseJSON response;
-                    DOMString type;
-                };
+    dictionary RegistrationResponseJSON {
+        Base64URLString id;
+        Base64URLString rawId;
+        AuthenticatorAttestationResponseJSON response;
+        DOMString type;
+    };
 
-                dictionary AuthenticatorAttestationResponseJSON {
-                    Base64URLString clientDataJSON;
-                    Base64URLString attestationObject;
-                };
+    dictionary AuthenticatorAttestationResponseJSON {
+        Base64URLString clientDataJSON;
+        Base64URLString attestationObject;
+    };
 
-                dictionary AuthenticationResponseJSON {
-                    Base64URLString id;
-                    Base64URLString rawId;
-                    AuthenticatorAssertionResponseJSON response;
-                    DOMString type;
-                };
+    dictionary AuthenticationResponseJSON {
+        Base64URLString id;
+        Base64URLString rawId;
+        AuthenticatorAssertionResponseJSON response;
+        DOMString type;
+    };
 
-                dictionary AuthenticatorAssertionResponseJSON {
-                    Base64URLString clientDataJSON;
-                    Base64URLString authenticatorData;
-                    Base64URLString signature;
-                    Base64URLString? userHandle;
-                };
-            </xmp>
-        </dl>
+    dictionary AuthenticatorAssertionResponseJSON {
+        Base64URLString clientDataJSON;
+        Base64URLString authenticatorData;
+        Base64URLString signature;
+        Base64URLString? userHandle;
+    };
+</xmp>
 
+<dl dfn-type="attribute" dfn-for="PublicKeyCredential">
     :   <dfn>\[[type]]</dfn>
     ::  The {{PublicKeyCredential}} [=interface object=]'s {{Credential/[[type]]}} [=internal slot=]'s value is the string
         "`public-key`".

--- a/index.bs
+++ b/index.bs
@@ -1459,6 +1459,10 @@ that are returned to the caller when a new credential is created, or a new asser
         steps to encode any {{ArrayBuffer}} values to {{DOMString}} values using [=base64url encoding=] to ensure compatibility
         with JSON syntax. {{ArrayBuffer}} values to be encoded are identified according to the detected type of the instance's
         `response` property.
+    ::  |clientExtensionResults| below should be the output of {{PublicKeyCredential/getClientExtensionResults()}}, with any
+        {{ArrayBuffer}} values encoded to {{DOMString}} values using [=base64url encoding=]. This may include {{ArrayBuffer}}
+        values from extensions registered in the IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]]
+        but not defined in [[#sctn-extensions]].
 </dl>
 
 <xmp class="idl">
@@ -1470,6 +1474,7 @@ that are returned to the caller when a new credential is created, or a new asser
         Base64URLString rawId;
         AuthenticatorAttestationResponseJSON response;
         DOMString?  authenticatorAttachment;
+        AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
         DOMString type;
     };
 
@@ -1484,6 +1489,7 @@ that are returned to the caller when a new credential is created, or a new asser
         Base64URLString rawId;
         AuthenticatorAssertionResponseJSON response;
         DOMString?  authenticatorAttachment;
+        AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
         DOMString type;
     };
 
@@ -1492,6 +1498,9 @@ that are returned to the caller when a new credential is created, or a new asser
         Base64URLString authenticatorData;
         Base64URLString signature;
         Base64URLString? userHandle;
+    };
+
+    dictionary AuthenticationExtensionsClientOutputsJSON {
     };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -1469,18 +1469,21 @@ that are returned to the caller when a new credential is created, or a new asser
         Base64URLString id;
         Base64URLString rawId;
         AuthenticatorAttestationResponseJSON response;
+        DOMString?  authenticatorAttachment;
         DOMString type;
     };
 
     dictionary AuthenticatorAttestationResponseJSON {
         Base64URLString clientDataJSON;
         Base64URLString attestationObject;
+        sequence<DOMString> transports;
     };
 
     dictionary AuthenticationResponseJSON {
         Base64URLString id;
         Base64URLString rawId;
         AuthenticatorAssertionResponseJSON response;
+        DOMString?  authenticatorAttachment;
         DOMString type;
     };
 


### PR DESCRIPTION
This PR introduces new methods to `PublicKeyCredential` that lean on the client to assist with JSON deserialization of `PublicKeyCredentialCreationOptions` and `PublicKeyCredentialRequestOptions`, and JSON serialization of `PublicKeyCredential` output from `navigator.credentials.create()` and `navigator.credentials.get()`.

See Issue #1683 for more context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1703.html" title="Last updated on Jun 20, 2022, 7:49 PM UTC (12e5071)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1703/dcd3190...12e5071.html" title="Last updated on Jun 20, 2022, 7:49 PM UTC (12e5071)">Diff</a>