### PR TITLE
Add packed attestation optional firmware version attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5831,11 +5831,11 @@ The attestation certificate MUST have the following fields/extensions:
 
 - The Basic Constraints extension MUST have the CA component set to [FALSE].
 
-Additionally, an Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension 
+Additionally, an Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension
     [[RFC5280]] are both OPTIONAL as the status of many attestation certificates is available through authenticator metadata
     services. See, for example, the FIDO Metadata Service [[FIDOMetadataService]].
 
-The firmware of a particular authenticator model MAY be differentiated using the Extension OID `1.3.6.1.4.1.45724.1.1.5` 
+The firmware of a particular authenticator model MAY be differentiated using the Extension OID `1.3.6.1.4.1.45724.1.1.5`
     (`id-fido-gen-ce-fw-version`). When present, this attribute contains an INTEGER with a non-negative value which is incremented for new
     firmware release versions. The extension MUST NOT be marked as critical.
 
@@ -5867,8 +5867,8 @@ The attributes above are structured within this certificate as such:
       65 3B 00 79 7D 03 CA 3C 
 
 30 12                                    -- SEQUENCE
-  06 0B 2B 06 01 04 01 82 E5 1C 01 01 05 -- OID 1.3.6.1.4.1.45724.1.1.4
-  04 03                                  -- OCTET STRING 
+  06 0B 2B 06 01 04 01 82 E5 1C 01 01 05 -- OID 1.3.6.1.4.1.45724.1.1.5
+  04 03                                  -- OCTET STRING
     02 01                                -- INTEGER
       2A                                 -- Firmware version: 42
 ~~~

--- a/index.bs
+++ b/index.bs
@@ -5841,45 +5841,37 @@ The firmware of a particular authenticator model MAY be differentiated using the
 
 For example, the following is an attestation certificate containing the above extension OIDs as well as required fields:
 
-<pre>
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number: 16909060 (0x1020304)
-        Signature Algorithm: sha256WithRSAEncryption
-        Issuer: CN = Example attestation certificate
-        Validity
-            Not Before: Aug  1 00:00:00 2014 GMT
-            Not After : Sep  4 00:00:00 2050 GMT
-        Subject: C = US, O = WebAuthn WG, CN = Attestation example
-        Subject Public Key Info:
-            Public Key Algorithm: id-ecPublicKey
-                Public-Key: (256 bit)
-                ASN1 OID: prime256v1
-                NIST CURVE: P-256
-        X509v3 extensions:
-            1.3.6.1.4.1.45724.1.1.4:
-                ....9\&...e;.y}..<
-            1.3.6.1.4.1.45724.1.1.5:
-                ..*
-            X509v3 Basic Constraints: critical
-                CA:FALSE
------BEGIN CERTIFICATE----- <!-- needs more text to prevent bikeshed emdash markdown bug -->
-MIICZzCCAU+gAwIBAgIEAQIDBDANBgkqhkiG9w0BAQsFADAqMSgwJgYDVQQDEx9F
-eGFtcGxlIGF0dGVzdGF0aW9uIGNlcnRpZmljYXRlMCAXDTE0MDgwMTAwMDAwMFoY
-DzIwNTAwOTA0MDAwMDAwWjBBMQswCQYDVQQGEwJVUzEUMBIGA1UECgwLV2ViQXV0
-aG4gV0cxHDAaBgNVBAMME0F0dGVzdGF0aW9uIGV4YW1wbGUwWTATBgcqhkjOPQIB
-BggqhkjOPQMBBwNCAAR56jssfElwEGIjDNI/62DlKTFx1IPxAL6FnWsPg5cDAbVG
-zdRuz8rj4/MPgentYr0mjUwevTezvL6SqMKu6046o0cwRTAhBgsrBgEEAYLlHAEB
-BAQSBBDNjDlcJu3u3mU7AHl9A8o8MBIGCysGAQQBguUcAQEFBAMCASowDAYDVR0T
-AQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAQEAl50Dl9hg+C7hXTEceW66+yL6p+CE
-2bq0xhu7V/PmtMGKSDe4XDxO2+SDQ/TWpdmxztqK4f7UkSkhcwWOXuHL3WvawHVX
-xqDo02gluhWef7WtjNr4BIaM+Q6PH4rqF8AWtVwqetSXyJT7cddT15uaSEtsN21y
-O5mNLh1DBr8QM7Wu+Myly7JWi2kkIm0io1irfYfkrF8uCRqnFXnzpWkJSX1y9U4G
-usHDtEE7ul6vlMO2TzT566Qay2rig3dtNkZTeEj+6IS93fWxuleYVM/9zrrDRAWV
-J+Vt1Zj49WZxWr5DAd0ZETDmufDGQDkSU+IpgD867ydL7b/eP8u9QurWeQ==
------END CERTIFICATE-----
-</pre>
+~~~ pem
+-----BEGIN CERTIFICATE----- <!-- bikeshed emdash workaround -->
+MIIBzTCCAXOgAwIBAgIUYHS3FJEL/JTfFqafuAHvlAS+hDYwCgYIKoZIzj0EAwIw
+QTELMAkGA1UEBhMCVVMxFDASBgNVBAoMC1dlYkF1dGhuIFdHMRwwGgYDVQQDDBNF
+eGFtcGxlIEF0dGVzdGF0aW9uMCAXDTI0MDEwMzE3NDUyMVoYDzIwNTAwMTA2MTc0
+NTIxWjBBMQswCQYDVQQGEwJVUzEUMBIGA1UECgwLV2ViQXV0aG4gV0cxHDAaBgNV
+BAMME0V4YW1wbGUgQXR0ZXN0YXRpb24wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+AATDQN9uaFFH4BKBjthHTM1drpb7gIuPod67qyF6UdL4qah6XUp6tE7Prl+DfQ7P
+YH9yMOOcci3nr+Q/jOBaWVERo0cwRTAhBgsrBgEEAYLlHAEBBAQSBBDNjDlcJu3u
+3mU7AHl9A8o8MBIGCysGAQQBguUcAQEFBAMCASowDAYDVR0TAQH/BAIwADAKBggq
+hkjOPQQDAgNIADBFAiA3k3aAUVtLhDHLXOgY2kRnK2hrbRgf2EKdTDLJ1Ds/RAIh
+AOmIblhI3ALCHOaO0IO7YlMpw/lSTvFYv3qwO3m7H8Dc
+-----END CERTIFICATE----- <!-- bikeshed emdash workaround -->
+~~~
+
+The attributes above are structured within this certificate as such:
+
+~~~ text
+30 21                                    -- SEQUENCE
+  06 0B 2B 06 01 04 01 82 E5 1C 01 01 04 -- OID 1.3.6.1.4.1.45724.1.1.4
+  04 12                                  -- OCTET STRING
+    04  10                               -- OCTET STRING
+      CD 8C 39 5C 26 ED EE DE            -- AAGUID cd8c395c-26ed-eede-653b-00797d03ca3c
+      65 3B 00 79 7D 03 CA 3C 
+
+30 12                                    -- SEQUENCE
+  06 0B 2B 06 01 04 01 82 E5 1C 01 01 05 -- OID 1.3.6.1.4.1.45724.1.1.4
+  04 03                                  -- OCTET STRING 
+    02 01                                -- INTEGER
+      2A                                 -- Firmware version: 42
+~~~
 
 ## TPM Attestation Statement Format ## {#sctn-tpm-attestation}
 

--- a/index.bs
+++ b/index.bs
@@ -5827,16 +5827,7 @@ The attestation certificate MUST have the following fields/extensions:
     The extension MUST NOT be marked as critical.
 
     Note that an X.509 Extension encodes the DER-encoding of the value in an OCTET STRING.
-    Thus, the AAGUID MUST be wrapped in <i>two</i> OCTET STRINGS to be valid. Here is a sample, encoded Extension structure:
-
-    <pre>
-  30 21                                     -- SEQUENCE
-    06 0b 2b 06 01 04 01 82 e5 1c 01 01 04  -- 1.3.6.1.4.1.45724.1.1.4
-    04 12                                   -- OCTET STRING
-      04 10                                 -- OCTET STRING
-        cd 8c 39 5c 26 ed ee de             -- AAGUID
-        65 3b 00 79 7d 03 ca 3c
-    </pre>
+    Thus, the AAGUID MUST be wrapped in <i>two</i> OCTET STRINGS to be valid.
 
 - The Basic Constraints extension MUST have the CA component set to [FALSE].
 
@@ -5847,6 +5838,48 @@ Additionally, an Authority Information Access (AIA) extension with entry `id-ad-
 The firmware of a particular authenticator model MAY be differentiated using the Extension OID `1.3.6.1.4.1.45724.1.1.5` 
     (`id-fido-gen-ce-fw-version`). When present, this attribute contains an INTEGER with a non-negative value which is incremented for new
     firmware release versions. The extension MUST NOT be marked as critical.
+
+For example, the following is an attestation certificate containing the above extension OIDs as well as required fields:
+
+<pre>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 16909060 (0x1020304)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Example attestation certificate
+        Validity
+            Not Before: Aug  1 00:00:00 2014 GMT
+            Not After : Sep  4 00:00:00 2050 GMT
+        Subject: C = US, O = WebAuthn WG, CN = Attestation example
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            1.3.6.1.4.1.45724.1.1.4:
+                ....9\&...e;.y}..<
+            1.3.6.1.4.1.45724.1.1.5:
+                ..*
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+-----BEGIN CERTIFICATE----- <!-- needs more text to prevent bikeshed emdash markdown bug -->
+MIICZzCCAU+gAwIBAgIEAQIDBDANBgkqhkiG9w0BAQsFADAqMSgwJgYDVQQDEx9F
+eGFtcGxlIGF0dGVzdGF0aW9uIGNlcnRpZmljYXRlMCAXDTE0MDgwMTAwMDAwMFoY
+DzIwNTAwOTA0MDAwMDAwWjBBMQswCQYDVQQGEwJVUzEUMBIGA1UECgwLV2ViQXV0
+aG4gV0cxHDAaBgNVBAMME0F0dGVzdGF0aW9uIGV4YW1wbGUwWTATBgcqhkjOPQIB
+BggqhkjOPQMBBwNCAAR56jssfElwEGIjDNI/62DlKTFx1IPxAL6FnWsPg5cDAbVG
+zdRuz8rj4/MPgentYr0mjUwevTezvL6SqMKu6046o0cwRTAhBgsrBgEEAYLlHAEB
+BAQSBBDNjDlcJu3u3mU7AHl9A8o8MBIGCysGAQQBguUcAQEFBAMCASowDAYDVR0T
+AQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAQEAl50Dl9hg+C7hXTEceW66+yL6p+CE
+2bq0xhu7V/PmtMGKSDe4XDxO2+SDQ/TWpdmxztqK4f7UkSkhcwWOXuHL3WvawHVX
+xqDo02gluhWef7WtjNr4BIaM+Q6PH4rqF8AWtVwqetSXyJT7cddT15uaSEtsN21y
+O5mNLh1DBr8QM7Wu+Myly7JWi2kkIm0io1irfYfkrF8uCRqnFXnzpWkJSX1y9U4G
+usHDtEE7ul6vlMO2TzT566Qay2rig3dtNkZTeEj+6IS93fWxuleYVM/9zrrDRAWV
+J+Vt1Zj49WZxWr5DAd0ZETDmufDGQDkSU+IpgD867ydL7b/eP8u9QurWeQ==
+-----END CERTIFICATE-----
+</pre>
 
 ## TPM Attestation Statement Format ## {#sctn-tpm-attestation}
 

--- a/index.bs
+++ b/index.bs
@@ -5845,7 +5845,7 @@ Additionally, an Authority Information Access (AIA) extension with entry `id-ad-
     services. See, for example, the FIDO Metadata Service [[FIDOMetadataService]].
 
 The firmware of a particular authenticator model MAY be differentiated using the Extension OID `1.3.6.1.4.1.45724.1.1.5` 
-    (`id-fido-gen-ce-fw-version`). When present, this attribute contains an unsigned INTEGER which is incremented for new
+    (`id-fido-gen-ce-fw-version`). When present, this attribute contains an INTEGER with a non-negative value which is incremented for new
     firmware release versions. The extension MUST NOT be marked as critical.
 
 ## TPM Attestation Statement Format ## {#sctn-tpm-attestation}

--- a/index.bs
+++ b/index.bs
@@ -5840,7 +5840,7 @@ The attestation certificate MUST have the following fields/extensions:
 
 - The Basic Constraints extension MUST have the CA component set to [FALSE].
 
-Additionally, Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension 
+Additionally, an Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension 
     [[RFC5280]] are both OPTIONAL as the status of many attestation certificates is available through authenticator metadata
     services. See, for example, the FIDO Metadata Service [[FIDOMetadataService]].
 

--- a/index.bs
+++ b/index.bs
@@ -5840,10 +5840,13 @@ The attestation certificate MUST have the following fields/extensions:
 
 - The Basic Constraints extension MUST have the CA component set to [FALSE].
 
-- An Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension [[RFC5280]]
-    are both OPTIONAL as the status of many attestation certificates is available through authenticator metadata services.
-    See, for example, the FIDO Metadata Service [[FIDOMetadataService]].
+Additionally, Authority Information Access (AIA) extension with entry `id-ad-ocsp` and a CRL Distribution Point extension 
+    [[RFC5280]] are both OPTIONAL as the status of many attestation certificates is available through authenticator metadata
+    services. See, for example, the FIDO Metadata Service [[FIDOMetadataService]].
 
+The firmware of a particular authenticator model MAY be differentiated using the Extension OID `1.3.6.1.4.1.45724.1.1.5` 
+    (`id-fido-gen-ce-fw-version`). When present, this attribute contains an unsigned INTEGER which is incremented for new
+    firmware release versions. The extension MUST NOT be marked as critical.
 
 ## TPM Attestation Statement Format ## {#sctn-tpm-attestation}
 


### PR DESCRIPTION
This describes the FIDO OID and data for the firmware version attribute.

It also changes the AIA attribute above it, which appears to actually have been added to the required attributes list.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dwaite/webauthn/pull/1953.html" title="Last updated on Feb 21, 2024, 7:02 PM UTC (27a8614)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1953/bd68fbf...dwaite:27a8614.html" title="Last updated on Feb 21, 2024, 7:02 PM UTC (27a8614)">Diff</a>