### PR TITLE
Remove Generic Passthrough

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5409,50 +5409,14 @@ ignored by the client browser or OS and not passed to the authenticator at all, 
 Ignoring an extension is never considered a failure in WebAuthn API processing, so when [=[RPS]=] include extensions with any
 API calls, they MUST be prepared to handle cases where some or all of those extensions are ignored.
 
-Clients wishing to support the widest possible range of extensions MAY choose to pass through any extensions that they do not
-recognize to authenticators, generating the [=authenticator extension input=] by simply encoding the [=client extension input=]
-in CBOR. All [=WebAuthn Extensions=] MUST be defined in such a way that this implementation choice does not endanger the user's
+All [=WebAuthn Extensions=] MUST be defined in such a way that this implementation choice does not endanger the user's
 security or privacy. For instance, if an extension requires client processing, it could be defined in a manner that ensures such
 a naïve pass-through will produce a semantically invalid [=authenticator extension input=] value, resulting in the extension
 being ignored by the authenticator. Since all extensions are OPTIONAL, this will not cause a functional failure in the API
-operation. Likewise, clients can choose to produce a [=client extension output=] value for an extension that it does not
-understand by encoding the [=authenticator extension output=] value into JSON, provided that the CBOR output uses only types
-present in JSON.
-
-When [=clients=] choose to pass through extensions they do not recognize,
-the JavaScript values in the [=client extension inputs=]
-are converted to [=CBOR=] values in the [=authenticator extension inputs=].
-When the JavaScript value is an [=%ArrayBuffer%=], it is converted to a [=CBOR=] byte array.
-When the JavaScript value is a non-integer number, it is converted to a 64-bit CBOR floating point number.
-Otherwise, when the JavaScript type corresponds to a JSON type, the conversion is done
-using the rules defined in Section 6.2 of [[!RFC8949]] (Converting from JSON to CBOR),
-but operating on inputs of JavaScript type values rather than inputs of JSON type values.
-Once these conversions are done,
-canonicalization of the resulting [=CBOR=] MUST be performed using the [=CTAP2 canonical CBOR encoding form=].
-
-Note that the JavaScript numeric conversion rules have the consequence that
-when a client passes through an extension it does not recognize,
-if the extension uses floating point values,
-[=authenticators=] need to be prepared to receive those values as [=CBOR=] integers,
-should the [=authenticator=] want the extension to always work without actual [=client=] support for it.
-This will happen when the floating point values used happen to be integers.
-
-Likewise, when clients receive outputs from extensions they have passed through that they do not recognize,
-the [=CBOR=] values in the [=authenticator extension outputs=]
-are converted to JavaScript values in the [=client extension outputs=].
-When the CBOR value is a byte string, it is converted to a JavaScript [=%ArrayBuffer%=]
-(rather than a base64url-encoded string).
-Otherwise, when the CBOR type corresponds to a JSON type, the conversion is done
-using the rules defined in Section 6.1 of [[!RFC8949]] (Converting from CBOR to JSON),
-but producing outputs of JavaScript type values rather than outputs of JSON type values.
-
-Note that some clients may choose to implement this pass-through capability under a feature flag.
-Supporting this capability can facilitate innovation, allowing authenticators to experiment with new extensions
-and [=[RPS]=] to use them before there is explicit support for them in clients.
+operation.
 
 The IANA "WebAuthn Extension Identifiers" registry [[!IANA-WebAuthn-Registries]] established by [[!RFC8809]] can be consulted
 for an up-to-date list of registered [=WebAuthn Extensions=].
-
 
 ## Extension Identifiers ## {#sctn-extension-id}
 


### PR DESCRIPTION
This is to address #1730. As discussed in the working group meeting, platforms do not currently support generic extension passthroughs there are no plans by platforms to support it, nor interest in retaining it. This will remove the generic passthrough processing provisioning from L3.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1737.html" title="Last updated on Jun 1, 2022, 6:57 PM UTC (f1f8b5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1737/0678b0d...f1f8b5a.html" title="Last updated on Jun 1, 2022, 6:57 PM UTC (f1f8b5a)">Diff</a>