### PR TITLE
Include the "Easily accessing credential data" fields in JSON.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1623,8 +1623,8 @@ that are returned to the caller when a new credential is created, or a new asser
         // negotiate a public-key algorithm that the user agent doesn't
         // understand. (See section “Easily accessing credential data” for a
         // list of which algorithms user agents must support.) If using such an
-        // algorithm then the public key must be parsed from attestationObject
-        // directly.
+        // algorithm then the public key must be parsed directly from
+        // attestationObject or authenticatorData.
         Base64URLString publicKey;
         required long long publicKeyAlgorithm;
         // This value contains copies of some of the fields above. See

--- a/index.bs
+++ b/index.bs
@@ -1617,8 +1617,21 @@ that are returned to the caller when a new credential is created, or a new asser
 
     dictionary AuthenticatorAttestationResponseJSON {
         required Base64URLString clientDataJSON;
-        required Base64URLString attestationObject;
+        required Base64URLString authenticatorData;
+        required long long publicKeyAlgorithm;
         required sequence<DOMString> transports;
+
+        // This field is missing if pubKeyCredParams was used to negotiate
+        // a public-key algorithm that the user agent doesn't understand.
+        // (See section “Easily accessing credential data” for a list of
+        // which algorithms user agents must support.) If using such an
+        // algorithm then the public key must be parsed from
+        // attestationObject directly.
+        Base64URLString publicKey;
+
+        // This value contains copies of some of the fields above. See
+        // section “Easily accessing credential data”.
+        required Base64URLString attestationObject;
     };
 
     dictionary AuthenticationResponseJSON {

--- a/index.bs
+++ b/index.bs
@@ -1618,17 +1618,15 @@ that are returned to the caller when a new credential is created, or a new asser
     dictionary AuthenticatorAttestationResponseJSON {
         required Base64URLString clientDataJSON;
         required Base64URLString authenticatorData;
-        required long long publicKeyAlgorithm;
         required sequence<DOMString> transports;
-
-        // This field is missing if pubKeyCredParams was used to negotiate
-        // a public-key algorithm that the user agent doesn't understand.
-        // (See section “Easily accessing credential data” for a list of
-        // which algorithms user agents must support.) If using such an
-        // algorithm then the public key must be parsed from
-        // attestationObject directly.
+	// The publicKey field will be missing if pubKeyCredParams was used to
+	// negotiate a public-key algorithm that the user agent doesn't
+	// understand. (See section “Easily accessing credential data” for a
+	// list of which algorithms user agents must support.) If using such an
+	// algorithm then the public key must be parsed from attestationObject
+	// directly.
         Base64URLString publicKey;
-
+        required long long publicKeyAlgorithm;
         // This value contains copies of some of the fields above. See
         // section “Easily accessing credential data”.
         required Base64URLString attestationObject;

--- a/index.bs
+++ b/index.bs
@@ -1619,12 +1619,12 @@ that are returned to the caller when a new credential is created, or a new asser
         required Base64URLString clientDataJSON;
         required Base64URLString authenticatorData;
         required sequence<DOMString> transports;
-	// The publicKey field will be missing if pubKeyCredParams was used to
-	// negotiate a public-key algorithm that the user agent doesn't
-	// understand. (See section “Easily accessing credential data” for a
-	// list of which algorithms user agents must support.) If using such an
-	// algorithm then the public key must be parsed from attestationObject
-	// directly.
+        // The publicKey field will be missing if pubKeyCredParams was used to
+        // negotiate a public-key algorithm that the user agent doesn't
+        // understand. (See section “Easily accessing credential data” for a
+        // list of which algorithms user agents must support.) If using such an
+        // algorithm then the public key must be parsed from attestationObject
+        // directly.
         Base64URLString publicKey;
         required long long publicKeyAlgorithm;
         // This value contains copies of some of the fields above. See


### PR DESCRIPTION
The WebAuthn API provides accessors to get the SPKI-formatted public key and authenticator data without needing to parse CBOR or handle COSE. However, the JSON structures, prior to this change, didn't include these values giving users an unfortunate choice: either use the accessors and do the JSON encoding yourself, or use the provided `toJSON` function.

But we can have both!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1887.html" title="Last updated on May 17, 2023, 7:12 PM UTC (5d62f33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1887/dbd8df4...5d62f33.html" title="Last updated on May 17, 2023, 7:12 PM UTC (5d62f33)">Diff</a>