### PR TITLE
DRAFT: Backup eligibility parameter during registration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2769,6 +2769,7 @@ attributes.
         DOMString                    residentKey;
         boolean                      requireResidentKey = false;
         DOMString                    userVerification = "preferred";
+        DOMString                    backupEligible = "any";
     };
 </xmp>
 
@@ -2798,6 +2799,12 @@ attributes.
         The value SHOULD be a member of {{UserVerificationRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=].
 
         See {{UserVerificationRequirement}} for the description of {{AuthenticatorSelectionCriteria/userVerification}}'s values and semantics.
+
+    :   <dfn>backupEligible</dfn>
+    ::  Specifies the extent to which the [=[RP]=] desires to create a [=backup eligible=] [=credential=].
+        The value SHOULD be a member of {{BackupEligibilityRequirement}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=map/exist|member does not exist=].
+
+        See {{BackupEligibilityRequirement}} for the description of {{AuthenticatorSelectionCriteria/backupEligible}}'s values and semantics.
 </div>
 
 
@@ -3411,6 +3418,63 @@ Note: The {{UserVerificationRequirement}} enumeration is deliberately not refere
     :   <dfn>discouraged</dfn>
     ::  The [=[RP]=] does not want [=user verification=] employed during the operation (e.g., in the
         interest of minimizing disruption to the user interaction flow).
+</div>
+
+
+### Backup Eligibility Requirement Enumeration (enum <dfn enum>BackupEligibilityRequirement</dfn>) ### {#enum-backupEligibilityRequirement}
+
+<xmp class="idl">
+    enum BackupEligibilityRequirement {
+        "forbidden",
+        "discouraged",
+        "any",
+        "preferred",
+        "required"
+    };
+</xmp>
+
+A [=[WRP]=] may desire for [=credentials=] to be [=backup eligible=] or not,
+and may use this type to express its preference during [=registration=].
+
+Note: The {{BackupEligibilityRequirement}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+
+<div dfn-type="enum-value" dfn-for="BackupEligibilityRequirement">
+    :   <dfn>forbidden</dfn>
+    ::  The [=[RP]=] wants to create a [=single-device credential=] and intends to reject the registration
+        if a [=multi-device credential=] is created.
+
+        The [=client=] SHOULD guide the user to create a [=single-device credential=] if possible.
+        The [=client=] MAY allow the user to create a [=multi-device credential=] anyway,
+        but SHOULD warn the user that it is unlikely to be accepted by the [=[RP]=].
+
+    :   <dfn>discouraged</dfn>
+    ::  The [=[RP]=] prefers to create a [=single-device credential=] but intends to accept the registration
+        even if a [=multi-device credential=] is created.
+
+        The [=client=] SHOULD guide the user to create a [=single-device credential=] if possible.
+        The [=client=] MAY allow the user to create a [=multi-device credential=] anyway,
+        and MAY warn the user that it might not be accepted by the [=[RP]=].
+
+    :   <dfn>any</dfn>
+    ::  The [=[RP]=] has no preference and intends to accept either a [=single-device credential=] or a [=multi-device credential=].
+
+        The [=client=] and [=authenticator=] MAY create either a [=single-device credential=] or a [=multi-device credential=].
+
+    :   <dfn>preferred</dfn>
+    ::  The [=[RP]=] prefers to create a [=multi-device credential=] but intends to accept the registration
+        even if a [=single-device credential=] is created.
+
+        The [=client=] SHOULD guide the user to create a [=multi-device credential=] if possible.
+        The [=client=] MAY allow the user to create a [=single-device credential=] anyway,
+        and MAY warn the user that it might not be accepted by the [=[RP]=].
+
+    :   <dfn>required</dfn>
+    ::  The [=[RP]=] wants to create a [=multi-device credential=] and intends to reject the registration
+        if a [=single-device credential=] is created.
+
+        The [=client=] SHOULD guide the user to create a [=multi-device credential=] if possible.
+        The [=client=] MAY allow the user to create a [=single-device credential=] anyway,
+        but SHOULD warn the user that it is unlikely to be accepted by the [=[RP]=].
 </div>
 
 


### PR DESCRIPTION
Brainstorm idea for #1739. This is meant to facilitate discussion, not a fully-formed proposal.

Something like this would enable the client to optimize the user interaction to increase the chance that the registration completes successfully. I note in https://github.com/w3c/webauthn/issues/1714#issuecomment-1084473966 that since we now have the `BS` and `BE` flags in the authenticator data, that to me signals that this is a significant credential property that there should perhaps be a feature toggle for.

However the argument against (again, see https://github.com/w3c/webauthn/issues/1714#issuecomment-1084473966) is that we don't want RPs to see this as a "make it more secure" parameter and just set it to `"forbidden"` without further consideration. So in order to respect the interests of the user, this proposal allows the client to let the user override the RP's preference if desired.

Perhaps something like this could be a reasonable middle-ground? Is the risk of ecosystem fragmentation still too great? Is it not powerful enough to be useful to RPs? Discuss!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1744.html" title="Last updated on Jun 9, 2022, 9:58 PM UTC (f6db880)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1744/9622388...f6db880.html" title="Last updated on Jun 9, 2022, 9:58 PM UTC (f6db880)">Diff</a>