### PR TITLE
Add `compound` attestation format

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6273,7 +6273,7 @@ The "compound" attestation statement format is used to pass multiple, self-conta
 :: compound
 
 : Attestation types supported
-:: Any attestation type defined in this specification except `compound`
+:: Any attestation type defined in the IANA "WebAuthn Attestation Statement Format Identifiers" registry [[!IANA-WebAuthn-Registries]] except `compound`
 
 : Syntax
 :: The syntax of a compound attestation statement is defined as follows:

--- a/index.bs
+++ b/index.bs
@@ -6266,13 +6266,14 @@ This attestation statement format is exclusively used by Apple for certain types
 
 ## Compound Attestation Statement Format ## {#sctn-compound-attestation}
 
-The "compound" attestation statement format is used to pass multiple, self-contained attestation statements in a single ceremony.
+The "compound" attestation statement format is used to pass multiple, self-contained attestation statements in a single ceremony. This
+
 
 : Attestation statement format identifier
 :: compound
 
 : Attestation types supported
-:: Any attestation type defined in this specification
+:: Any attestation type defined in this specification except `compound`
 
 : Syntax
 :: The syntax of a compound attestation statement is defined as follows:
@@ -6286,7 +6287,7 @@ The "compound" attestation statement format is used to pass multiple, self-conta
     compoundAttStmts = []
     ```
 
-`compoundAttStmts` MUST NOT contain additional compound attestation statements.
+`compoundAttStmts` MUST contain two or more attestation statements which MUST NOT be compound attestation statements.
 
 : Signing procedure
 :: Not applicable

--- a/index.bs
+++ b/index.bs
@@ -6281,13 +6281,11 @@ The "compound" attestation statement format is used to pass multiple, self-conta
     ```
     $$attStmtType //= (
                           fmt: "compound",
-                          attStmt: compoundAttStmts
+                          attStmt: [2* nonCompoundAttStmt]
                       )
 
-    compoundAttStmts = []
+    nonCompoundAttStmt = { $$attStmtType } .within { fmt: text .ne "compound" }
     ```
-
-`compoundAttStmts` MUST contain two or more attestation statements which MUST NOT be compound attestation statements.
 
 : Signing procedure
 :: Not applicable

--- a/index.bs
+++ b/index.bs
@@ -6206,7 +6206,7 @@ if the [=authenticator=] does not support [=attestation=].
                           attStmt: emptyMap
                       )
 
-    compound = {}
+    emptyMap = {}
     ```
 
 : Signing procedure

--- a/index.bs
+++ b/index.bs
@@ -6272,7 +6272,7 @@ The "compound" attestation statement format is used to pass multiple, self-conta
 :: compound
 
 : Attestation types supported
-:: [=Basic=], [=AttCA=], [=Anonymization CA=]
+:: Any attestation type defined in this specification
 
 : Syntax
 :: The syntax of a compound attestation statement is defined as follows:

--- a/index.bs
+++ b/index.bs
@@ -6273,7 +6273,7 @@ The "compound" attestation statement format is used to pass multiple, self-conta
 :: compound
 
 : Attestation types supported
-:: Any attestation type defined in the IANA "WebAuthn Attestation Statement Format Identifiers" registry [[!IANA-WebAuthn-Registries]] except `compound`
+:: Any attestation type defined in the IANA "WebAuthn Attestation Statement Format Identifiers" registry [[!IANA-WebAuthn-Registries]] except for `compound`
 
 : Syntax
 :: The syntax of a compound attestation statement is defined as follows:

--- a/index.bs
+++ b/index.bs
@@ -6266,7 +6266,7 @@ This attestation statement format is exclusively used by Apple for certain types
 
 ## Compound Attestation Statement Format ## {#sctn-compound-attestation}
 
-The "compound" attestation statement format is used to pass multiple, self-contained attestation statements in a single ceremony. This
+The "compound" attestation statement format is used to pass multiple, self-contained attestation statements in a single ceremony.
 
 
 : Attestation statement format identifier

--- a/index.bs
+++ b/index.bs
@@ -6291,7 +6291,17 @@ The "compound" attestation statement format is used to pass multiple, self-conta
 :: Not applicable
 
 : Verification procedure
-:: For every element in the array, validate the attestation statement based on the verification procedure specified for that format (using the `fmt` identifier). If validation fails for one or more compound attestation statements, [=[RPS]=] should decide the appropriate results based on policy from information they have about the [=authenticators=].
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
+    as follows:
+    1. [=list/For each=] |subStmt| of |attStmt|, evaluate the [=verification procedure=]
+        corresponding to the [=attestation statement format identifier=] <code>|subStmt|.fmt</code>
+        with [=verification procedure inputs=] |subStmt|, |authenticatorData| and |clientDataHash|.
+
+        If validation fails for one or more |subStmt|, decide the appropriate result based on [=[RP]=] policy.
+
+    2. If sufficiently many (as determined by [=[RP]=] policy) [=list/items=] of |attStmt| verify successfully,
+        return implementation-specific values representing any combination of outputs from successful [=verification procedures=].
+        
 
 # <dfn>WebAuthn Extensions</dfn> # {#sctn-extensions}
 

--- a/index.bs
+++ b/index.bs
@@ -6273,7 +6273,7 @@ The "compound" attestation statement format is used to pass multiple, self-conta
 :: compound
 
 : Attestation types supported
-:: Any attestation type defined in the IANA "WebAuthn Attestation Statement Format Identifiers" registry [[!IANA-WebAuthn-Registries]] except for `compound`
+:: Any. See [[#sctn-attestation-types]].
 
 : Syntax
 :: The syntax of a compound attestation statement is defined as follows:

--- a/index.bs
+++ b/index.bs
@@ -6292,7 +6292,7 @@ The "compound" attestation statement format is used to pass multiple, self-conta
 :: Not applicable
 
 : Verification procedure
-:: For every element in the array, validate the attestation statement based on the verification procedure specified for that format (using the `fmt` identifier).
+:: For every element in the array, validate the attestation statement based on the verification procedure specified for that format (using the `fmt` identifier). If validation fails for one or more compound attestation statements, [=[RPS]=] should decide the appropriate results based on policy from information they have about the [=authenticators=].
 
 # <dfn>WebAuthn Extensions</dfn> # {#sctn-extensions}
 

--- a/index.bs
+++ b/index.bs
@@ -6206,7 +6206,7 @@ if the [=authenticator=] does not support [=attestation=].
                           attStmt: emptyMap
                       )
 
-    emptyMap = {}
+    compound = {}
     ```
 
 : Signing procedure
@@ -6263,6 +6263,36 @@ This attestation statement format is exclusively used by Apple for certain types
     4. Verify that |nonce| equals the value of the extension with OID `1.2.840.113635.100.8.2` in |credCert|.
     5. Verify that the [=credential public key=] equals the Subject Public Key of |credCert|.
     6. If successful, return implementation-specific values representing attestation type [=Anonymization CA=] and attestation trust path |x5c|.
+
+## Compound Attestation Statement Format ## {#sctn-compound-attestation}
+
+The "compound" attestation statement format is used to pass multiple, self-contained attestation statements in a single ceremony.
+
+: Attestation statement format identifier
+:: compound
+
+: Attestation types supported
+:: [=Basic=], [=AttCA=], [=Anonymization CA=]
+
+: Syntax
+:: The syntax of a compound attestation statement is defined as follows:
+
+    ```
+    $$attStmtType //= (
+                          fmt: "compound",
+                          attStmt: compoundAttStmts
+                      )
+
+    compoundAttStmts = []
+    ```
+
+`compoundAttStmts` MUST NOT contain additional compound attestation statements.
+
+: Signing procedure
+:: Not applicable
+
+: Verification procedure
+:: For every element in the array, validate the attestation statement based on the verification procedure specified for that format (using the `fmt` identifier).
 
 # <dfn>WebAuthn Extensions</dfn> # {#sctn-extensions}
 


### PR DESCRIPTION
This PR defines a new attestation format, named `compound`, which allows for multiple attestation statements to be included in a single ceremony. 

The primary use case is for passkey providers which need statements about both the key and the app-based provider.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1950.html" title="Last updated on Oct 5, 2023, 5:02 PM UTC (e0a4f31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1950/bd68fbf...e0a4f31.html" title="Last updated on Oct 5, 2023, 5:02 PM UTC (e0a4f31)">Diff</a>