### PR TITLE
Delete outdated note about checking registration UV with PRF extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6779,8 +6779,6 @@ Note: this extension may be implemented for [=authenticators=] that do not use [
        1. Set {{AuthenticationExtensionsPRFOutputs/enabled}} to the value of `hmac-secret` in the authenticator extensions output. If not present, set {{AuthenticationExtensionsPRFOutputs/enabled}} to [FALSE].
        1. Set {{AuthenticationExtensionsPRFOutputs/results}} to the decrypted PRF result(s), if any.
 
-Note: If PRF results are obtained during [=registration=] then the [=[RP]=] MUST inspect the [=UV=] bit in the [=flags=] of the response in order to determine the correct value of {{PublicKeyCredentialRequestOptions/userVerification}} for future [=assertions=]. Otherwise results from [=assertions=] may be inconsistent with those from the [=registration=].
-
 : Client extension processing ([=authentication extension|authentication=])
 ::
       1. If {{AuthenticationExtensionsPRFInputs/evalByCredential}} is not empty but {{PublicKeyCredentialRequestOptions/allowCredentials}} is empty, return a {{DOMException}} whose name is “{{NotSupportedError}}”.


### PR DESCRIPTION
Looks like this was left behind in #1836.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1944.html" title="Last updated on Aug 23, 2023, 1:42 PM UTC (7b877b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1944/bd68fbf...7b877b6.html" title="Last updated on Aug 23, 2023, 1:42 PM UTC (7b877b6)">Diff</a>