### PR TITLE
Define discrete list of pubKeyCredParams algs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3036,6 +3036,12 @@ optionally evidence of [=user consent=] to a specific transaction.
         The [=client=] and [=authenticator=] make a best-effort to create a credential of the most preferred type possible.
         If none of the listed types can be created, the {{CredentialsContainer/create()}} operation fails.
 
+        [=[RP]=]'s that wish to support a wide range of [=authenticators=] SHOULD define entries for the following discrete list of signature algorithms:
+
+        * -8 (Ed25519)
+        * -7 (ES256)
+        * -257 (RS256)
+
     :   <dfn>timeout</dfn>
     ::  This OPTIONAL member specifies a time, in milliseconds, that the [=[RP]=] is willing to wait for the call to complete. This is
         treated as a hint, and MAY be overridden by the [=client=].

--- a/index.bs
+++ b/index.bs
@@ -3036,7 +3036,7 @@ optionally evidence of [=user consent=] to a specific transaction.
         The [=client=] and [=authenticator=] make a best-effort to create a credential of the most preferred type possible.
         If none of the listed types can be created, the {{CredentialsContainer/create()}} operation fails.
 
-        [=[RP]=]'s that wish to support a wide range of [=authenticators=] SHOULD define entries for the following discrete list of signature algorithms:
+        [=[RPS]=] that wish to support a wide range of [=authenticators=] SHOULD include at least the following {{COSEAlgorithmIdentifier}} values:
 
         * -8 (Ed25519)
         * -7 (ES256)

--- a/index.bs
+++ b/index.bs
@@ -3042,6 +3042,8 @@ optionally evidence of [=user consent=] to a specific transaction.
         * -7 (ES256)
         * -257 (RS256)
 
+        Additional signature algorithms can be included as needed.
+
     :   <dfn>timeout</dfn>
     ::  This OPTIONAL member specifies a time, in milliseconds, that the [=[RP]=] is willing to wait for the call to complete. This is
         treated as a hint, and MAY be overridden by the [=client=].


### PR DESCRIPTION
This PR adds a suggestion to RP's to define three algorithm ID's in `pubKeyCredParams` for the widest possible authenticator support. [Quoting myself from comments I made in #1757](https://github.com/w3c/webauthn/issues/1757#issuecomment-1321203084):

> I'd put `-8` at the top of the list to encourage adoption of Ed25519, since authenticators that can support it will choose to use it if it's first on the list (in my experience this is basically YubiKey 5's, but I think SoloKeys support it too). After that `-7` and `-257` are the two that practically cover almost 100% of existing authenticators.

Fixes #1757.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1843.html" title="Last updated on Jan 26, 2023, 5:26 PM UTC (4670540)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1843/d3270c5...4670540.html" title="Last updated on Jan 26, 2023, 5:26 PM UTC (4670540)">Diff</a>