### PR TITLE
Remove redundant extra step in DPK processing.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7271,22 +7271,6 @@ If the [=[RP]=] requested the `devicePubKey` extension in a {{CredentialsContain
             1. Otherwise there is some form of error: we recieved a known |dpk| value, but one or more of the accompanying |aaguid|, |scope|, or |fmt| values did not match what the [=[RP]=] has stored along with that |dpk| value. Terminate these verification steps.
     </dl>
 
-1. Otherwise, the [=[RP]=] does not have a [=device-bound key record=] for this [=device public key=].
-
-    1. If |fmt|'s value is "none" there is no attestation signature to verify. [$Create a new device-bound key record$], then terminate these verification steps.
-
-    1. Otherwise, verify that |attStmt| is a correct [=attestation statement=], conveying a valid [=attestation signature=], by using the [=attestation statement format=] |fmt|'s [=verification procedure=] given |attStmt|. See [[#sctn-device-publickey-attestation-calculations]]. [=[RP]=] policy may specifiy which attestations are acceptable.
-
-        If the result is:
-
-            <dl class="switch">
-                : successful
-                :: This is the first [=device public key=]&mdash;and thus device&mdash;mapped to this [=user account=] and <code>|credential|.{{Credential/id}}</code> pair. [$Create a new device-bound key record$], then terminate these verification steps.
-
-                : unsuccessful
-                :: Some form of error has occurred. It is indeterminate whether this is a valid new device. Terminate these verification steps.
-            </dl>
-
 See also [[#sctn-device-publickey-extension-usage]].
 
 To <dfn abstract-op>Create a new device-bound key record</dfn>, perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -7268,7 +7268,7 @@ If the [=[RP]=] requested the `devicePubKey` extension in a {{CredentialsContain
                         </dl>
                 </dl>
 
-            1. Otherwise there is some form of error: we recieved a known |dpk| value, but one or more of the accompanying |aaguid|, |scope|, or |fmt| values did not match what the [=[RP]=] has stored along with that |dpk| value. Terminate these verification steps.
+            1. Otherwise there is some form of error: we recieved a known |dpk| value, but one or more of the accompanying |aaguid| or |scope| values did not match what the [=[RP]=] has stored along with that |dpk| value. Terminate these verification steps.
     </dl>
 
 See also [[#sctn-device-publickey-extension-usage]].


### PR DESCRIPTION
This got left in during edits but is covered by the previous step.

Fixes #1853


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1858.html" title="Last updated on Feb 27, 2023, 12:24 PM UTC (b8d23c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1858/6a2e2b4...b8d23c6.html" title="Last updated on Feb 27, 2023, 12:24 PM UTC (b8d23c6)">Diff</a>