### PR TITLE
Fix broken cross-spec references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -307,6 +307,7 @@ spec: BCP47; urlPrefix: https://tools.ietf.org/html/bcp47
 <pre class="link-defaults">
 spec:credential-management; type:dfn; text:credentials
 spec:html; type:dfn; for:environment settings object; text:global object
+spec:html; type:dfn; for:/; text:same site
 spec:infra; type:dfn; for:/; text:set
 spec:infra; type:dfn; text:list
 spec:infra; type:dfn; for:struct; text:item
@@ -891,11 +892,11 @@ below and in [[#index-defined-elsewhere]].
 :: [=%ArrayBuffer%=] is defined in [[!ECMAScript]].
 
 : HTML
-:: The concepts of [=browsing context=], [=origin=], [=opaque origin=], [=tuple origin=], [=relevant settings object=],
+:: The concepts of [=browsing context=], [=origin=], [=opaque origin=], [=tuple origin=], [=relevant settings object=], [=same site=]
     and [=is a registrable domain suffix of or is equal to=] are defined in [[!HTML]].
 
 : URL
-:: The concept of [=same site=] is defined in [[!URL]].
+:: The concepts of [=domain=], [=host=], [=port=], [=scheme=], [=valid domain=] and [=valid domain string=] are defined in [[!URL]].
 
 : Web IDL
 :: Many of the interface definitions and all of the IDL in this specification depend on [[!WebIDL]]. This updated version of

--- a/index.bs
+++ b/index.bs
@@ -269,18 +269,13 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
         text: WebDriver error code; url: dfn-error-code
         text: endpoint node; url: dfn-endpoint-node
         text: extension capability; url: dfn-extension-capability
-        text: extension command; url: dfn-extension-command
-        text: extension command name; url: dfn-extension-command-name
+        text: extension command; url: dfn-extension-commands
         text: getting a property; url: dfn-getting-properties
         text: set a property; url: dfn-set-a-property
-        text: prefix; url: dfn-url-prefix
         text: invalid argument; url: dfn-invalid-argument
-        text: local end; url: dfn-local-end
         text: matching capabilities; url: dfn-matching-capabilities
         text: remote end steps; url: dfn-remote-end-steps
-        text: session; url: dfn-session
         text: success; url: dfn-success
-        text: trying; url: dfn-try
         text: unsupported operation; url: dfn-unsupported-operation
         text: validating capabilities; url: dfn-validate-capabilities
 

--- a/index.bs
+++ b/index.bs
@@ -261,7 +261,7 @@ spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
 
 spec: webidl; urlPrefix: https://heycam.github.io/webidl
     type: dfn;
-        text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-reference
+        text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-copy
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn


### PR DESCRIPTION
Fixes most of #1794.

The Credential Management references aren't spelled out as explicit anchor handles, so I think those would be better fixed by updating Bikeshed somehow.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1796.html" title="Last updated on Sep 8, 2022, 1:26 PM UTC (d5deef9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1796/f754904...d5deef9.html" title="Last updated on Sep 8, 2022, 1:26 PM UTC (d5deef9)">Diff</a>