### PR TITLE
Fix broken PublicKeyCredentialJSON WebIDL definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1609,7 +1609,9 @@ that are returned to the caller when a new credential is created, or a new asser
 
 <xmp class="idl">
     typedef DOMString Base64URLString;
-    typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
+    // The structure of this object will be either
+    // RegistrationResponseJSON or AuthenticationResponseJSON
+    typedef object PublicKeyCredentialJSON;
 
     dictionary RegistrationResponseJSON {
         required Base64URLString id;


### PR DESCRIPTION
Update the WebIDL definition of the shape of `PublicKeyCredentialJSON` based on feedback in #1958.

NOTE: I have no idea how to validate that this is actually going to fix the issue.

Fixes #1958.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1969.html" title="Last updated on Sep 20, 2023, 7:01 PM UTC (8af0385)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1969/58d60d0...8af0385.html" title="Last updated on Sep 20, 2023, 7:01 PM UTC (8af0385)">Diff</a>