### PR TITLE
Update Authenticator Definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -952,13 +952,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>[WAA]</dfn>
 :: A cryptographic entity, existing in hardware or software, that can [=registration|register=] a user with a given [=[RP]=]
     and later [=Authentication Assertion|assert possession=] of the registered [=public key credential=], and optionally
-    [=user verification|verify the user=] when requested by the [=[RP]=]. [=Authenticators=] can report information
+    [=user verification|verify the user=] to the [=[RP]=]. [=Authenticators=] can report information
     regarding their [=authenticator types|type=] and security characteristics via [=attestation=] during [=registration=]
     and [=assertion=].
 
     A [=[WAA]=] could be a [=roaming authenticator=], a dedicated hardware subsystem integrated into the [=client device=],
     or a software component of the [=client=] or [=client device=]. A [=[WAA]=] is not necessarily confined to operating in 
-    a local context, and can generate or store a [=credential key pair=] in a server outside of the [=client device=].
+    a local context, and can generate or store a [=credential key pair=] in a server outside of [=client-side=] hardware.
 
     In general, an [=authenticator=] is assumed to have only one user.
     If multiple natural persons share access to an [=authenticator=],

--- a/index.bs
+++ b/index.bs
@@ -952,11 +952,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>[WAA]</dfn>
 :: A cryptographic entity, existing in hardware or software, that can [=registration|register=] a user with a given [=[RP]=]
     and later [=Authentication Assertion|assert possession=] of the registered [=public key credential=], and optionally
-    [=user verification|verify the user=], when requested by the [=[RP]=]. [=Authenticators=] can report information
-    regarding their [=authenticator types|type=] and security characteristics via [=attestation=] during [=registration=].
+    [=user verification|verify the user=] when requested by the [=[RP]=]. [=Authenticators=] can report information
+    regarding their [=authenticator types|type=] and security characteristics via [=attestation=] during [=registration=]
+    and [=assertion=].
 
     A [=[WAA]=] could be a [=roaming authenticator=], a dedicated hardware subsystem integrated into the [=client device=],
-    or a software component of the [=client=] or [=client device=].
+    or a software component of the [=client=] or [=client device=]. A [=[WAA]=] is not necessarily confined to operating in 
+    a local context, and can generate or store a [=credential key pair=] in a server outside of the [=client device=].
 
     In general, an [=authenticator=] is assumed to have only one user.
     If multiple natural persons share access to an [=authenticator=],


### PR DESCRIPTION
This addresses #1743 by updating the authenticator definition to denote that an authenticator does not have to be wholly local without going into more detail on concepts like an identity fabric.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1931.html" title="Last updated on Jul 26, 2023, 9:52 PM UTC (aff97c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1931/5bd3dd1...aff97c2.html" title="Last updated on Jul 26, 2023, 9:52 PM UTC (aff97c2)">Diff</a>