### PR TITLE
Specify what an unknown type credential descriptor being ignored means

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3529,6 +3529,8 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
             of [[#sctn-op-get-assertion]]).
 
         If not [=list/empty=], the client MUST return an error if none of the listed credentials can be used.
+        For instance, if all of the listed credentials have {{PublicKeyCredentialDescriptor}} with an unknown {{PublicKeyCredentialDescriptor/type}},
+        the client MUST throw "{{NotAllowedError}}".
 
         The list is ordered in descending order of preference: the first item in the list is the most
         preferred credential, and the last is the least preferred.


### PR DESCRIPTION
The spec describes that client platforms MUST ignore any PublicKeyCredentialDescriptor with an unknown type. However, there is no further specification about the case when this results in an empty allowCredentials. It must not be treated as an empty list.

The client MUST return an error if none of the listed credentials can be used in allowCredentials. For instance, if all of the listed credentials have PublicKeyCredentialDescriptor with an unknown type, the client MUST throw NotAllowedError.

Fixes #1748


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amoseui/webauthn/pull/1966.html" title="Last updated on Sep 18, 2023, 4:09 PM UTC (5f47918)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1966/58d60d0...amoseui:5f47918.html" title="Last updated on Sep 18, 2023, 4:09 PM UTC (5f47918)">Diff</a>