### PR TITLE
Define RP processing of be and bs flags during `.create()` and `.get()`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5292,7 +5292,7 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 1. If the [=[RP]=] requires [=user verification=] for this registration,
     verify that the [=authData/flags/UV=] bit of the <code>[=flags=]</code> in |authData| is set.
 
-1. If the credential's [=backup eligibility=] is not set, verify that the credential's [=backup state=] is not set.
+1. If the [=authData/flags/BE=] bit of the <code>[=flags=]</code> in |authData| is not set, verify that the [=authData/flags/BS=] bit is not set.
 
 1. If the [=[RP]=] uses the credential's [=backup eligibility=] to inform its user experience flows and/or policies, evaluate the
     [=authData/flags/BE=] bit of the <code>[=flags=]</code> in |authData|.

--- a/index.bs
+++ b/index.bs
@@ -5292,6 +5292,8 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 1. If the [=[RP]=] requires [=user verification=] for this registration,
     verify that the [=authData/flags/UV=] bit of the <code>[=flags=]</code> in |authData| is set.
 
+1. If the credential's [=backup eligibility=] is not set, verify that the credential's [=backup state=] is not set.
+
 1. If the [=[RP]=] uses the credential's [=backup eligibility=] to inform its user experience flows and/or policies, evaluate the
     [=authData/flags/BE=] bit of the <code>[=flags=]</code> in |authData|.
 

--- a/index.bs
+++ b/index.bs
@@ -5527,6 +5527,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
     1. If <code>|credentialRecord|.[$credential record/backupEligible$]</code> is set, verify that |currentBe| is set.
 
+    1. If <code>|credentialRecord|.[$credential record/backupEligible$]</code> is not set, verify that |currentBe| is not set.
+
     1. If <code>|credentialRecord|.[$credential record/backupEligible$]</code> is not set, verify that |currentBs| is not set.
 
     1. Apply [=[RP]=] policy, if any.

--- a/index.bs
+++ b/index.bs
@@ -5519,6 +5519,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     verify that the [=authData/flags/UV=] bit of the <code>[=flags=]</code> in |authData| is set.
     Otherwise, ignore the value of the [=authData/flags/UV=] [=flag=].
 
+1. If the [=authData/flags/BE=] bit of the <code>[=flags=]</code> in |authData| is not set, verify that the [=authData/flags/BS=] bit is not set.
+
 1. If the credential [=backup state=] is used as part of [=[RP]=] business logic or policy,
     let |currentBe| and |currentBs| be the values of the [=authData/flags/BE=] and [=authData/flags/BS=] bits, respectively,
     of the <code>[=flags=]</code> in |authData|.

--- a/index.bs
+++ b/index.bs
@@ -5523,8 +5523,13 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     let |currentBe| and |currentBs| be the values of the [=authData/flags/BE=] and [=authData/flags/BS=] bits, respectively,
     of the <code>[=flags=]</code> in |authData|.
     Compare |currentBe| and |currentBs| with
-    <code>|credentialRecord|.[$credential record/backupEligible$]</code> and <code>|credentialRecord|.[$credential record/backupState$]</code>
-    and apply [=[RP]=] policy, if any.
+    <code>|credentialRecord|.[$credential record/backupEligible$]</code> and <code>|credentialRecord|.[$credential record/backupState$]</code>:
+
+    1. If <code>|credentialRecord|.[$credential record/backupEligible$]</code> is set, verify that |currentBe| is set.
+
+    1. If <code>|credentialRecord|.[$credential record/backupEligible$]</code> is not set, verify that |currentBs| is not set.
+
+    1. Apply [=[RP]=] policy, if any.
 
     Note: See [[#sctn-credential-backup]] for examples of how a [=[RP]=] might process the [=authData/flags/BS=] [=flag=] values.
 

--- a/index.bs
+++ b/index.bs
@@ -5531,8 +5531,6 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
     1. If <code>|credentialRecord|.[$credential record/backupEligible$]</code> is not set, verify that |currentBe| is not set.
 
-    1. If <code>|credentialRecord|.[$credential record/backupEligible$]</code> is not set, verify that |currentBs| is not set.
-
     1. Apply [=[RP]=] policy, if any.
 
     Note: See [[#sctn-credential-backup]] for examples of how a [=[RP]=] might process the [=authData/flags/BS=] [=flag=] values.


### PR DESCRIPTION
The spec was light on details on how to handle a couple of states of the `be` and `bs` flags coming out of calls to `.create()` and `.get()`. This PR tries to clarify RP handling of potential combinations of these flags during registration and authentication:

1. A device-bound credential indicates that it is backed up during registration (`be:0+bs:1`)
2. A device-bound credential indicates that it is backed up after authentication (`be:0+bs:1`)
3. A credential's backup eligibility changes after registration (`be:0 -> be:1` or `be:1 -> be:0`)

This should address #1791.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1907.html" title="Last updated on Jul 12, 2023, 1:54 PM UTC (4514f5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1907/6dfbdba...4514f5f.html" title="Last updated on Jul 12, 2023, 1:54 PM UTC (4514f5f)">Diff</a>