### PR TITLE
Clarify distinction between PublicKeyCredentialUserEntity name and displayName

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2784,7 +2784,7 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 <div link-for-hint="WebAuthentication/isPasskeyPlatformAuthenticatorAvailable">
 
 [=[WRPS]=] use this method to determine whether they can create a new [=passkey=] using a [=user-verifying platform authenticator=] or a {{AuthenticatorTransport/hybrid}} authenticator.
-Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the 
+Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the
 availability of {{AuthenticatorTransport/hybrid}} transport.
 If one or both are discovered, the promise is resolved with the value of [TRUE].
 If neither is discovered, the promise is resolved with the value of [FALSE].
@@ -3186,9 +3186,12 @@ associated with or [=scoped=] to, respectively.
           - When inherited by {{PublicKeyCredentialUserEntity}}, it is a
             [=human palatability|human-palatable=] identifier for a [=user account=]. This
             identifier is the primary value displayed to users by [=Clients=] to help users
-            understand with which [=user account=] a credential is associated. Examples of suitable
-            values for this identifier include, "alexm", "alex.mueller@example.com", or
-            "+14255551234".
+            understand with which [=user account=] a credential is associated. The [=[RP]=] MAY
+            extend the identifier to help a user differentiate between multiple credentials for
+            a single [=user account=] when the same value would otherwise be used for all
+            credentials.
+
+            Examples of suitable values for this identifier include, "alex.mueller@example.com (Production)", "alexm", or "+14255551234".
 
               - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,
                 as prescribed in Section 3.4.3 of [[!RFC8265]] for the UsernameCasePreserved Profile of the PRECIS
@@ -3257,13 +3260,10 @@ credential.
 
     :   <dfn>displayName</dfn>
     ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for
-        display. [=Clients=] may display this value to help users differentiate between multiple
-        [=credentials=] with the same value of {{PublicKeyCredentialEntity/name}}. Examples of
-        suitable values for this identifier include, "Alex Müller" or "田中倫".
+        display. The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice
+        more than necessary. The [=[RP]=] MAY set this to the same value as {{PublicKeyCredentialEntity/name}}.
 
-        The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
-
-        The [=[RP]=] MAY set this to the same value as {{PublicKeyCredentialEntity/name}}.
+        Examples of suitable values for this identifier include, "Alex Müller (ACME Co.)" or "田中倫".
 
         - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],

--- a/index.bs
+++ b/index.bs
@@ -3258,8 +3258,8 @@ credential.
         [=Clients=] may display this value to help users differentiate between multiple sub-accounts for a
         given [=user account=] for situations in which every credential uses the same value for
         {{PublicKeyCredentialEntity/name}}. When such differentiation is not required, this value
-        MAY be set to the same value as {{PublicKeyCredentialEntity/name}}. Examples of suitable values for this identifier include,
-        "Alex Müller" or "田中倫".
+        MAY be set to the same value as {{PublicKeyCredentialEntity/name}}. Examples of suitable
+        values for this identifier include, "Alex Müller" or "田中倫".
 
         A [=[RP]=] MAY let the user specify this value, and SHOULD NOT restrict the choice
         more than necessary when doing so.

--- a/index.bs
+++ b/index.bs
@@ -3254,8 +3254,12 @@ credential.
         with more than one [=user account=] at the [=[RP]=].
 
     :   <dfn>displayName</dfn>
-    ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for display. For example, "Alex Müller" or "田中倫". The
-        [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
+    ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for display.
+        [=Clients=] may display this value to help users differentiate between multiple sub-accounts for a
+        given [=user account=] for situations in which every credential uses the same value for
+        {{PublicKeyCredentialEntity/name}}. Examples of suitable values for this identifier include,
+        "Alex Müller" or "田中倫". The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict
+        the choice more than necessary.
 
         - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],

--- a/index.bs
+++ b/index.bs
@@ -3183,10 +3183,12 @@ associated with or [=scoped=] to, respectively.
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
-          - When inherited by {{PublicKeyCredentialUserEntity}}, it is a [=human palatability|human-palatable=] identifier for a
-            [=user account=]. This identifier is the primary value displayed to users by [=Clients=] to help users understand with which
-            [=user account=] a credential is associated. Examples of suitable values for this identifier include, "alexm", "alex.mueller@example.com"
-            or "+14255551234".
+          - When inherited by {{PublicKeyCredentialUserEntity}}, it is a
+            [=human palatability|human-palatable=] identifier for a [=user account=]. This
+            identifier is the primary value displayed to users by [=Clients=] to help users
+            understand with which [=user account=] a credential is associated. Examples of suitable
+            values for this identifier include, "alexm", "alex.mueller@example.com", or
+            "+14255551234".
 
               - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,
                 as prescribed in Section 3.4.3 of [[!RFC8265]] for the UsernameCasePreserved Profile of the PRECIS

--- a/index.bs
+++ b/index.bs
@@ -3186,12 +3186,11 @@ associated with or [=scoped=] to, respectively.
           - When inherited by {{PublicKeyCredentialUserEntity}}, it is a
             [=human palatability|human-palatable=] identifier for a [=user account=]. This
             identifier is the primary value displayed to users by [=Clients=] to help users
-            understand with which [=user account=] a credential is associated. The [=[RP]=] MAY
-            extend the identifier to help a user differentiate between multiple credentials for
-            a single [=user account=] when the same value would otherwise be used for all
-            credentials.
+            understand with which [=user account=] a credential is associated.
 
-            Examples of suitable values for this identifier include, "alex.mueller@example.com (Production)", "alexm", or "+14255551234".
+            Examples of suitable values for this identifier include, "alexm", "+14255551234",
+            "alex.mueller@example.com", "alex.mueller@example.com (prod-env)",
+            "alex.mueller@example.com (ACME Corp.)", or "alex.mueller@example.com (ОАО Примертех)".
 
               - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,
                 as prescribed in Section 3.4.3 of [[!RFC8265]] for the UsernameCasePreserved Profile of the PRECIS

--- a/index.bs
+++ b/index.bs
@@ -3184,8 +3184,8 @@ associated with or [=scoped=] to, respectively.
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
           - When inherited by {{PublicKeyCredentialUserEntity}}, it is a [=human palatability|human-palatable=] identifier for a
-            [=user account=]. It is intended only for display, i.e., aiding the user in determining the difference between user
-            accounts with similar {{PublicKeyCredentialUserEntity/displayName}}s. For example, "alexm", "alex.mueller@example.com"
+            [=user account=]. This identifier is the primary value displayed to users by [=Clients=] to help users understand with which
+            [=user account=] a credential is associated. Examples of suitable values for this identifier include, "alexm", "alex.mueller@example.com"
             or "+14255551234".
 
               - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,

--- a/index.bs
+++ b/index.bs
@@ -3261,7 +3261,8 @@ credential.
     :   <dfn>displayName</dfn>
     ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for
         display. The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice
-        more than necessary. The [=[RP]=] MAY set this to the same value as {{PublicKeyCredentialEntity/name}}.
+        more than necessary. If no suitable or [=human palatability|human-palatable=] name is
+        available, the [=[RP]=] SHOULD set this value to an empty string.
 
         Examples of suitable values for this identifier include, "Alex Müller (ACME Co.)" or "田中倫".
 

--- a/index.bs
+++ b/index.bs
@@ -3256,15 +3256,14 @@ credential.
         with more than one [=user account=] at the [=[RP]=].
 
     :   <dfn>displayName</dfn>
-    ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for display.
-        [=Clients=] may display this value to help users differentiate between multiple sub-accounts for a
-        given [=user account=] for situations in which every credential uses the same value for
-        {{PublicKeyCredentialEntity/name}}. When such differentiation is not required, this value
-        MAY be set to the same value as {{PublicKeyCredentialEntity/name}}. Examples of suitable
-        values for this identifier include, "Alex Müller" or "田中倫".
+    ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for
+        display. [=Clients=] may display this value to help users differentiate between multiple
+        [=credentials=] with the same value of {{PublicKeyCredentialEntity/name}}. Examples of
+        suitable values for this identifier include, "Alex Müller" or "田中倫".
 
-        A [=[RP]=] MAY let the user specify this value, and SHOULD NOT restrict the choice
-        more than necessary when doing so.
+        The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
+
+        The [=[RP]=] MAY set this to the same value as {{PublicKeyCredentialEntity/name}}.
 
         - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],

--- a/index.bs
+++ b/index.bs
@@ -3190,7 +3190,7 @@ associated with or [=scoped=] to, respectively.
 
             Examples of suitable values for this identifier include, "alexm", "+14255551234",
             "alex.mueller@example.com", "alex.mueller@example.com (prod-env)",
-            "alex.mueller@example.com (ACME Corp.)", or "alex.mueller@example.com (ОАО Примертех)".
+            or "alex.mueller@example.com (ОАО Примертех)".
 
               - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,
                 as prescribed in Section 3.4.3 of [[!RFC8265]] for the UsernameCasePreserved Profile of the PRECIS
@@ -3263,7 +3263,7 @@ credential.
         more than necessary. If no suitable or [=human palatability|human-palatable=] name is
         available, the [=[RP]=] SHOULD set this value to an empty string.
 
-        Examples of suitable values for this identifier include, "Alex Müller (ACME Co.)" or "田中倫".
+        Examples of suitable values for this identifier include, "Alex Müller", "Alex Müller (ACME Co.)" or "田中倫".
 
         - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],

--- a/index.bs
+++ b/index.bs
@@ -3257,9 +3257,12 @@ credential.
     ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for display.
         [=Clients=] may display this value to help users differentiate between multiple sub-accounts for a
         given [=user account=] for situations in which every credential uses the same value for
-        {{PublicKeyCredentialEntity/name}}. Examples of suitable values for this identifier include,
-        "Alex Müller" or "田中倫". The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict
-        the choice more than necessary.
+        {{PublicKeyCredentialEntity/name}}. When such differentiation is not required, this value
+        MAY be set to the same value as {{PublicKeyCredentialEntity/name}}. Examples of suitable values for this identifier include,
+        "Alex Müller" or "田中倫".
+
+        A [=[RP]=] MAY let the user specify this value, and SHOULD NOT restrict the choice
+        more than necessary when doing so.
 
         - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],


### PR DESCRIPTION
This PR attempts to help RP's understand the differences between `user.name` and `user.displayName`. It most importantly establishes `user.name` as the primary value displayed by browsers to users. The definition of `user.displayName` has also been tweaked to emphasize that this value has utility to differentiate "sub-accounts" for a given `user.name`, but without encouraging its use as based on [observations I made back in February](https://github.com/w3c/webauthn/issues/1852#issuecomment-1429062522) only Android currently exposes this value.

Fixes #1852.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1932.html" title="Last updated on Sep 6, 2023, 5:42 PM UTC (aefe8f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1932/5bd3dd1...aefe8f2.html" title="Last updated on Sep 6, 2023, 5:42 PM UTC (aefe8f2)">Diff</a>