### PR TITLE
remove passkey word

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2779,29 +2779,6 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 
 </div>
 
-### Availability of a [=passkey platform authenticator=] - PublicKeyCredential's `isPasskeyPlatformAuthenticatorAvailable()` Method ### {#sctn-isPasskeyPlatformAuthenticatorAvailable}
-
-<div link-for-hint="WebAuthentication/isPasskeyPlatformAuthenticatorAvailable">
-
-[=[WRPS]=] use this method to determine whether they can create a new [=passkey=] using a [=user-verifying platform authenticator=] or a {{AuthenticatorTransport/hybrid}} authenticator.
-Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the 
-availability of {{AuthenticatorTransport/hybrid}} transport.
-If one or both are discovered, the promise is resolved with the value of [TRUE].
-If neither is discovered, the promise is resolved with the value of [FALSE].
-Based on the result, the [=[RP]=] can take further actions to guide the user to create a [=passkey=].
-
-This method has no arguments and returns a Boolean value.
-
-<xmp class="idl">
-    partial interface PublicKeyCredential {
-        static Promise<boolean> isPasskeyPlatformAuthenticatorAvailable();
-    };
-</xmp>
-
-Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=permissions policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-permissions-policy]].
-
-</div>
-
 ### Deserialize Registration ceremony options - PublicKeyCredential's `parseCreationOptionsFromJSON()` Method ### {#sctn-parseCreationOptionsFromJSON}
 
 <div link-for-hint="WebAuthentication/parseCreationOptionsFromJSON">

--- a/index.bs
+++ b/index.bs
@@ -1043,7 +1043,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Client-side discoverable Public Key Credential Source</dfn>
 : <dfn>Client-side discoverable Credential</dfn>
 : <dfn>Discoverable Credential</dfn>
-: <dfn>Passkey</dfn>
 : \[DEPRECATED] <dfn>Resident Credential</dfn>
 : \[DEPRECATED] <dfn>Resident Key</dfn>
 :: Note: Historically, [=client-side discoverable credentials=] have  been known as [=resident credentials=] or [=resident keys=].
@@ -4364,7 +4363,7 @@ lists and names some [=authenticator types=] of particular interest.
                 <td> [=Multi-factor capable=] </td>
             </tr>
             <tr>
-                <th> <dfn>Passkey platform authenticator</dfn> </th>
+                <th> <dfn>Discoverable platform authenticator</dfn> </th>
                 <td> [=platform attachment|platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/internal}}) or [=cross-platform attachment|cross-platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/hybrid}})</td>
                 <td> [=client-side credential storage modality|Client-side storage=] </td>
                 <td> [=Multi-factor capable=] </td>


### PR DESCRIPTION
This PR removes the word "passkey"

See PR https://github.com/w3c/webauthn/pull/1936 for additional context.

+@maxhata


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ko-koiwai/webauthn/pull/1938.html" title="Last updated on Aug 4, 2023, 5:54 AM UTC (64207d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1938/5bd3dd1...ko-koiwai:64207d1.html" title="Last updated on Aug 4, 2023, 5:54 AM UTC (64207d1)">Diff</a>