### PR TITLE
Namespace authData dfns under authData/ and flags under authData/flags/

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1327,7 +1327,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     It MUST NOT contain personally identifying information, see [[#sctn-user-handle-privacy]].
 
 : <dfn id=concept-user-present>User Present</dfn>
-: <dfn>UP</dfn>
 :: Upon successful completion of a [=test of user presence|user presence test=], the user is said to be
     "[=user present|present=]".
 
@@ -1361,7 +1360,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [=User verification=] procedures MAY implement [=rate limiting=] as a protection against brute force attacks.
 
 : <dfn id=concept-user-verified>User Verified</dfn>
-: <dfn>UV</dfn>
 :: Upon successful completion of a [=user verification=] process, the user is said to be "[=user verified|verified=]".
 
 
@@ -3824,7 +3822,7 @@ laid out as shown in <a href="#table-authData">Table <span class="table-ref-foll
 
 
 <figure id="table-authData" class="table">
-    <table class="complex data longlastcol">
+    <table class="complex data longlastcol" dfn-for="authData">
         <tr>
             <th>Name</th>
             <th>Length (in bytes)</th>
@@ -3840,26 +3838,26 @@ laid out as shown in <a href="#table-authData">Table <span class="table-ref-foll
         <tr>
             <td><dfn>flags</dfn></td>
             <td>1</td>
-            <td>
+            <td dfn-for="authData/flags">
                 Flags (bit 0 is the least significant bit):
-                - Bit 0: [=User Present=] ([=UP=]) result.
+                - Bit 0: [=User Present=] (<dfn>UP</dfn>) result.
                     - `1` means the user is [=user present|present=].
                     - `0` means the user is not [=user present|present=].
                 - Bit 1: Reserved for future use (`RFU1`).
-                - Bit 2: [=User Verified=] ([=UV=]) result.
+                - Bit 2: [=User Verified=] (<dfn>UV</dfn>) result.
                     - `1` means the user is [=user verified|verified=].
                     - `0` means the user is not [=user verified|verified=].
-                - Bit 3: [=Backup Eligibility=] ([=BE=]).
+                - Bit 3: [=Backup Eligibility=] (<dfn>BE</dfn>).
                     - `1` means the [=public key credential source=] is allowed to be backed up.
                     - `0` means the [=public key credential source=] is not allowed to be backed up.
-                - Bit 4: [=Backup State=] ([=BS=]).
+                - Bit 4: [=Backup State=] (<dfn>BS</dfn>).
                     - `1` means the [=public key credential source=] is currently backed up.
                     - `0` means the [=public key credential source=] is not currently backed up.
                 - Bits 5: Reserved for future use (`RFU2`).
-                - Bit 6: [=Attested credential data=] included (`AT`).
+                - Bit 6: [=Attested credential data=] included (<dfn>AT</dfn>).
                     - Indicates whether the authenticator added [=attested credential data=].
-                - Bit 7: Extension data included (`ED`).
-                    - Indicates if the [=authenticator data=] has [=authDataExtensions|extensions=].
+                - Bit 7: Extension data included (<dfn>ED</dfn>).
+                    - Indicates if the [=authenticator data=] has [=authData/extensions=].
             </td>
         </tr>
         <tr>
@@ -3877,7 +3875,7 @@ laid out as shown in <a href="#table-authData">Table <span class="table-ref-foll
             </td>
         </tr>
         <tr>
-            <td><dfn lt="authDataExtensions">extensions</dfn></td>
+            <td><dfn>extensions</dfn></td>
             <td>variable (if present)</td>
             <td>
                 Extension-defined [=authenticator data=]. This is a [=CBOR=] [[!RFC8949]] map with [=extension identifiers=] as keys,
@@ -3901,19 +3899,19 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 
 - Hash [=RP ID=] using SHA-256 to generate the [=rpIdHash=].
 
-- The `UP` [=flag=] SHALL be set if and only if the authenticator performed a [=test of user presence=].
-    The `UV` [=flag=] SHALL be set if and only if the authenticator performed [=user verification=].
+- The [=UP=] [=flag=] SHALL be set if and only if the authenticator performed a [=test of user presence=].
+    The [=UV=] [=flag=] SHALL be set if and only if the authenticator performed [=user verification=].
     The `RFU` bits SHALL be set to zero.
 
     Note: If the authenticator performed both a [=test of user presence=] and [=user verification=],
     possibly combined in a single [=authorization gesture=],
-    then the authenticator will set both the `UP` [=flag=] and the `UV` [=flag=].
+    then the authenticator will set both the [=UP=] [=flag=] and the [=UV=] [=flag=].
 
-- For [=attestation signatures=], the authenticator MUST set the AT [=flag=] and include the <code>[=attestedCredentialData=]</code>.
-    For [=assertion signatures=], the AT [=flag=] MUST NOT be set and the <code>[=attestedCredentialData=]</code> MUST NOT be included.
+- For [=attestation signatures=], the authenticator MUST set the [=AT=] [=flag=] and include the <code>[=attestedCredentialData=]</code>.
+    For [=assertion signatures=], the [=AT=] [=flag=] MUST NOT be set and the <code>[=attestedCredentialData=]</code> MUST NOT be included.
 
-- If the authenticator does not include any [=authDataExtensions|extension data=], it MUST set the `ED` [=flag=] to zero, and to one if
-    [=authDataExtensions|extension data=] is included.
+- If the authenticator does not include any [=authData/extensions|extension data=], it MUST set the [=authData/flags/ED=] [=flag=] to zero, and to one if
+    [=authData/extensions|extension data=] is included.
 
 <a href="#fig-authData">Figure <span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
 
@@ -3923,8 +3921,8 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 </figure>
 
 <div class="note">
-    Note: [=authenticator data=] describes its own length: If the AT and ED [=flags=] are not set, it is always 37 bytes long.
-    The [=attested credential data=] (which is only present if the AT [=flag=] is set) describes its own length. If the ED [=flag=] is set, then the total length is 37 bytes plus the length of the [=attested credential data=] (if the AT [=flag=] is set), plus the length of the [=authDataExtensions|extensions=] output (a [=CBOR=] map) that
+    Note: [=authenticator data=] describes its own length: If the [=AT=] and [=authData/flags/ED=] [=flags=] are not set, it is always 37 bytes long.
+    The [=attested credential data=] (which is only present if the [=AT=] [=flag=] is set) describes its own length. If the [=authData/flags/ED=] [=flag=] is set, then the total length is 37 bytes plus the length of the [=attested credential data=] (if the [=AT=] [=flag=] is set), plus the length of the [=authData/extensions=] output (a [=CBOR=] map) that
     follows.
 
     Determining [=attested credential data=]'s length, which is variable, involves determining <code>[=credentialPublicKey=]</code>'s beginning location given the preceding <code>[=credentialid|credentialId=]</code>'s [=credentialidlength|length=], and then determining the <code>[=credentialPublicKey=]</code>'s length (see also [=Section 7=] of [[!RFC8152]]).
@@ -3944,7 +3942,7 @@ leave the <code>[=signCount=]</code> in the [=authenticator data=] constant at z
 
 A [=[RP]=] stores the [=signature counter=] of the most recent [=authenticatorGetAssertion=] operation. (Or the counter from the [=authenticatorMakeCredential=] operation if no [=authenticatorGetAssertion=] has ever been performed on a credential.) In subsequent
 [=authenticatorGetAssertion=] operations, the [=[RP]=] compares the stored [=signature counter=] value with the new
-<code>[=signCount=]</code> value returned in the assertion's [=authenticator data=].  If either is non-zero, and the new <code>[=signCount=]</code> value is less than or equal to the stored value, a cloned authenticator may exist, or the authenticator may be malfunctioning.
+<code>[=signCount=]</code> value returned in the assertion's [=authenticator data=]. If either is non-zero, and the new <code>[=signCount=]</code> value is less than or equal to the stored value, a cloned authenticator may exist, or the authenticator may be malfunctioning.
 
 Detecting a [=signature counter=] mismatch does not indicate whether the current operation was performed by a cloned authenticator or the original authenticator.  [=[RPS]=] should address this situation appropriately relative to their individual situations, i.e., their risk tolerance.
 
@@ -3968,24 +3966,24 @@ This is because the first 37 bytes of the signed data in a FIDO U2F authenticati
 [=authenticator data=] structure, and the remaining 32 bytes are the [=hash of the serialized client data=]. In this
 [=authenticator data=] structure, the <code>[=rpIdHash=]</code> is the FIDO U2F [=application parameter=], all
 <code>[=flags=]</code> except <code>[=UP=]</code> are always zero, and the <code>[=attestedCredentialData=]</code> and
-<code>[=authDataExtensions|extensions=]</code> are never present. FIDO U2F authentication signatures can therefore be verified by
+<code>[=authData/extensions=]</code> are never present. FIDO U2F authentication signatures can therefore be verified by
 the same procedure as other [=assertion signatures=] generated by the [=authenticatorGetAssertion=] operation.
 
 ### Credential Backup State ### {#sctn-credential-backup}
 
-Credential [=backup eligibility=] and current [=backup state=] is conveyed by the `BE` and `BS` [=flags=] in the [=authenticator data=], as
+Credential [=backup eligibility=] and current [=backup state=] is conveyed by the [=BE=] and [=BS=] [=flags=] in the [=authenticator data=], as
 defined in <a href="#table-authData">Table <span class="table-ref-previous"/></a>.
 
-The value of the `BE` [=flag=] is set during [=authenticatorMakeCredential=] operation and MUST NOT change.
+The value of the [=BE=] [=flag=] is set during [=authenticatorMakeCredential=] operation and MUST NOT change.
 
-The value of the `BS` [=flag=] may change over time based on the current state of the [=public key credential source=]. <a href="#table-backupStates">Table <span class="table-ref-following"/></a> below defines
+The value of the [=BS=] [=flag=] may change over time based on the current state of the [=public key credential source=]. <a href="#table-backupStates">Table <span class="table-ref-following"/></a> below defines
 valid combinations and their meaning.
 
 <figure id="table-backupStates" class="table">
     <table class="complex data longlastcol">
             <tr>
-            <th>`BE`</th>
-            <th>`BS`</th>
+            <th>[=BE=]</th>
+            <th>[=BS=]</th>
             <th>Description</th>
         </tr>
         <tr>
@@ -4018,7 +4016,7 @@ valid combinations and their meaning.
         </tr>
     </table>
     <figcaption>
-        `BE` and `BS` [=flag=] combinations
+        [=BE=] and [=BS=] [=flag=] combinations
     </figcaption>
 </figure>
 
@@ -4028,7 +4026,7 @@ The following is a non-normative, non-exhaustive list of how [=[RPS]=] might use
 
     - Requiring additional [=authenticators=]:
 
-        When `BE` [=flag=] is set to `0`, the credential is a [=single-device credential=] and the [=generating authenticator=] will never
+        When the [=BE=] [=flag=] is set to `0`, the credential is a [=single-device credential=] and the [=generating authenticator=] will never
         allow the credential to be backed up.
 
         A [=single-device credential=] is not resilient to single device loss. [=[RPS]=] SHOULD ensure that a [=user account=]
@@ -4039,13 +4037,13 @@ The following is a non-normative, non-exhaustive list of how [=[RPS]=] might use
 
     - Upgrading a user to a password-free account:
 
-        When the `BS` [=flag=] changes from `0` to `1`, the [=authenticator=] is signaling that the [=credential=] is backed up and is protected from single device loss.
+        When the [=BS=] [=flag=] changes from `0` to `1`, the [=authenticator=] is signaling that the [=credential=] is backed up and is protected from single device loss.
 
         A [=[RP]=] may decide to prompt the user to upgrade their account security and remove their password.
 
     - Adding an additional factor after a state change:
 
-        When the `BS` [=flag=] changes from `1` to `0`, the [=authenticator=] is signaling that the [=credential=] is no longer backed up,
+        When the [=BS=] [=flag=] changes from `1` to `0`, the [=authenticator=] is signaling that the [=credential=] is no longer backed up,
         and no longer protected from single device loss. This could be the result of the user actions, such as disabling the backup service,
         or errors, such as issues with the backup service.
 
@@ -4246,7 +4244,7 @@ could support several modes of [=user verification=], meaning it could act as al
 
 Although [=user verification=] is performed locally on the [=authenticator=] and not by the [=[RP]=], the [=authenticator=]
 indicates if [=user verification=] was performed by setting the [=UV=] [=flag=] in the signed response returned to the [=[RP]=].
-The [=[RP]=] can therefore use the [=UV=] flag to verify that additional [=authentication factors=] were used in a
+The [=[RP]=] can therefore use the [=UV=] [=flag=] to verify that additional [=authentication factors=] were used in a
 [=registration=] or [=authentication ceremony=]. The authenticity of the [=UV=] [=flag=] can in turn be assessed by inspecting the
 [=authenticator=]'s [=attestation statement=].
 
@@ -4414,7 +4412,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 1. Let |attestedCredentialData| be the [=attested credential data=] byte array including the |credentialId| and |publicKey|.
 1. Let |authenticatorData| [=perform the following steps to generate an authenticator data structure|be the byte array=] specified in [[#sctn-authenticator-data]], including |attestedCredentialData| as the
     <code>[=attestedCredentialData=]</code> and |processedExtensions|, if any, as the
-    <code>[=authDataExtensions|extensions=]</code>.
+    <code>[=authData/extensions=]</code>.
 1. Create an [=attestation object=] for the new credential using the procedure specified in
     [[#sctn-generating-an-attestation-object]], using an authenticator-chosen [=attestation statement format=], |authenticatorData|,
     and |hash|, as well as {{enterprise|taking into account}} the value of |enterpriseAttestationPossible|. For more details on attestation, see [[#sctn-attestation]].
@@ -4482,7 +4480,7 @@ When this method is invoked, the [=authenticator=] MUST perform the following pr
     zero.
 1. Let |authenticatorData| [=perform the following steps to generate an authenticator data structure|be the byte array=]
     specified in [[#sctn-authenticator-data]] including |processedExtensions|, if any, as
-    the <code>[=authDataExtensions|extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.
+    the <code>[=authData/extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>.
 1. Let |signature| be the [=assertion signature=] of the concatenation <code>|authenticatorData| || |hash|</code> using the
     [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature">Figure <span class="figure-num-following"/></a>, below. A simple,
     undelimited
@@ -4694,7 +4692,7 @@ understand the characteristics of the [=authenticators=] that they trust, based 
 object=] for a given credential. Its format is shown in <a href="#table-attestedCredentialData">Table <span class="table-ref-following"/></a>.
 
 <figure id="table-attestedCredentialData" class="table">
-    <table class="complex data longlastcol">
+    <table class="complex data longlastcol" dfn-for="authData/attestedCredentialData">
         <tr>
             <th>Name</th>
             <th>Length (in bytes)</th>
@@ -5019,15 +5017,15 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 
 1. Verify that the <code>[=rpIdHash=]</code> in |authData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
 
-1. Verify that the [=User Present=] bit of the <code>[=flags=]</code> in |authData| is set.
+1. Verify that the [=UP=] bit of the <code>[=flags=]</code> in |authData| is set.
 
 1. If the [=[RP]=] requires [=user verification=] for this registration,
-    verify that the [=User Verified=] bit of the <code>[=flags=]</code> in |authData| is set.
+    verify that the [=UV=] bit of the <code>[=flags=]</code> in |authData| is set.
 
 1. If the [=[RP]=] uses the credential's [=backup eligibility=] to inform its user experience flows and/or policies, evaluate the
-    [=backup eligibility=] (BE) bit of the <code>[=flags=]</code> in |authData|.
+    [=BE=] bit of the <code>[=flags=]</code> in |authData|.
 
-1. If the [=[RP]=] uses the credential's [=backup state=] to inform its user experience flows and/or policies, evaluate the [=backup state=] (BS)
+1. If the [=[RP]=] uses the credential's [=backup state=] to inform its user experience flows and/or policies, evaluate the [=BS=]
     bit of the <code>[=flags=]</code> in |authData|, and then store the value for evaluation in future [=authentication ceremonies=].
 
 1. Verify that the "alg" parameter in the [=credentialPublicKey|credential public key=] in |authData|
@@ -5035,7 +5033,7 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
     <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>.
 
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
-    outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
+    outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
     extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
     and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
     <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
@@ -5192,16 +5190,16 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
       Note: If using the [=appid=] extension, this step needs some special logic. See [[#sctn-appid-extension]] for details.
     </li>
 
-1. Verify that the [=User Present=] bit of the <code>[=flags=]</code> in |authData| is set.
+1. Verify that the [=UP=] bit of the <code>[=flags=]</code> in |authData| is set.
 
 1. If the [=[RP]=] requires [=user verification=] for this assertion,
-    verify that the [=User Verified=] bit of the <code>[=flags=]</code> in |authData| is set.
+    verify that the [=UV=] bit of the <code>[=flags=]</code> in |authData| is set.
 
 1. If the credential [=backup state=] is used as part of [=[RP]=] business logic or policy, compare the previously stored
-    value with the [=backup state=] (BS) bit of the <code>[=flags=]</code> in |authData|, perform evaluation, and then store the new value.
+    value with the [=BS=] bit of the <code>[=flags=]</code> in |authData|, perform evaluation, and then store the new value.
 
 1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
-    outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
+    outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
     extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
     and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
     <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
@@ -6010,8 +6008,8 @@ parameter of the [=authenticatorMakeCredential=] and [=authenticatorGetAssertion
 [=CBOR=] map where each key is an [=extension identifier=] and the corresponding value is the [=authenticator extension input=]
 for that extension.
 
-Likewise, the extension output is represented in the [=authdataextensions|extensions=] part of the [=authenticator data=]. The
-[=authdataextensions|extensions=] part of the [=authenticator data=] is a CBOR map where each key is an [=extension identifier=]
+Likewise, the extension output is represented in the [=authData/extensions=] part of the [=authenticator data=]. The
+[=authData/extensions=] part of the [=authenticator data=] is a CBOR map where each key is an [=extension identifier=]
 and the corresponding value is the <dfn>authenticator extension output</dfn> for that extension.
 
 For each supported extension, the [=authenticator extension processing=] rule for that extension is used create the


### PR DESCRIPTION
This is a step towards resolving #1740 and #1510, but I think it's substantive enough to warrant review on its own. This is a prerequisite of PR #1772, PR #1773 and PR #1774.

This repurposes the definitions of the **UP** and **UV** terms from referring to the abstract procedure to the corresponding authenticator data flags instead, because we were already using the terms only to refer to the flags. Also added are formal definitions for the other authData flags. These definitions along with those for other authData components are also moved into the `authData/` namespace for better consistency with properties of other interfaces and dictionaries.

This will break some link anchors:

| Anchor before | Anchor after
| ------------- | ------------
| [`#rpidhash`](https://w3c.github.io/webauthn/#rpidhash) | `#authdata-rpidhash`
| [`#flags`](https://w3c.github.io/webauthn/#flags) | `#authdata-flags`
| [`#signcount`](https://w3c.github.io/webauthn/#signcount) | `#authdata-signcount`
| [`#attestedcredentialdata`](https://w3c.github.io/webauthn/#attestedcredentialdata) | `#authdata-attestedcredentialdata`
| [`#authdataextensions`](https://w3c.github.io/webauthn/#authdataextensions) | `#authdata-extensions`
| [`#up`](https://w3c.github.io/webauthn/#up) | [`#authdata-flags-up`](https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1771.html#authdata-flags-up)
| [`#uv`](https://w3c.github.io/webauthn/#uv) | [`#authdata-flags-uv`](https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1771.html#authdata-flags-uv)
| [`#aaguid`](https://w3c.github.io/webauthn/#aaguid) | `#authdata-attestedcredentialdata-aaguid`
| [`#credentialidlength`](https://w3c.github.io/webauthn/#credentialidlength) | `#authdata-attestedcredentialdata-credentialidlength`
| [`#credentialid`](https://w3c.github.io/webauthn/#credentialid) | `#authdata-attestedcredentialdata-credentialid`
| [`#credentialpublickey`](https://w3c.github.io/webauthn/#credentialpublickey) | `#authdata-attestedcredentialdata-credentialpublickey`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1771.html" title="Last updated on Jul 11, 2022, 2:44 PM UTC (573b1c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1771/3f86ce7...573b1c2.html" title="Last updated on Jul 11, 2022, 2:44 PM UTC (573b1c2)">Diff</a>