### PR TITLE
Add new isPasskeyPlatformAuthenticatorAvailable() method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4392,13 +4392,10 @@ typically a PIN or [=biometric recognition=].
 The [=authenticator=] can thus act as two kinds of [=authentication factor=],
 which enables [=multi-factor=] authentication while eliminating the need to share a password with the [=[RP]=].
 
-The four combinations not named in <a href="#table-authenticatorTypes">Table <span class="table-ref-previous"/></a>
+The combinations not named in <a href="#table-authenticatorTypes">Table <span class="table-ref-previous"/></a>
 have less distinguished use cases:
 
 
-- The [=credential storage modality=] is less relevant for a [=platform authenticator=] than for a [=roaming authenticator=],
-    since users using a [=platform authenticator=] can typically be identified by a session cookie or the like
-    (i.e., ambient credentials).
 - A [=roaming authenticator=] that is [=discoverable credential capable=] but not [=multi-factor capable=]
     can be used for [=single-factor=] authentication without a username,
     where the user is automatically identified by the [=user handle=]

--- a/index.bs
+++ b/index.bs
@@ -2762,9 +2762,9 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 <div link-for-hint="WebAuthentication/isPasskeyPlatformAuthenticatorAvailable">
 
-[=[WRPS]=] use this method to determine whether they can create a new [=passkey=] using a [=user-verifying platform authenticator=] or a [=hybrid=] authenticator.
+[=[WRPS]=] use this method to determine whether they can create a new [=passkey=] using a [=user-verifying platform authenticator=] or a {{AuthenticatorTransport/hybrid}} authenticator.
 Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the 
-availability of [=hybrid=] transport.
+availability of {{AuthenticatorTransport/hybrid}} transport.
 If one or both are discovered, the promise is resolved with the value of [TRUE].
 If neither are discovered, the promise is resolved with the value of [FALSE].
 Based on the result, the [=[RP]=] can take further actions to guide the user to create a [=passkey=].

--- a/index.bs
+++ b/index.bs
@@ -2758,6 +2758,29 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 </div>
 
+### Availability of a [=passkey platform authenticator=] - PublicKeyCredential's `isPasskeyPlatformAuthenticatorAvailable()` Method ### {#sctn-isPasskeyPlatformAuthenticatorAvailable}
+
+<div link-for-hint="WebAuthentication/isPasskeyPlatformAuthenticatorAvailable">
+
+[=[WRPS]=] use this method to determine whether they can create a new [=passkey=] using a [=user-verifying platform authenticator=] or a [=hybrid=] authenticator.
+Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the 
+availability of [=hybrid=] transport.
+If one or both are discovered, the promise is resolved with the value of [TRUE].
+If neither are discovered, the promise is resolved with the value of [FALSE].
+Based on the result, the [=[RP]=] can take further actions to guide the user to create a [=passkey=].
+
+This method has no arguments and returns a Boolean value.
+
+<xmp class="idl">
+    partial interface PublicKeyCredential {
+        static Promise<boolean> isPasskeyPlatformAuthenticatorAvailable();
+    };
+</xmp>
+
+Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=permissions policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-permissions-policy]].
+
+</div>
+
 ### Deserialize Registration ceremony options - PublicKeyCredential's `parseCreationOptionsFromJSON()` Method ### {#sctn-parseCreationOptionsFromJSON}
 
 <div link-for-hint="WebAuthentication/parseCreationOptionsFromJSON">

--- a/index.bs
+++ b/index.bs
@@ -2766,7 +2766,7 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the 
 availability of {{AuthenticatorTransport/hybrid}} transport.
 If one or both are discovered, the promise is resolved with the value of [TRUE].
-If neither are discovered, the promise is resolved with the value of [FALSE].
+If neither is discovered, the promise is resolved with the value of [FALSE].
 Based on the result, the [=[RP]=] can take further actions to guide the user to create a [=passkey=].
 
 This method has no arguments and returns a Boolean value.

--- a/index.bs
+++ b/index.bs
@@ -1043,6 +1043,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Client-side discoverable Public Key Credential Source</dfn>
 : <dfn>Client-side discoverable Credential</dfn>
 : <dfn>Discoverable Credential</dfn>
+: <dfn>Passkey</dfn>
 : \[DEPRECATED] <dfn>Resident Credential</dfn>
 : \[DEPRECATED] <dfn>Resident Key</dfn>
 :: Note: Historically, [=client-side discoverable credentials=] have  been known as [=resident credentials=] or [=resident keys=].

--- a/index.bs
+++ b/index.bs
@@ -4343,7 +4343,7 @@ lists and names some [=authenticator types=] of particular interest.
                 <td> [=Multi-factor capable=] </td>
             </tr>
             <tr>
-                <th> <dfn>Platform passkey authenticator</dfn> </th>
+                <th> <dfn>Passkey platform authenticator</dfn> </th>
                 <td> [=platform attachment|platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/internal}}) or [=cross-platform attachment|cross-platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/hybrid}})</td>
                 <td> [=client-side credential storage modality|Client-side storage=] </td>
                 <td> [=Multi-factor capable=] </td>

--- a/index.bs
+++ b/index.bs
@@ -4296,8 +4296,8 @@ For example:
 
 The above examples illustrate the primary <dfn>authenticator type</dfn> characteristics:
 
-- Whether the [=authenticator=] is a [=roaming authenticator|roaming=] or [=platform authenticator|platform=] authenticator
-    &mdash; the [=authenticator attachment modality=].
+- Whether the [=authenticator=] is a [=roaming authenticator|roaming=] or [=platform authenticator|platform=] authenticator,
+    or in some cases both &mdash; the [=authenticator attachment modality=].
     A [=roaming authenticator=] can support one or more [[#enum-transport|transports]] for communicating with the [=client=].
 - Whether the authenticator is capable of [=user verification=] &mdash; the [=authentication factor capability=].
 - Whether the authenticator is [=discoverable credential capable=] &mdash; the [=credential storage modality=].
@@ -4339,6 +4339,12 @@ lists and names some [=authenticator types=] of particular interest.
             <tr>
                 <th> <dfn>First-factor roaming authenticator</dfn> </th>
                 <td> [=cross-platform attachment|cross-platform=] </td>
+                <td> [=client-side credential storage modality|Client-side storage=] </td>
+                <td> [=Multi-factor capable=] </td>
+            </tr>
+            <tr>
+                <th> <dfn>Platform passkey authenticator</dfn> </th>
+                <td> [=platform attachment|platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/internal}}) or [=cross-platform attachment|cross-platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/hybrid}})</td>
                 <td> [=client-side credential storage modality|Client-side storage=] </td>
                 <td> [=Multi-factor capable=] </td>
             </tr>


### PR DESCRIPTION
The current developer guidance to relying parties for whether they can offer passkeys to users is to call `isUVPAA()` and `isConditionalMediationAvailable()`. One returns a boolean, the other a promise. This is already complex . This also doesn't tell the whole story. For example, in Chrome and Edge on Ubuntu, users can currently create a syncable passkey on another device such as a phone or tablet using Cross-Device Authentication (hybrid transport). There is no way for a relying party to know this today, and passkeys won't be offered to users. This is a similar case with smart displays and other devices such as kiosks.

This method is designed to be a very simple way for the majority of developers to detect whether they can offer passkeys to users.

For more advanced use cases, `isUVPAA()` remains available, and an upcoming PR will introduce a more advanced feature detection method for things like specific transports (e.g. is just hybrid available) and CTAP2 security keys with client PIN entry support.

This was originally proposed during the WebAuthn F2F in April 2023.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1901.html" title="Last updated on Jun 28, 2023, 2:13 PM UTC (8813987)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1901/ad61c6f...8813987.html" title="Last updated on Jun 28, 2023, 2:13 PM UTC (8813987)">Diff</a>