### PR TITLE
Add smart-card to transports enum

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3827,6 +3827,7 @@ It mirrors some fields of the {{PublicKeyCredential}} object returned by
         "usb",
         "nfc",
         "ble",
+        "smart-card",
         "hybrid",
         "internal"
     };
@@ -3849,6 +3850,9 @@ Note: The {{AuthenticatorTransport}} enumeration is deliberately not referenced,
 
     :   <dfn>ble</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted over Bluetooth Smart (Bluetooth Low Energy / BLE).
+
+    :   <dfn>smart-card</dfn>
+    ::  Indicates the respective [=authenticator=] can be contacted over ISO/IEC 7816 smart card with contacts.
 
     :   <dfn>hybrid</dfn>
     ::  Indicates the respective [=authenticator=] can be contacted using a combination of (often separate) data-transport and proximity mechanisms. This supports, for example, authentication on a desktop computer using a smartphone.


### PR DESCRIPTION
Fixes #1835.

This change adds the "smart-card" enum value, signifying the authenticator may be contacted via a smart card reader with contacts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pascoej/webauthn/pull/1865.html" title="Last updated on Apr 21, 2023, 5:26 PM UTC (38b0161)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1865/fa65a36...pascoej:38b0161.html" title="Last updated on Apr 21, 2023, 5:26 PM UTC (38b0161)">Diff</a>