### PR TITLE
Give flag items in credential record more descriptive names

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1149,10 +1149,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             Note: Modifying or removing [=list/items=] from the value returned from {{AuthenticatorAttestationResponse/getTransports()}}
             could negatively impact user experience, or even prevent use of the corresponding credential.
 
-        :   <dfn>BE</dfn>
+        :   <dfn>backupEligible</dfn>
         ::  The value of the [=authData/flags/BE=] [=flag=] when the [=public key credential source=] was created.
 
-        :   <dfn>BS</dfn>
+        :   <dfn>backupState</dfn>
         ::  The latest value of the [=authData/flags/BS=] [=flag=] in the [=authenticator data=]
             from any [=ceremony=] using the [=public key credential source=].
     </dl>
@@ -5176,10 +5176,10 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
         :   [$credential record/transports$]
         ::  The value returned from <code>|response|.{{AuthenticatorAttestationResponse/getTransports()}}</code>.
 
-        :   [$credential record/BE$]
+        :   [$credential record/backupEligible$]
         ::  The value of the [=authData/flags/BE=] [=flag=] in |authData|.
 
-        :   [$credential record/BS$]
+        :   [$credential record/backupState$]
         ::  The value of the [=authData/flags/BS=] [=flag=] in |authData|.
     </dl>
 
@@ -5292,7 +5292,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     let |currentBe| and |currentBs| be the values of the [=authData/flags/BE=] and [=authData/flags/BS=] bits, respectively,
     of the <code>[=flags=]</code> in |authData|.
     Compare |currentBe| and |currentBs| with
-    <code>|credentialRecord|.[$credential record/BE$]</code> and <code>|credentialRecord|.[$credential record/BS$]</code>
+    <code>|credentialRecord|.[$credential record/backupEligible$]</code> and <code>|credentialRecord|.[$credential record/backupState$]</code>
     and apply [=[RP]=] policy, if any.
 
     Note: See [[#sctn-credential-backup]] for examples of how a [=[RP]=] might process the [=authData/flags/BS=] [=flag=] values.
@@ -5344,7 +5344,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 1. Update |credentialRecord| with new state values:
 
     1. Update <code>|credentialRecord|.[$credential record/signCount$]</code> to the value of |authData|.<code>[=authData/signCount=]</code>.
-    1. Update <code>|credentialRecord|.[$credential record/BS$]</code> to the value of |currentBs|.
+    1. Update <code>|credentialRecord|.[$credential record/backupState$]</code> to the value of |currentBs|.
 
 1. If all the above steps are successful, continue with the [=authentication ceremony=] as appropriate. Otherwise, fail the
     [=authentication ceremony=].


### PR DESCRIPTION
Fixes #1811. See also: https://github.com/w3c/webauthn/pull/1807#pullrequestreview-1130566110.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1813.html" title="Last updated on Oct 6, 2022, 8:07 AM UTC (2685408)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1813/008b979...2685408.html" title="Last updated on Oct 6, 2022, 8:07 AM UTC (2685408)">Diff</a>