### PR TITLE
Reference CTAP 2.1 Proposed Standard

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Previous Version: https://www.w3.org/TR/2019/REC-webauthn-1-20190304/
 Shortname: webauthn
 Level: 3
 Include MDN Panels: maybe
-Editor: Michael B. Jones, w3cid 38745, independent, michael_b_jones@hotmail.com
+Editor: Michael B. Jones, w3cid 38745, Self-Issued Consulting, michael_b_jones@hotmail.com
 Editor: Akshay Kumar, w3cid 99318, Microsoft, akshayku@microsoft.com
 Editor: Emil Lundberg, w3cid 102508, Yubico, emil@yubico.com
 Former Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
@@ -8963,10 +8963,10 @@ for their contributions as our W3C Team Contacts.
 
   "FIDO-CTAP": {
     "authors": ["J. Bradley", "J. Hodges", "M. B. Jones", "A. Kumar", "R. Lindemann", "J. Verrept"],
-    "title": "Client to Authenticator Protocol",
-    "href": "https://fidoalliance.org/specs/fido-v2.1-rd-20210309/fido-client-to-authenticator-protocol-v2.1-rd-20210309.html",
-    "status": "FIDO Alliance Review Draft",
-    "date": "9 March 2021"
+    "title": "Client to Authenticator Protocol (CTAP)",
+    "href": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html",
+    "status": "FIDO Alliance Proposed Standard",
+    "date": "15 June 2021"
   },
 
   "FIDO-UAF-AUTHNR-CMDS": {


### PR DESCRIPTION
Upgrade CTAP reference from Review Draft to Proposed Standard


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/1961.html" title="Last updated on Sep 11, 2023, 8:31 AM UTC (efe2c28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1961/40be3db...selfissued:efe2c28.html" title="Last updated on Sep 11, 2023, 8:31 AM UTC (efe2c28)">Diff</a>