### PR TITLE
Fix now-single RFU bit still referred to as plural

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4031,7 +4031,7 @@ laid out as shown in <a href="#table-authData">Table <span class="table-ref-foll
                 - Bit 4: [=Backup State=] (<dfn>BS</dfn>).
                     - `1` means the [=public key credential source=] is currently [=backed up=].
                     - `0` means the [=public key credential source=] is not currently [=backed up=].
-                - Bits 5: Reserved for future use (`RFU2`).
+                - Bit 5: Reserved for future use (`RFU2`).
                 - Bit 6: [=Attested credential data=] included (<dfn>AT</dfn>).
                     - Indicates whether the authenticator added [=attested credential data=].
                 - Bit 7: Extension data included (<dfn>ED</dfn>).


### PR DESCRIPTION
See title.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1821.html" title="Last updated on Nov 2, 2022, 4:12 AM UTC (dc4ac78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1821/57c4617...dc4ac78.html" title="Last updated on Nov 2, 2022, 4:12 AM UTC (dc4ac78)">Diff</a>