### PR TITLE
Fix dangling language in WebAuthn Extensions section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5870,9 +5870,11 @@ ignored by the client browser or OS and not passed to the authenticator at all, 
 Ignoring an extension is never considered a failure in WebAuthn API processing, so when [=[RPS]=] include extensions with any
 API calls, they MUST be prepared to handle cases where some or all of those extensions are ignored.
 
-All [=WebAuthn Extensions=] MUST be defined in such a way that this implementation choice does not endanger the user's
-security or privacy. For instance, if an extension requires client processing, it could be defined in a manner that ensures such
-a naïve pass-through will produce a semantically invalid [=authenticator extension input=] value, resulting in the extension
+All [=WebAuthn Extensions=] MUST be defined in such a way that lack of support for them by the [=client=] or [=authenticator=]
+does not endanger the user's security or privacy.
+For instance, if an extension requires client processing, it could be defined in a manner that ensures
+that a naïve pass-through that simply transcodes [=client extension inputs=] from JSON to CBOR
+will produce a semantically invalid [=authenticator extension input=] value, resulting in the extension
 being ignored by the authenticator. Since all extensions are OPTIONAL, this will not cause a functional failure in the API
 operation.
 


### PR DESCRIPTION
This fixes an [outstanding review comment](https://github.com/w3c/webauthn/pull/1737#discussion_r891370788) from PR #1737.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1768.html" title="Last updated on Jul 11, 2022, 1:09 PM UTC (a6cc726)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1768/3f86ce7...a6cc726.html" title="Last updated on Jul 11, 2022, 1:09 PM UTC (a6cc726)">Diff</a>