### PR TITLE
Highlight that filtering all pubKeyCredParams is an error.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3882,6 +3882,8 @@ It mirrors some fields of the {{PublicKeyCredential}} object returned by
 
         This mirrors the {{Credential/type}} field of {{PublicKeyCredential}}.
 
+        Note: if all {{PublicKeyCredentialDescriptor}} elements in {{PublicKeyCredentialRequestOptions/allowCredentials}} are ignored then that must result in an error since an empty {{PublicKeyCredentialRequestOptions/allowCredentials}} is semantically distinct.
+
     :   <dfn>id</dfn>
     ::  This member contains the [=credential ID=] of the [=public key credential=] the caller is referring to.
 

--- a/index.bs
+++ b/index.bs
@@ -3882,7 +3882,7 @@ It mirrors some fields of the {{PublicKeyCredential}} object returned by
 
         This mirrors the {{Credential/type}} field of {{PublicKeyCredential}}.
 
-        Note: if all {{PublicKeyCredentialDescriptor}} elements in {{PublicKeyCredentialRequestOptions/allowCredentials}} are ignored then that must result in an error since an empty {{PublicKeyCredentialRequestOptions/allowCredentials}} is semantically distinct.
+        Note: If all {{PublicKeyCredentialDescriptor}} elements in {{PublicKeyCredentialRequestOptions/allowCredentials}} are ignored then that MUST result in an error since an empty {{PublicKeyCredentialRequestOptions/allowCredentials}} is semantically distinct.
 
     :   <dfn>id</dfn>
     ::  This member contains the [=credential ID=] of the [=public key credential=] the caller is referring to.


### PR DESCRIPTION
While this is specified in the [algorithm steps][REF], it's arguably subtle and surprising and thus worth calling out.

See also #1966

[REF]: https://w3c.github.io/webauthn/#ref-for-dom-publickeycredentialdescriptor-type%E2%91%A0


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1971.html" title="Last updated on Sep 21, 2023, 7:33 PM UTC (254d007)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1971/baf774a...254d007.html" title="Last updated on Sep 21, 2023, 7:33 PM UTC (254d007)">Diff</a>