### PR TITLE
remove isPasskeyPlatformAuthenticatorAvailable()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2779,29 +2779,6 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 </div>
 
-### Availability of a [=passkey platform authenticator=] - PublicKeyCredential's `isPasskeyPlatformAuthenticatorAvailable()` Method ### {#sctn-isPasskeyPlatformAuthenticatorAvailable}
-
-<div link-for-hint="WebAuthentication/isPasskeyPlatformAuthenticatorAvailable">
-
-[=[WRPS]=] use this method to determine whether they can create a new [=passkey=] using a [=user-verifying platform authenticator=] or a {{AuthenticatorTransport/hybrid}} authenticator.
-Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the 
-availability of {{AuthenticatorTransport/hybrid}} transport.
-If one or both are discovered, the promise is resolved with the value of [TRUE].
-If neither is discovered, the promise is resolved with the value of [FALSE].
-Based on the result, the [=[RP]=] can take further actions to guide the user to create a [=passkey=].
-
-This method has no arguments and returns a Boolean value.
-
-<xmp class="idl">
-    partial interface PublicKeyCredential {
-        static Promise<boolean> isPasskeyPlatformAuthenticatorAvailable();
-    };
-</xmp>
-
-Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=permissions policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-permissions-policy]].
-
-</div>
-
 ### Deserialize Registration ceremony options - PublicKeyCredential's `parseCreationOptionsFromJSON()` Method ### {#sctn-parseCreationOptionsFromJSON}
 
 <div link-for-hint="WebAuthentication/parseCreationOptionsFromJSON">


### PR DESCRIPTION
This PR removes the `isPasskeyPlatformAuthenticatorAvailable()` method in favor of the `getClientCapabilities()` method defined in #1923.

See issue #1937 for additional context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1936.html" title="Last updated on Aug 9, 2023, 8:09 PM UTC (9606e71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1936/baa930a...9606e71.html" title="Last updated on Aug 9, 2023, 8:09 PM UTC (9606e71)">Diff</a>