### PR TITLE
Move state updates to last in RP verification steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1127,7 +1127,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     The following [=struct/items=] are RECOMMENDED in order to implement all steps of
     [[#sctn-registering-a-new-credential]] and [[#sctn-verifying-assertion]] as defined:
 
-    <dl dfn-for="credential record">
+    <dl dfn-for="credential record" dfn-type="abstract-op">
         :   <dfn>type</dfn>
         ::  The [=public key credential source/type=] of the [=public key credential source=].
 
@@ -1158,7 +1158,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
     The following [=struct/items=] are OPTIONAL:
 
-    <dl dfn-for="credential record">
+    <dl dfn-for="credential record" dfn-type="abstract-op">
         :   <dfn>attestationObject</dfn>
         ::  The value of the {{AuthenticatorAttestationResponse/attestationObject}} attribute
             when the [=public key credential source=] was [=registration|registered=].
@@ -1167,7 +1167,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         :   <dfn>attestationClientDataJSON</dfn>
         ::  The value of the {{AuthenticatorResponse/clientDataJSON}} attribute
             when the [=public key credential source=] was [=registration|registered=].
-            Storing this in combination with the above [=credential record/attestationObject=] [=struct/item=]
+            Storing this in combination with the above [$credential record/attestationObject$] [=struct/item=]
             enables the [=[RP]=] to re-verify the [=attestation signature=] at a later time.
     </dl>
 
@@ -1178,13 +1178,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     The <dfn>credential descriptor for a credential record</dfn> is a {{PublicKeyCredentialDescriptor}} value with the contents:
 
     :   {{PublicKeyCredentialDescriptor/type}}
-    ::  The [=credential record/type=] of the [=credential record=].
+    ::  The [$credential record/type$] of the [=credential record=].
 
     :   {{PublicKeyCredentialDescriptor/id}}
-    ::  The [=credential record/id=] of the [=credential record=].
+    ::  The [$credential record/id$] of the [=credential record=].
 
     :   {{PublicKeyCredentialDescriptor/transports}}
-    ::  The [=credential record/transports=] of the [=credential record=].
+    ::  The [$credential record/transports$] of the [=credential record=].
 
 
 : <dfn>Generating Authenticator</dfn>
@@ -5157,36 +5157,36 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
     with the following contents:
 
     <dl>
-        :   [=credential record/type=]
+        :   [$credential record/type$]
         ::  <code>|credential|.{{Credential/type}}</code>.
 
-        :   [=credential record/id=]
+        :   [$credential record/id$]
         ::  <code>|credential|.{{Credential/id}}</code> or <code>|credential|.{{PublicKeyCredential/rawId}}</code>,
             whichever format is preferred by the [=[RP]=].
 
-        :   [=credential record/publicKey=]
+        :   [$credential record/publicKey$]
         ::  The [=credential public key=] in |authData|.
 
-        :   [=credential record/signCount=]
+        :   [$credential record/signCount$]
         ::  <code>|authData|.[=authData/signCount=]</code>.
 
-        :   [=credential record/transports=]
+        :   [$credential record/transports$]
         ::  The value returned from <code>|response|.{{AuthenticatorAttestationResponse/getTransports()}}</code>.
 
-        :   [=credential record/BE=]
+        :   [$credential record/BE$]
         ::  The value of the [=authData/flags/BE=] [=flag=] in |authData|.
 
-        :   [=credential record/BS=]
+        :   [$credential record/BS$]
         ::  The value of the [=authData/flags/BS=] [=flag=] in |authData|.
     </dl>
 
     The new [=credential record=] MAY also include the following OPTIONAL contents:
 
     <dl>
-        :   [=credential record/attestationObject=]
+        :   [$credential record/attestationObject$]
         ::  <code>|response|.{{AuthenticatorAttestationResponse/attestationObject}}</code>.
 
-        :   [=credential record/attestationClientDataJSON=]
+        :   [$credential record/attestationClientDataJSON$]
         ::  <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code>.
     </dl>
 
@@ -5232,7 +5232,7 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
     <dl class="switch">
         :  If the user was identified before the [=authentication ceremony=] was initiated, e.g., via a username or cookie,
         :: verify that the identified [=user account=] contains a [=credential record=]
-            whose [=credential record/id=] equals <code>|credential|.{{PublicKeyCredential/rawId}}</code>.
+            whose [$credential record/id$] equals <code>|credential|.{{PublicKeyCredential/rawId}}</code>.
             Let |credentialRecord| be that [=credential record=].
             If <code>|response|.{{AuthenticatorAssertionResponse/userHandle}}</code> is present,
             verify that it equals the [=user handle=] of the [=user account=].
@@ -5240,7 +5240,7 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
         :  If the user was not identified before the [=authentication ceremony=] was initiated,
         :: verify that <code>|response|.{{AuthenticatorAssertionResponse/userHandle}}</code> is present.
             Verify that the [=user account=] identified by <code>|response|.{{AuthenticatorAssertionResponse/userHandle}}</code>
-            contains a [=credential record=] whose [=credential record/id=] equals <code>|credential|.{{PublicKeyCredential/rawId}}</code>.
+            contains a [=credential record=] whose [$credential record/id$] equals <code>|credential|.{{PublicKeyCredential/rawId}}</code>.
             Let |credentialRecord| be that [=credential record=].
     </dl>
 
@@ -5289,9 +5289,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     let |currentBe| and |currentBs| be the values of the [=authData/flags/BE=] and [=authData/flags/BS=] bits, respectively,
     of the <code>[=flags=]</code> in |authData|.
     Compare |currentBe| and |currentBs| with
-    <code>|credentialRecord|.[=credential record/BE=]</code> and <code>|credentialRecord|.[=credential record/BS=]</code>
+    <code>|credentialRecord|.[$credential record/BE$]</code> and <code>|credentialRecord|.[$credential record/BS$]</code>
     and apply [=[RP]=] policy, if any,
-    and then update <code>|credentialRecord|.[=credential record/BS=]</code> to the value of |currentBs|.
+    and then update <code>|credentialRecord|.[$credential record/BS$]</code> to the value of |currentBs|.
 
     Note: See [[#sctn-credential-backup]] for examples of how a [=[RP]=] might process the [=authData/flags/BS=] [=flag=] values.
 
@@ -5314,27 +5314,27 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Let |hash| be the result of computing a hash over the |cData| using SHA-256.
 
-1. Using <code>|credentialRecord|.[=credential record/publicKey=]</code>,
+1. Using <code>|credentialRecord|.[$credential record/publicKey$]</code>,
     verify that |sig| is a valid signature over the binary concatenation of
     |authData| and |hash|.
 
     Note: This verification step is compatible with signatures generated by FIDO U2F authenticators. See
     [[#sctn-fido-u2f-sig-format-compat]].
 
-1. If |authData|.<code>[=authData/signCount=]</code> is nonzero or <code>|credentialRecord|.[=credential record/signCount=]</code> is nonzero,
+1. If |authData|.<code>[=authData/signCount=]</code> is nonzero or <code>|credentialRecord|.[$credential record/signCount$]</code> is nonzero,
     then run the following sub-step:
       - If |authData|.<code>[=authData/signCount=]</code> is
            <dl class="switch">
-              <dt>greater than <code>|credentialRecord|.[=credential record/signCount=]</code>:</dt>
-              <dd>Update <code>|credentialRecord|.[=credential record/signCount=]</code> to be the value of
+              <dt>greater than <code>|credentialRecord|.[$credential record/signCount$]</code>:</dt>
+              <dd>Update <code>|credentialRecord|.[$credential record/signCount$]</code> to be the value of
                   |authData|.<code>[=authData/signCount=]</code>.</dd>
-              <dt>less than or equal to <code>|credentialRecord|.[=credential record/signCount=]</code>:</dt>
+              <dt>less than or equal to <code>|credentialRecord|.[$credential record/signCount$]</code>:</dt>
               <dd>This is a signal that
                   the authenticator may be cloned, i.e. at least
                   two copies of the [=credential private key=] may exist and are
                   being used in parallel. [=[RPS]=] should incorporate this information
                   into their risk scoring.
-                  Whether the [=[RP]=] updates <code>|credentialRecord|.[=credential record/signCount=]</code>
+                  Whether the [=[RP]=] updates <code>|credentialRecord|.[$credential record/signCount$]</code>
                   in this case, or not, or fails the
                   [=authentication ceremony=] or not, is
                   [=[RP]=]-specific. </dd>

--- a/index.bs
+++ b/index.bs
@@ -5290,8 +5290,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     of the <code>[=flags=]</code> in |authData|.
     Compare |currentBe| and |currentBs| with
     <code>|credentialRecord|.[$credential record/BE$]</code> and <code>|credentialRecord|.[$credential record/BS$]</code>
-    and apply [=[RP]=] policy, if any,
-    and then update <code>|credentialRecord|.[$credential record/BS$]</code> to the value of |currentBs|.
+    and apply [=[RP]=] policy, if any.
 
     Note: See [[#sctn-credential-backup]] for examples of how a [=[RP]=] might process the [=authData/flags/BS=] [=flag=] values.
 
@@ -5326,8 +5325,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
       - If |authData|.<code>[=authData/signCount=]</code> is
            <dl class="switch">
               <dt>greater than <code>|credentialRecord|.[$credential record/signCount$]</code>:</dt>
-              <dd>Update <code>|credentialRecord|.[$credential record/signCount$]</code> to be the value of
-                  |authData|.<code>[=authData/signCount=]</code>.</dd>
+              <dd>The signature counter is valid.</dd>
               <dt>less than or equal to <code>|credentialRecord|.[$credential record/signCount$]</code>:</dt>
               <dd>This is a signal that
                   the authenticator may be cloned, i.e. at least
@@ -5335,10 +5333,15 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                   being used in parallel. [=[RPS]=] should incorporate this information
                   into their risk scoring.
                   Whether the [=[RP]=] updates <code>|credentialRecord|.[$credential record/signCount$]</code>
-                  in this case, or not, or fails the
+                  below in this case, or not, or fails the
                   [=authentication ceremony=] or not, is
                   [=[RP]=]-specific. </dd>
            </dl>
+
+1. Update |credentialRecord| with new state values:
+
+    1. Update <code>|credentialRecord|.[$credential record/signCount$]</code> to the value of |authData|.<code>[=authData/signCount=]</code>.
+    1. Update <code>|credentialRecord|.[$credential record/BS$]</code> to the value of |currentBs|.
 
 1. If all the above steps are successful, continue with the [=authentication ceremony=] as appropriate. Otherwise, fail the
     [=authentication ceremony=].


### PR DESCRIPTION
This relates to (but does not fix) issue #1711, and will be useful for applying the new "credential record" (see #1773) abstraction to PR #1663. The stored state should be updated only after performing all validation and verification steps.

This also changes the definition type (and therefore autolink syntax) for the credential record struct members from `dfn` to `abstract-op`. This will help avoid conflicts with existing definitions, including `[=scope=]`, as we introduce a struct for devicePubKey records as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1807.html" title="Last updated on Sep 26, 2022, 8:30 AM UTC (05fe54d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1807/6c823f1...05fe54d.html" title="Last updated on Sep 26, 2022, 8:30 AM UTC (05fe54d)">Diff</a>