### PR TITLE
Fix incorrectly described reference to attStmt formats registry

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5376,7 +5376,7 @@ Attestation statement formats that may exist in multiple versions SHOULD include
 different versions are thus treated as different formats, e.g., `packed2` as a new version of the [[#sctn-packed-attestation]].
 
 The following sections present a set of currently-defined and registered attestation statement formats and their identifiers.
-The up-to-date list of registered [=WebAuthn Extensions=] is maintained in the
+The up-to-date list of registered [=attestation statement format identifiers=] is maintained in the
 IANA "WebAuthn Attestation Statement Format Identifiers" registry [[!IANA-WebAuthn-Registries]] established by [[!RFC8809]].
 
 


### PR DESCRIPTION
Fixes #1689.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1814.html" title="Last updated on Oct 6, 2022, 12:17 PM UTC (736e524)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1814/008b979...736e524.html" title="Last updated on Oct 6, 2022, 12:17 PM UTC (736e524)">Diff</a>