### PR TITLE
Fix incorrect use of options variable: rename to pkOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1648,15 +1648,15 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     Note: This "sameOriginWithAncestors" restriction aims to address a tracking concern raised in [Issue #1336](https://github.com/w3c/webauthn/issues/1336). This may be revised in future versions of this specification.
 
-1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
+1. Let |pkOptions| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
-1. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is present, check if its value lies within a
+1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/timeout}}</code> is present, check if its value lies within a
     reasonable range as defined by the [=client=] and if not, correct it to the closest value lying within that range. Set a timer
-    |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is not
+    |lifetimeTimer| to this adjusted value. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/timeout}}</code> is not
     present, then set |lifetimeTimer| to a [=client=]-specific default.
 
-        Recommended ranges and defaults for the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| are as follows.
-          If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
+        Recommended ranges and defaults for <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/timeout}}</code> are as follows.
+          If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
             <dl class="switch">
                 :   is set to {{UserVerificationRequirement/discouraged}}
                 ::  Recommended range: 30000 milliseconds to 180000 milliseconds.
@@ -1669,7 +1669,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
         Note: The user agent should take cognitive guidelines into considerations regarding timeout for users with special needs.
 
-1. If the length of <code>|options|.{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> is not between 1 and 64 bytes (inclusive) then throw a {{TypeError}}.
+1. If the length of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> is not between 1 and 64 bytes (inclusive) then throw a {{TypeError}}.
 
 1. Let |callerOrigin| be {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/origin}}. If |callerOrigin| is an [=opaque origin=], throw a "{{NotAllowedError}}" {{DOMException}}.
 
@@ -1688,29 +1688,29 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 -->
     <li id='CreateCred-DetermineRpId'>
 
-        If <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+        If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
             <dl class="switch">
 
                 :   is present
-                ::  If <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> [=is not a
+                ::  If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> [=is not a
                     registrable domain suffix of and is not equal to=] |effectiveDomain|, throw a "{{SecurityError}}" {{DOMException}}.
 
                 :   Is not present
-                ::  Set <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to
+                ::  Set <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to
                     |effectiveDomain|.
             </dl>
 
-        Note: <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> represents the
+        Note: <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> represents the
             caller's [=RP ID=]. The [=RP ID=] defaults to being the caller's [=environment settings object/origin=]'s
             [=effective domain=] unless the caller has explicitly set
-            <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> when calling
+            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> when calling
             {{CredentialsContainer/create()}}.
     </li>
 
 1. Let |credTypesAndPubKeyAlgs| be a new [=list=] whose [=list/items=] are pairs of {{PublicKeyCredentialType}} and
     a {{COSEAlgorithmIdentifier}}.
 
-1. If <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>'s [=list/size=]
+1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>'s [=list/size=]
     <dl class="switch">
         :   is zero
         ::  [=list/Append=] the following pairs of {{PublicKeyCredentialType}} and {{COSEAlgorithmIdentifier}} values to |credTypesAndPubKeyAlgs|:
@@ -1718,7 +1718,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
              * {{public-key}} and <code>-257</code> ("RS256").
 
         :   is non-zero
-        ::  [=list/For each=] |current| of <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
+        ::  [=list/For each=] |current| of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>:
 
             1. If <code>|current|.{{PublicKeyCredentialParameters/type}}</code> does not contain a {{PublicKeyCredentialType}} supported
                 by this implementation, then [=continue=].
@@ -1731,8 +1731,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
 
-1. If the {{PublicKeyCredentialCreationOptions/extensions}} member of |options| is present, then [=map/for each=]
-    |extensionId| → |clientExtensionInput| of <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>:
+1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/extensions}}</code> is present, then [=map/for each=]
+    |extensionId| → |clientExtensionInput| of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/extensions}}</code>:
     1. If |extensionId| is not supported by this [=client platform=] or is not a [=registration extension=], then [=continue=].
 
     1. [=map/Set=] |clientExtensions|[|extensionId|] to |clientExtensionInput|.
@@ -1748,7 +1748,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     : {{CollectedClientData/type}}
     :: The string "webauthn.create".
     : {{CollectedClientData/challenge}}
-    :: The [=base64url encoding=] of |options|.{{PublicKeyCredentialCreationOptions/challenge}}.
+    :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialCreationOptions/challenge}}.
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/crossOrigin}}
@@ -1795,12 +1795,12 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
             1. This |authenticator| is now the <dfn for="create">candidate authenticator</dfn>.
 
-            1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}</code> is present:
+            1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}</code> is present:
 
-                  1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/authenticatorAttachment}}</code> is
+                  1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/authenticatorAttachment}}</code> is
                     present and its value is not equal to |authenticator|'s [=authenticator attachment modality=], [=iteration/continue=].
 
-                  1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
+                  1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
 
                       <dl class="switch">
                           :   is present and set to {{ResidentKeyRequirement/required}}
@@ -1811,18 +1811,18 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                           ::  No effect.
 
                           :   is not present
-                          ::  if <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>
+                          ::  if <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>
                               is set to [TRUE] and the |authenticator| is not capable of storing a [=client-side discoverable public
                               key credential source=], [=iteration/continue=].
                       </dl>
 
-                  1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
+                  1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
                     set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
                     verification=], [=iteration/continue=].
 
             1. Let |requireResidentKey| be the <dfn>effective resident key requirement for credential creation</dfn>, a Boolean value, as follows:
 
-                If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
+                If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
 
                     <dl class="switch">
 
@@ -1844,13 +1844,13 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         ::  Let |requireResidentKey| be [FALSE].
 
                         :   is not present
-                        ::  Let |requireResidentKey| be the value of <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>.
+                        ::  Let |requireResidentKey| be the value of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>.
 
                     </dl>
 
             1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
                 as follows. If
-                <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
+                <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code>
 
                     <dl class="switch">
 
@@ -1874,12 +1874,12 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                     </dl>
 
             1. Let |enterpriseAttestationPossible| be a Boolean value, as follows. If
-                <code>|options|.{{PublicKeyCredentialCreationOptions/attestation}}</code>
+                <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/attestation}}</code>
 
                     <dl class="switch">
 
                         :   is set to {{AttestationConveyancePreference/enterprise}}
-                        ::  Let |enterpriseAttestationPossible| be [TRUE] if the user agent wishes to support enterprise attestation for <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> (see [Step 8](#CreateCred-DetermineRpId), above). Otherwise [FALSE].
+                        ::  Let |enterpriseAttestationPossible| be [TRUE] if the user agent wishes to support enterprise attestation for <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> (see [Step 8](#CreateCred-DetermineRpId), above). Otherwise [FALSE].
 
                         :   otherwise
                         ::  Let |enterpriseAttestationPossible| be [FALSE].
@@ -1888,7 +1888,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
             1. Let |excludeCredentialDescriptorList| be a new [=list=].
 
-            1. [=list/For each=] credential descriptor |C| in <code>|options|.{{PublicKeyCredentialCreationOptions/excludeCredentials}}</code>:
+            1. [=list/For each=] credential descriptor |C| in <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/excludeCredentials}}</code>:
                 1. If <code>|C|.{{PublicKeyCredentialDescriptor/transports}}</code> [=list/is not empty=], and |authenticator| is connected over a transport not
                     mentioned in <code>|C|.{{PublicKeyCredentialDescriptor/transports}}</code>, the client MAY [=continue=].
 
@@ -1908,8 +1908,8 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                         <!-- @@EDITOR-ANCHOR-01A: KEEP THIS LIST SYNC'D WITH THE LIST UP AT @@EDITOR-ANCHOR-01B -->
                         Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
                             |clientDataHash|,
-                            <code>|options|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
-                            <code>|options|.{{PublicKeyCredentialCreationOptions/user}}</code>,
+                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
+                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
                             |requireResidentKey|,
                             |userVerification|,
                             |credTypesAndPubKeyAlgs|,
@@ -1963,13 +1963,13 @@ a numbered step. If outdented, it (today) is rendered either as a bullet in the 
                 ::  whose value is the bytes of |clientDataJSON|.
 
                 :   <code><dfn for="credentialCreationData">attestationConveyancePreferenceOption</dfn></code>
-                ::  whose value is the value of |options|.{{PublicKeyCredentialCreationOptions/attestation}}.
+                ::  whose value is the value of |pkOptions|.{{PublicKeyCredentialCreationOptions/attestation}}.
 
                 :   <code><dfn for="credentialCreationData">clientExtensionResults</dfn></code>
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
+                    [=client extension=] in <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
 
             1.  Let |constructCredentialAlg| be an algorithm that takes a [=global object=]
                 |global|, and whose steps are:
@@ -2114,12 +2114,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialRequestOptions/publicKey}}</code> is present.
 
-1. Let |options| be the value of <code>|options|.{{CredentialRequestOptions/publicKey}}</code>.
+1. Let |pkOptions| be the value of <code>|options|.{{CredentialRequestOptions/publicKey}}</code>.
 
 1. If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is present with the value
     {{CredentialMediationRequirement/conditional}}:
 
-    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=],
+    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=],
         return a {{DOMException}} whose name is "{{NotSupportedError}}", and terminate this algorithm.
 
     1. Set a timer |lifetimeTimer| to a value of infinity.
@@ -2129,13 +2129,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Else:
 
-    1. If the {{PublicKeyCredentialRequestOptions/timeout}} member of |options| is present, check if its value lies
+    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/timeout}}</code> is present, check if its value lies
         within a reasonable range as defined by the [=client=] and if not, correct it to the closest value lying within that range.
-        Set a timer |lifetimeTimer| to this adjusted value. If the {{PublicKeyCredentialRequestOptions/timeout}} member of
-        |options| is not present, then set |lifetimeTimer| to a [=client=]-specific default.
+        Set a timer |lifetimeTimer| to this adjusted value. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/timeout}}</code>
+        is not present, then set |lifetimeTimer| to a [=client=]-specific default.
 
-            Recommended ranges and defaults for the {{PublicKeyCredentialRequestOptions/timeout}} member of |options| are as follows.
-              If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
+            Recommended ranges and defaults for <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/timeout}}</code> are as follows.
+              If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
                 <dl class="switch">
                     :   is set to {{UserVerificationRequirement/discouraged}}
                     ::  Recommended range: 30000 milliseconds to 180000 milliseconds.
@@ -2162,25 +2162,25 @@ When this method is invoked, the user agent MUST execute the following algorithm
         PKI-based security.
 
         <li id='GetAssn-DetermineRpId'>
-            If |options|.{{PublicKeyCredentialRequestOptions/rpId}} is not present, then set |rpId| to
+            If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> is not present, then set |rpId| to
                 |effectiveDomain|.
 
                 Otherwise:
 
-                1. If |options|.{{PublicKeyCredentialRequestOptions/rpId}} [=is not a registrable domain suffix of and is not
+                1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> [=is not a registrable domain suffix of and is not
                     equal to=] |effectiveDomain|, throw a "{{SecurityError}}" {{DOMException}}.
 
-                1. Set |rpId| to |options|.{{PublicKeyCredentialRequestOptions/rpId}}.
+                1. Set |rpId| to <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>.
 
                     Note: |rpId| represents the caller's [=RP ID=]. The [=RP ID=] defaults to being the caller's [=environment
                     settings object/origin=]'s [=effective domain=] unless the caller has explicitly set
-                    |options|.{{PublicKeyCredentialRequestOptions/rpId}} when calling {{CredentialsContainer/get()}}.
+                    <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> when calling {{CredentialsContainer/get()}}.
         </li>
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
 
-1. If the {{PublicKeyCredentialRequestOptions/extensions}} member of |options| is present, then [=map/for each=]
-    |extensionId| → |clientExtensionInput| of <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>:
+1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/extensions}}</code> is present, then [=map/for each=]
+    |extensionId| → |clientExtensionInput| of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/extensions}}</code>:
     1. If |extensionId| is not supported by this [=client platform=] or is not an [=authentication extension=], then [=continue=].
 
     1. [=map/Set=] |clientExtensions|[|extensionId|] to |clientExtensionInput|.
@@ -2196,7 +2196,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
     : {{CollectedClientData/type}}
     :: The string "webauthn.get".
     : {{CollectedClientData/challenge}}
-    :: The [=base64url encoding=] of |options|.{{PublicKeyCredentialRequestOptions/challenge}}
+    :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialRequestOptions/challenge}}
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/crossOrigin}}
@@ -2260,7 +2260,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                 1. If the user selects a |credentialMetadata|,
 
-                    1. Let |publicKeyOptions| be a temporary copy of |options|.{{CredentialRequestOptions/publicKey}}.
+                    1. Let |publicKeyOptions| be a temporary copy of |pkOptions|.
 
                     1. Let |authenticator| be the value of |silentlyDiscoveredCredentials|[|credentialMetadata|].
 
@@ -2277,11 +2277,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
                     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
         :   If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is not {{CredentialMediationRequirement/conditional}},
-            |issuedRequests| is empty, <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty,
+            |issuedRequests| is empty, <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty,
             and no |authenticator| will become available for any [=public key credentials=] therein,
         ::  Indicate to the user that no eligible credential could be found. When the user acknowledges the dialog, throw a "{{NotAllowedError}}" {{DOMException}}.
 
-            Note: One way a [=client platform=] can determine that no |authenticator| will become available is by examining the <code>{{PublicKeyCredentialDescriptor/transports}}</code> members of the present <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] of <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>, if any. For example, if all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] list only <code>{{AuthenticatorTransport/internal}}</code>, but all [=platform authenticator|platform=] |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] may list <code>{{PublicKeyCredentialDescriptor/transports}}</code> that the [=client platform=] does not support.
+            Note: One way a [=client platform=] can determine that no |authenticator| will become available is by examining the <code>{{PublicKeyCredentialDescriptor/transports}}</code> members of the present <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>, if any. For example, if all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] list only <code>{{AuthenticatorTransport/internal}}</code>, but all [=platform authenticator|platform=] |authenticator|s have been tried, then there is no possibility of satisfying the request. Alternatively, all <code>{{PublicKeyCredentialDescriptor}}</code> [=list/items=] may list <code>{{PublicKeyCredentialDescriptor/transports}}</code> that the [=client platform=] does not support.
 
         :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
@@ -2302,7 +2302,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Else:
 
                 1. Execute the [=issuing a credential request to an authenticator=] algorithm with |authenticator|, |savedCredentialIds|,
-                    |options|.{{CredentialRequestOptions/publicKey}}, |rpId|, |clientDataHash|, and |authenticatorExtensions|.
+                    |pkOptions|, |rpId|, |clientDataHash|, and |authenticatorExtensions|.
 
                     If this returns [FALSE], [=continue=].
 
@@ -2355,7 +2355,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 ::  whose value is an {{AuthenticationExtensionsClientOutputs}} object containing [=extension identifier=] →
                     [=client extension output=] entries. The entries are created by running each extension's
                     [=client extension processing=] algorithm to create the [=client extension outputs=], for each
-                    [=client extension=] in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
+                    [=client extension=] in <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
 
             1.  Let |constructAssertionAlg| be an algorithm that takes a [=global object=]
                 |global|, and whose steps are:
@@ -2424,7 +2424,7 @@ This algorithm accepts the following arguments:
     :   <dfn>savedCredentialIds</dfn>
     ::  A [=map=] containing [=authenticator=] → [=credential ID=]. This argument will be modified in this algorithm.
 
-    :   <dfn>options</dfn>
+    :   <dfn>pkOptions</dfn>
     ::  This argument is a {{PublicKeyCredentialRequestOptions}} object specifying the desired attributes of the
         [=public key credential=] to discover.
 
@@ -2444,12 +2444,12 @@ the request was issued successfully.
 
 The steps for [=issuing a credential request to an authenticator=] are as follows:
 
-    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code> is set to
+    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/userVerification}}</code> is set to
         {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user verification=],
         return [FALSE].
 
     1. Let |userVerification| be the <dfn>effective user verification requirement for assertion</dfn>, a Boolean value, as
-        follows. If <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
+        follows. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/userVerification}}</code>
 
             <dl class="switch">
 
@@ -2473,16 +2473,16 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
             </dl>
 
     1. <span id="allowCredentialDescriptorListCreation"></span>
-        If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>
+        If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>
         <dl class="switch">
             :   [=list/is not empty=]
             ::  1. Let |allowCredentialDescriptorList| be a new [=list=].
 
                 1. Execute a [=client platform=]-specific procedure to determine which, if any, [=public key credentials=] described by
-                    <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are [=bound credential|bound=] to this
+                    <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> are [=bound credential|bound=] to this
                     |authenticator|, by matching with |rpId|,
-                    <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
-                    and <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/type}}</code>.
+                    <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/id}}</code>,
+                    and <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}.{{PublicKeyCredentialDescriptor/type}}</code>.
                     Set |allowCredentialDescriptorList| to this filtered list.
 
                 1. If |allowCredentialDescriptorList| [=list/is empty=], return [FALSE].


### PR DESCRIPTION
Fixes #1752. This is mutually exclusive with PR #1806. I couldn't decide which approach is better, but I'm slightly favouring this one over #1806.

This fixes the issue by introducing a new variable _pkOptions_ instead of re-assigning the existing variable _options_, so that _options_ can keep its original value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1805.html" title="Last updated on Sep 22, 2022, 5:27 PM UTC (3a543c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1805/0bfc0d0...3a543c4.html" title="Last updated on Sep 22, 2022, 5:27 PM UTC (3a543c4)">Diff</a>