### PR TITLE
Fix broken links to steps in RP ops from DPK extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5243,24 +5243,26 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
     matches the {{PublicKeyCredentialParameters/alg}} attribute of one of the [=list/items=] in
     <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>.
 
-1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
-    outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
-    extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
-    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
-    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
-    In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
+    <li id='reg-ceremony-verify-extension-outputs'>
+        Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
+        outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
+        extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
+        and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
+        <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
+        In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
-    Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
-    [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
-    [=client extension outputs=] that were not originally specified as part of
-    <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
-    situations, whether it be to ignore the unsolicited extensions or reject the attestation. The [=[RP]=] can make this
-    decision based on local policy and the extensions in use.
+        Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
+        [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
+        [=client extension outputs=] that were not originally specified as part of
+        <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
+        situations, whether it be to ignore the unsolicited extensions or reject the attestation. The [=[RP]=] can make this
+        decision based on local policy and the extensions in use.
 
-    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be
-    prepared to handle cases where none or not all of the requested extensions were acted upon.
+        Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be
+        prepared to handle cases where none or not all of the requested extensions were acted upon.
 
-    Note: The [=devicePubKey=] extension has explicit verification procedures, see [[#sctn-device-publickey-extension-verification-create]].
+        Note: The [=devicePubKey=] extension has explicit verification procedures, see [[#sctn-device-publickey-extension-verification-create]].
+    </li>
 
 1. Determine the attestation statement format by performing a USASCII case-sensitive match on |fmt| against the set of
     supported WebAuthn Attestation Statement Format Identifier values.
@@ -5434,24 +5436,26 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
     Note: See [[#sctn-credential-backup]] for examples of how a [=[RP]=] might process the [=authData/flags/BS=] [=flag=] values.
 
-1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
-    outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
-    extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
-    and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
-    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
-    In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
+    <li id='authn-ceremony-verify-extension-outputs'>
+        Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
+        outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
+        extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
+        and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
+        <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
+        In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
-    Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
-    [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
-    [=client extension outputs=] that were not originally specified as part of
-    <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
-    situations, whether it be to ignore the unsolicited extensions or reject the assertion. The [=[RP]=] can make this
-    decision based on local policy and the extensions in use.
+        Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
+        [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
+        [=client extension outputs=] that were not originally specified as part of
+        <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
+        situations, whether it be to ignore the unsolicited extensions or reject the assertion. The [=[RP]=] can make this
+        decision based on local policy and the extensions in use.
 
-    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be
-    prepared to handle cases where none or not all of the requested extensions were acted upon.
+        Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST also be
+        prepared to handle cases where none or not all of the requested extensions were acted upon.
 
-    Note: The [=devicePubKey=] extension has explicit verification procedures, see [[#sctn-device-publickey-extension-verification-get]].
+        Note: The [=devicePubKey=] extension has explicit verification procedures, see [[#sctn-device-publickey-extension-verification-get]].
+    </li>
 
 1. Let |hash| be the result of computing a hash over the |cData| using SHA-256.
 


### PR DESCRIPTION
Fixes Bikeshed errors:

```
FATAL ERROR: Couldn't find target anchor reg-ceremony-verify-extension-outputs:
<a href="#reg-ceremony-verify-extension-outputs">this step</a>
FATAL ERROR: Couldn't find target anchor authn-ceremony-verify-extension-outputs:
<a href="#authn-ceremony-verify-extension-outputs">this step</a>
```

Looks like these got lost in the merge commit dd7dba6d.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1815.html" title="Last updated on Oct 10, 2022, 9:13 AM UTC (5cae00d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1815/dd7dba6...5cae00d.html" title="Last updated on Oct 10, 2022, 9:13 AM UTC (5cae00d)">Diff</a>