### PR TITLE
Clarify why PII is not allowed in user handle

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7519,7 +7519,9 @@ only to the operating system user that created that [=platform credential=].
 
 ### User Handle Contents ### {#sctn-user-handle-privacy}
 
-Since the [=user handle=] is not considered [PII] in [[#sctn-pii-privacy]], the [=[RP]=] MUST NOT include [PII], e.g., e-mail
+Since the [=user handle=] is not considered [PII] in [[#sctn-pii-privacy]],
+and since [=authenticators=] MAY reveal [=user handles=] without first performing [=user verification=],
+the [=[RP]=] MUST NOT include [PII], e.g., e-mail
 addresses or usernames, in the [=user handle=]. This includes hash values of [PII], unless the hash
 function is [=salted=] with [=salt=] values private to the [=[RP]=], since hashing does not prevent probing for guessable input
 values. It is RECOMMENDED to let the [=user handle=] be 64 random bytes, and store this value in the [=user account=].


### PR DESCRIPTION
The connection between [§14.6.1. User Handle Contents](https://w3c.github.io/webauthn/#sctn-user-handle-privacy) and [§14.4.2. Privacy of personally identifying information Stored in Authenticators](https://w3c.github.io/webauthn/#sctn-pii-privacy) is not entirely clear.

Fixes #1763.