### PR TITLE
Add authenticatorDisplayName to credProps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1168,7 +1168,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             Storing this in combination with the above [$credential record/attestationObject$] [=struct/item=]
             enables the [=[RP]=] to re-verify the [=attestation signature=] at a later time.
 
-        :   <dfn>displayName</dfn>
+        :   <dfn>authenticatorDisplayName</dfn>
         ::  A [=human palatability|human-palatable=] description of the [=public key credential source=].
 
             If used, the [=[RP]=] SHOULD use this to describe the [=credential record=] in the user's account settings.
@@ -6632,9 +6632,9 @@ This [=client extension|client=] [=registration extension=] facilitates reportin
             The [=client=] MAY consider a user-configured response chosen by the user,
             and SHOULD allow the user to modify a vendor-provided default response.
 
-            If the [=[RP]=] includes a <code>[$credential record/displayName$]</code> [=struct/item=] in [=credential records=],
+            If the [=[RP]=] includes an <code>[$credential record/authenticatorDisplayName$]</code> [=struct/item=] in [=credential records=],
             the [=[RP]=] MAY offer this value, if present,
-            as a default value for the <code>[$credential record/displayName$]</code> of the new [=credential record=].
+            as a default value for the <code>[$credential record/authenticatorDisplayName$]</code> of the new [=credential record=].
     </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -1167,6 +1167,17 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             when the [=public key credential source=] was [=registration|registered=].
             Storing this in combination with the above [$credential record/attestationObject$] [=struct/item=]
             enables the [=[RP]=] to re-verify the [=attestation signature=] at a later time.
+
+        :   <dfn>displayName</dfn>
+        ::  A [=human palatability|human-palatable=] description of the [=public key credential source=].
+
+            If used, the [=[RP]=] SHOULD use this to describe the [=credential record=] in the user's account settings.
+            The [=[RP]=] SHOULD allow the user to choose this value, and MAY allow the user to modify it at will.
+
+            The [=credProps|Credential Properties Extension=] defines two [=credential properties=],
+            {{CredentialPropertiesOutput/userDisplayName}} and {{CredentialPropertiesOutput/vendorDisplayName}},
+            which, when available, MAY be offered as defaults for this value.
+            The [=[RP]=] MAY also derive a default value from the authenticator's [=attestation statement=], if any.
     </dl>
 
     [=WebAuthn extensions=] MAY define additional [=struct/items=] needed to process the extension.
@@ -6564,9 +6575,6 @@ During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a popu
 
 This [=client extension|client=] [=registration extension=] facilitates reporting certain [=credential properties=] known by the [=client=] to the requesting [=[WRP]=] upon creation of a [=public key credential source=] as a result of a [=registration ceremony=].
 
-At this time, one [=credential property=] is defined: the [=resident key credential property=]
-(i.e., [=client-side discoverable credential property=]).
-
 : Extension identifier
 :: `credProps`
 
@@ -6590,6 +6598,8 @@ At this time, one [=credential property=] is defined: the [=resident key credent
     <xmp class="idl">
     dictionary CredentialPropertiesOutput {
         boolean rk;
+        USVString userDisplayName;
+        USVString vendorDisplayName;
     };
 
     partial dictionary AuthenticationExtensionsClientOutputs {
@@ -6608,6 +6618,33 @@ At this time, one [=credential property=] is defined: the [=resident key credent
             If {{rk}} is not present, it is not known whether the credential is a [=discoverable credential=] or a [=server-side credential=].
 
             Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the [=client platform=]. Because of this, [=client platforms=] may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE]. [=[RPS]=] should assume that, if the `credProps` extension is supported, then [=client platforms=] will endeavour to populate the {{rk}} property. Therefore a missing {{rk}} indicates that the created credential is most likely a [=non-discoverable credential=].
+
+        :   <dfn>userDisplayName</dfn>
+        ::  This OPTIONAL property is a [=human palatability|human-palatable=] description of the credential,
+            chosen by the user.
+
+            The [=client=] MUST allow the user to choose this value,
+            MAY or MAY not present that choice during [=registration ceremonies=],
+            and MAY reuse the same value for multiple credentials with the same [=managing authenticator=] across multiple [=[RPS]=].
+            The [=client=] MAY offer the user a default for this value.
+            The [=client=] MAY query the [=authenticator=], by some unspecified mechanism, for a suitable default value.
+
+            If the [=[RP]=] includes a <code>[$credential record/displayName$]</code> [=struct/item=] in [=credential records=],
+            the [=[RP]=] MAY offer this value, if present,
+            as a default value for the <code>[$credential record/displayName$]</code> of the new [=credential record=].
+
+        :   <dfn>vendorDisplayName</dfn>
+        ::  This OPTIONAL property is a [=human palatability|human-palatable=] description of the credential,
+            chosen by the [=authenticator=] vendor.
+
+            The [=client=] MAY query the [=authenticator=], by some unspecified mechanism, for this value,
+            MAY allow the user to override that value, if any,
+            and MAY reuse the same value for multiple credentials across multiple [=[RPS]=].
+
+            If the [=[RP]=] includes a <code>[$credential record/displayName$]</code> [=struct/item=] in [=credential records=],
+            the [=[RP]=] MAY offer this value, if present,
+            as a default value for the <code>[$credential record/displayName$]</code> of the new [=credential record=].
+            {{userDisplayName}} SHOULD take precedence over {{vendorDisplayName}} if present.
     </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -1174,9 +1174,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             If used, the [=[RP]=] SHOULD use this to describe the [=credential record=] in the user's account settings.
             The [=[RP]=] SHOULD allow the user to choose this value, and MAY allow the user to modify it at will.
 
-            The [=credProps|Credential Properties Extension=] defines two [=credential properties=],
-            {{CredentialPropertiesOutput/userDisplayName}} and {{CredentialPropertiesOutput/vendorDisplayName}},
-            which, when available, MAY be offered as defaults for this value.
+            The [=credProps|Credential Properties Extension=] defines the [=credential property=]
+            {{CredentialPropertiesOutput/authenticatorDisplayName}}
+            which, when available, MAY be offered as a default for this value.
             The [=[RP]=] MAY also derive a default value from the authenticator's [=attestation statement=], if any.
     </dl>
 
@@ -6598,8 +6598,7 @@ This [=client extension|client=] [=registration extension=] facilitates reportin
     <xmp class="idl">
     dictionary CredentialPropertiesOutput {
         boolean rk;
-        USVString userDisplayName;
-        USVString vendorDisplayName;
+        USVString authenticatorDisplayName;
     };
 
     partial dictionary AuthenticationExtensionsClientOutputs {
@@ -6619,32 +6618,23 @@ This [=client extension|client=] [=registration extension=] facilitates reportin
 
             Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the [=client platform=]. Because of this, [=client platforms=] may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE]. [=[RPS]=] should assume that, if the `credProps` extension is supported, then [=client platforms=] will endeavour to populate the {{rk}} property. Therefore a missing {{rk}} indicates that the created credential is most likely a [=non-discoverable credential=].
 
-        :   <dfn>userDisplayName</dfn>
-        ::  This OPTIONAL property is a [=human palatability|human-palatable=] description of the credential,
+        :   <dfn>authenticatorDisplayName</dfn>
+        ::  This OPTIONAL property is a [=human palatability|human-palatable=] description of the credential's [=managing authenticator=],
             chosen by the user.
 
             The [=client=] MUST allow the user to choose this value,
             MAY or MAY not present that choice during [=registration ceremonies=],
             and MAY reuse the same value for multiple credentials with the same [=managing authenticator=] across multiple [=[RPS]=].
-            The [=client=] MAY offer the user a default for this value.
-            The [=client=] MAY query the [=authenticator=], by some unspecified mechanism, for a suitable default value.
+
+            The [=client=] MAY query the [=authenticator=], by some unspecified mechanism, for this value.
+            The [=authenticator=] MAY allow the user to configure the response to such a query.
+            The [=authenticator=] vendor MAY provide a default response to such a query.
+            The [=client=] MAY consider a user-configured response chosen by the user,
+            and SHOULD allow the user to modify a vendor-provided default response.
 
             If the [=[RP]=] includes a <code>[$credential record/displayName$]</code> [=struct/item=] in [=credential records=],
             the [=[RP]=] MAY offer this value, if present,
             as a default value for the <code>[$credential record/displayName$]</code> of the new [=credential record=].
-
-        :   <dfn>vendorDisplayName</dfn>
-        ::  This OPTIONAL property is a [=human palatability|human-palatable=] description of the credential,
-            chosen by the [=authenticator=] vendor.
-
-            The [=client=] MAY query the [=authenticator=], by some unspecified mechanism, for this value,
-            MAY allow the user to override that value, if any,
-            and MAY reuse the same value for multiple credentials across multiple [=[RPS]=].
-
-            If the [=[RP]=] includes a <code>[$credential record/displayName$]</code> [=struct/item=] in [=credential records=],
-            the [=[RP]=] MAY offer this value, if present,
-            as a default value for the <code>[$credential record/displayName$]</code> of the new [=credential record=].
-            {{userDisplayName}} SHOULD take precedence over {{vendorDisplayName}} if present.
     </div>
 
 


### PR DESCRIPTION
In today's WG meeting, there was a desire expressed for some way for the RP to receive a user-friendly name for the new credential. For example, in order to instruct the user to "use your passkey saved in Password Manager X". To that end, this would add a new credential property to the `credProps` extension, possibly configurable by the user and with the possibility of a fallback value set by the authenticator vendor.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1880.html" title="Last updated on May 3, 2023, 7:26 PM UTC (8dd7190)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1880/54e0962...8dd7190.html" title="Last updated on May 3, 2023, 7:26 PM UTC (8dd7190)">Diff</a>