### PR TITLE
Disambiguate autolink references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1183,7 +1183,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
         :   <dfn>otherUI</dfn>
         ::  OPTIONAL other information used by the [=authenticator=] to inform its UI. For example, this might include the user's
-            {{displayName}}. [=public key credential source/otherUI=] is a <dfn>mutable item</dfn> and SHOULD NOT be bound to the
+            {{PublicKeyCredentialUserEntity/displayName}}. [=public key credential source/otherUI=] is a <dfn>mutable item</dfn> and SHOULD NOT be bound to the
             [=public key credential source=] in a way that prevents [=public key credential source/otherUI=] from being updated.
     </dl>
 
@@ -1892,12 +1892,12 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
             1. [=list/For each=] credential descriptor |C| in <code>|options|.{{PublicKeyCredentialCreationOptions/excludeCredentials}}</code>:
-                1. If <code>|C|.{{transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
-                    mentioned in <code>|C|.{{transports}}</code>, the client MAY [=continue=].
+                1. If <code>|C|.{{PublicKeyCredentialDescriptor/transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
+                    mentioned in <code>|C|.{{PublicKeyCredentialDescriptor/transports}}</code>, the client MAY [=continue=].
 
                     Note: If the client chooses to [=continue=], this could result in
                     inadvertently registering multiple credentials [=bound credential|bound to=] the same [=authenticator=]
-                    if the transport hints in <code>|C|.{{transports}}</code> are not accurate.
+                    if the transport hints in <code>|C|.{{PublicKeyCredentialDescriptor/transports}}</code> are not accurate.
                     For example, stored transport hints could become inaccurate
                     as a result of software upgrades adding new connectivity options.
 
@@ -2284,7 +2284,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             and no |authenticator| will become available for any [=public key credentials=] therein,
         ::  Indicate to the user that no eligible credential could be found. When the user acknowledges the dialog, throw a "{{NotAllowedError}}" {{DOMException}}.
 
-            Note: One way a [=client platform=] can determine that no |authenticator| will become available is by examining the <code>{{transports}}</code> members of the present <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>, if any. For example, if all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] list only <code>{{AuthenticatorTransport/internal}}</code>, but all [=platform authenticator|platform=] |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] may list <code>{{transports}}</code> that the [=client platform=] does not support.
+            Note: One way a [=client platform=] can determine that no |authenticator| will become available is by examining the <code>{{PublicKeyCredentialDescriptor/transports}}</code> members of the present <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>, if any. For example, if all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] list only <code>{{AuthenticatorTransport/internal}}</code>, but all [=platform authenticator|platform=] |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] may list <code>{{PublicKeyCredentialDescriptor/transports}}</code> that the [=client platform=] does not support.
 
         :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
@@ -2497,9 +2497,9 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
                     value (see [here](#authenticatorGetAssertion-return-values) in [[#sctn-op-get-assertion]] for more information).
 
                 1. [=list/For each=] credential descriptor |C| in |allowCredentialDescriptorList|,
-                    [=set/append=] each value, if any, of <code>|C|.{{transports}}</code> to |distinctTransports|.
+                    [=set/append=] each value, if any, of <code>|C|.{{PublicKeyCredentialDescriptor/transports}}</code> to |distinctTransports|.
 
-                    Note: This will aggregate only distinct values of {{transports}} (for this [=authenticator=]) in
+                    Note: This will aggregate only distinct values of {{PublicKeyCredentialDescriptor/transports}} (for this [=authenticator=]) in
                         |distinctTransports| due to the properties of [=ordered sets=].
 
                 1. If |distinctTransports|
@@ -2872,7 +2872,7 @@ optionally evidence of [=user consent=] to a specific transaction.
         {{PublicKeyCredentialUserEntity/id}} can be returned as the {{AuthenticatorAssertionResponse/userHandle}}
         in some future [=authentication ceremonies=],
         and is used to overwrite existing [=discoverable credentials=]
-        that have the same <code>{{rp}}.{{PublicKeyCredentialRpEntity/id}}</code> and <code>{{user}}.{{PublicKeyCredentialUserEntity/id}}</code>
+        that have the same <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> and <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code>
         on the same [=authenticator=].
         {{PublicKeyCredentialEntity/name}} and {{PublicKeyCredentialUserEntity/displayName}}
         MAY be used by the [=authenticator=] and [=client=] in future [=authentication ceremonies=]


### PR DESCRIPTION
Fixes #1769.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1770.html" title="Last updated on Jul 11, 2022, 1:29 PM UTC (e70c93f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1770/3f86ce7...e70c93f.html" title="Last updated on Jul 11, 2022, 1:29 PM UTC (e70c93f)">Diff</a>