### PR TITLE
Add "hybrid" as a transport.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3358,7 +3358,7 @@ Note: The {{AuthenticatorTransport}} enumeration is deliberately not referenced,
     ::  Indicates the respective [=authenticator=] can be contacted over Bluetooth Smart (Bluetooth Low Energy / BLE).
 
     :   <dfn>hybrid</dfn>
-    ::  Indicates the respective [=authenticator=] can be contacted over the Hybrid transport that combines (often separate) data-transport and proximity mechanisms. This is most commonly used to communicate with phones.
+    ::  Indicates the respective [=authenticator=] can be contacted using a combination of (often separate) data-transport and proximity mechanisms. This supports, for example, authentication on a desktop computer using a smartphone.
 
     :   <dfn>internal</dfn>
     ::  Indicates the respective [=authenticator=] is contacted using a [=client device=]-specific transport,

--- a/index.bs
+++ b/index.bs
@@ -3334,6 +3334,7 @@ It mirrors some fields of the {{PublicKeyCredential}} object returned by
         "usb",
         "nfc",
         "ble",
+        "hybrid",
         "internal"
     };
 </xmp>
@@ -3355,6 +3356,9 @@ Note: The {{AuthenticatorTransport}} enumeration is deliberately not referenced,
 
     :   <dfn>ble</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over Bluetooth Smart (Bluetooth Low Energy / BLE).
+
+    :   <dfn>hybrid</dfn>
+    ::  Indicates the respective [=authenticator=] can be contacted over the Hybrid transport that combines (often separate) data-transport and proximity mechanisms. This is most commonly used to communicate with phones.
 
     :   <dfn>internal</dfn>
     ::  Indicates the respective [=authenticator=] is contacted using a [=client device=]-specific transport,


### PR DESCRIPTION
FIDO has chosen the name Hybrid for the transport formerly known as
caBLE. This change adds it as a known transport in WebAuthn. Since the
`AuthenticatorTransport` enum is illustrative and not actually
referenced anywhere in the IDL, this is technically a non-normative
change. Also, RPs only store and regurgitate these strings so no change
in RP processing is needed. Still, it's useful to have these strings
documented.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1755.html" title="Last updated on Jul 14, 2022, 10:52 PM UTC (aaf8ebc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1755/9622388...aaf8ebc.html" title="Last updated on Jul 14, 2022, 10:52 PM UTC (aaf8ebc)">Diff</a>