### PR TITLE
Fix incorrect use of options variable: extract signal and mediation attributes first

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1648,6 +1648,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     Note: This "sameOriginWithAncestors" restriction aims to address a tracking concern raised in [Issue #1336](https://github.com/w3c/webauthn/issues/1336). This may be revised in future versions of this specification.
 
+1. Let |signal| be the value of <code>|options|.{{CredentialCreationOptions/signal}}</code>.
+
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
 1. If the {{PublicKeyCredentialCreationOptions/timeout}} member of |options| is present, check if its value lies within a
@@ -1760,8 +1762,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Let |clientDataHash| be the [=hash of the serialized client data=] represented by |clientDataJSON|.
 
-1. If <code>|options|.{{CredentialCreationOptions/signal}}</code> is present and [=AbortSignal/aborted=], throw
-    the <code>|options|.{{CredentialCreationOptions/signal}}</code>'s [=AbortSignal/abort reason=].
+1. If |signal| is present and [=AbortSignal/aborted=], throw
+    the |signal|'s [=AbortSignal/abort reason=].
 
 1. Let |issuedRequests| be a new [=ordered set=].
 
@@ -1785,10 +1787,10 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|. Throw a "{{NotAllowedError}}" {{DOMException}}.
 
-        :   If <code>|options|.{{CredentialCreationOptions/signal}}</code> is present and [=AbortSignal/aborted=],
+        :   If |signal| is present and [=AbortSignal/aborted=],
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=]
             operation on |authenticator| and [=set/remove=] |authenticator| from |issuedRequests|. Then throw the
-            <code>|options|.{{CredentialCreationOptions/signal}}</code>'s [=AbortSignal/abort reason=].
+            |signal|'s [=AbortSignal/abort reason=].
 
         :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
@@ -2114,9 +2116,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialRequestOptions/publicKey}}</code> is present.
 
+1. Let |signal| be the value of <code>|options|.{{CredentialRequestOptions/signal}}</code>.
+
+1. Let |mediation| be the value of <code>|options|.{{CredentialRequestOptions/mediation}}</code>.
+
 1. Let |options| be the value of <code>|options|.{{CredentialRequestOptions/publicKey}}</code>.
 
-1. If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is present with the value
+1. If |mediation| is present with the value
     {{CredentialMediationRequirement/conditional}}:
 
     1. If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not [=list/empty=],
@@ -2208,8 +2214,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Let |clientDataHash| be the [=hash of the serialized client data=] represented by |clientDataJSON|.
 
-1. If <code>|options|.{{CredentialRequestOptions/signal}}</code> is present and [=AbortSignal/aborted=], throw
-    the <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
+1. If |signal| is present and [=AbortSignal/aborted=], throw
+    the |signal|'s [=AbortSignal/abort reason=].
 
 1. Let |issuedRequests| be a new [=ordered set=].
 
@@ -2239,14 +2245,14 @@ When this method is invoked, the user agent MUST execute the following algorithm
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|. Throw a "{{NotAllowedError}}" {{DOMException}}.
 
-        :   If <code>|options|.{{CredentialRequestOptions/signal}}</code> is present and [=AbortSignal/aborted=],
+        :   If |signal| is present and [=AbortSignal/aborted=],
         ::  [=set/For each=] |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation on |authenticator|
             and [=set/remove=] |authenticator| from |issuedRequests|. Then
-            throw the <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
+            throw the |signal|'s [=AbortSignal/abort reason=].
 
             <!-- this needs to be indented 2 more levels to get it to render properly -->
                 <dt id="GetAssn-ConditionalMediation-Interact-FormControl">
-                  If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is {{CredentialMediationRequirement/conditional}}
+                  If |mediation| is {{CredentialMediationRequirement/conditional}}
                   and the user interacts with an <{input}> or <{textarea}> form control with an <{input/autocomplete}> attribute whose value
                   contains a `"webauthn"` [=autofill detail token=],
                 </dt>
@@ -2260,7 +2266,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                 1. If the user selects a |credentialMetadata|,
 
-                    1. Let |publicKeyOptions| be a temporary copy of |options|.{{CredentialRequestOptions/publicKey}}.
+                    1. Let |publicKeyOptions| be a temporary copy of |options|.
 
                     1. Let |authenticator| be the value of |silentlyDiscoveredCredentials|[|credentialMetadata|].
 
@@ -2276,7 +2282,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                     1. [=set/Append=] |authenticator| to |issuedRequests|.
 
-        :   If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is not {{CredentialMediationRequirement/conditional}},
+        :   If |mediation| is not {{CredentialMediationRequirement/conditional}},
             |issuedRequests| is empty, <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> is not empty,
             and no |authenticator| will become available for any [=public key credentials=] therein,
         ::  Indicate to the user that no eligible credential could be found. When the user acknowledges the dialog, throw a "{{NotAllowedError}}" {{DOMException}}.
@@ -2286,7 +2292,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         :   If an |authenticator| becomes available on this [=client device=],
         ::  Note:  This includes the case where an |authenticator| was available upon |lifetimeTimer| initiation.
 
-            1. If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is {{CredentialMediationRequirement/conditional}}
+            1. If |mediation| is {{CredentialMediationRequirement/conditional}}
                 and the |authenticator| supports the [=silentCredentialDiscovery=] operation:
 
                 1. Let |collectedDiscoveredCredentialMetadata| be the result of invoking the [=silentCredentialDiscovery=] operation on |authenticator| with |rpId| as parameter.
@@ -2302,11 +2308,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Else:
 
                 1. Execute the [=issuing a credential request to an authenticator=] algorithm with |authenticator|, |savedCredentialIds|,
-                    |options|.{{CredentialRequestOptions/publicKey}}, |rpId|, |clientDataHash|, and |authenticatorExtensions|.
+                    |options|, |rpId|, |clientDataHash|, and |authenticatorExtensions|.
 
                     If this returns [FALSE], [=continue=].
 
-                    Note: This branch is taken if <code>|options|.{{CredentialRequestOptions/mediation}}</code> is {{CredentialMediationRequirement/conditional}}
+                    Note: This branch is taken if |mediation| is {{CredentialMediationRequirement/conditional}}
                     and the |authenticator| does not support the [=silentCredentialDiscovery=] operation to allow use of such authenticators during a
                     {{CredentialMediationRequirement/conditional}} [=user mediation=] request.
 


### PR DESCRIPTION
Fixes #1752. This is a mutually exclusive alternative to PR #1805. I couldn't decide which approach is better, but I'm slightly favouring #1805 over this one.

This fixes the issue by introducing new variables for _signal_ and _mediation_, so that _options_ can continue to reference the `publicKey` member of the original _options_ value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1806.html" title="Last updated on Sep 22, 2022, 5:26 PM UTC (70b6f64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1806/0bfc0d0...70b6f64.html" title="Last updated on Sep 22, 2022, 5:26 PM UTC (70b6f64)">Diff</a>