### PR TITLE
Mark all JSON fields as required.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1607,34 +1607,34 @@ that are returned to the caller when a new credential is created, or a new asser
     typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
 
     dictionary RegistrationResponseJSON {
-        Base64URLString id;
-        Base64URLString rawId;
-        AuthenticatorAttestationResponseJSON response;
-        DOMString? authenticatorAttachment;
-        AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
-        DOMString type;
+        required Base64URLString id;
+        required Base64URLString rawId;
+        required AuthenticatorAttestationResponseJSON response;
+        required DOMString? authenticatorAttachment;
+        required AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
+        required DOMString type;
     };
 
     dictionary AuthenticatorAttestationResponseJSON {
-        Base64URLString clientDataJSON;
-        Base64URLString attestationObject;
-        sequence<DOMString> transports;
+        required Base64URLString clientDataJSON;
+        required Base64URLString attestationObject;
+        required sequence<DOMString> transports;
     };
 
     dictionary AuthenticationResponseJSON {
-        Base64URLString id;
-        Base64URLString rawId;
-        AuthenticatorAssertionResponseJSON response;
-        DOMString? authenticatorAttachment;
-        AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
-        DOMString type;
+        required Base64URLString id;
+        required Base64URLString rawId;
+        required AuthenticatorAssertionResponseJSON response;
+        required DOMString? authenticatorAttachment;
+        required AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
+        required DOMString type;
     };
 
     dictionary AuthenticatorAssertionResponseJSON {
-        Base64URLString clientDataJSON;
-        Base64URLString authenticatorData;
-        Base64URLString signature;
-        Base64URLString? userHandle;
+        required Base64URLString clientDataJSON;
+        required Base64URLString authenticatorData;
+        required Base64URLString signature;
+        required Base64URLString? userHandle;
     };
 
     dictionary AuthenticationExtensionsClientOutputsJSON {

--- a/index.bs
+++ b/index.bs
@@ -1610,7 +1610,7 @@ that are returned to the caller when a new credential is created, or a new asser
         required Base64URLString id;
         required Base64URLString rawId;
         required AuthenticatorAttestationResponseJSON response;
-        required DOMString? authenticatorAttachment;
+        DOMString authenticatorAttachment;
         required AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
         required DOMString type;
     };
@@ -1625,7 +1625,7 @@ that are returned to the caller when a new credential is created, or a new asser
         required Base64URLString id;
         required Base64URLString rawId;
         required AuthenticatorAssertionResponseJSON response;
-        required DOMString? authenticatorAttachment;
+        DOMString authenticatorAttachment;
         required AuthenticationExtensionsClientOutputsJSON clientExtensionResults;
         required DOMString type;
     };
@@ -1634,7 +1634,7 @@ that are returned to the caller when a new credential is created, or a new asser
         required Base64URLString clientDataJSON;
         required Base64URLString authenticatorData;
         required Base64URLString signature;
-        required Base64URLString? userHandle;
+        Base64URLString userHandle;
     };
 
     dictionary AuthenticationExtensionsClientOutputsJSON {


### PR DESCRIPTION
These fields should always be present (although some can be null) but the default for a dictionary field is `optional`. Thus mark them all as required.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1878.html" title="Last updated on May 3, 2023, 11:07 PM UTC (dbd8df4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1878/748eea0...dbd8df4.html" title="Last updated on May 3, 2023, 11:07 PM UTC (dbd8df4)">Diff</a>