### PR TITLE
Remove [SameObject] attribute from PublicKeyCredential.authenticatorAttachment

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1522,7 +1522,7 @@ that are returned to the caller when a new credential is created, or a new asser
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
         [SameObject] readonly attribute AuthenticatorResponse    response;
-        [SameObject] readonly attribute DOMString?               authenticatorAttachment;
+        readonly attribute DOMString?                            authenticatorAttachment;
         AuthenticationExtensionsClientOutputs getClientExtensionResults();
         static Promise<boolean> isConditionalMediationAvailable();
         PublicKeyCredentialJSON toJSON();


### PR DESCRIPTION
Fixes #1977.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1981.html" title="Last updated on Oct 2, 2023, 12:48 PM UTC (b4b1390)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1981/77654c9...b4b1390.html" title="Last updated on Oct 2, 2023, 12:48 PM UTC (b4b1390)">Diff</a>