### PR TITLE
Don't define a [[preventSilentAccess]] internal method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1704,6 +1704,9 @@ that are returned to the caller when a new credential is created, or a new asser
 implementation of each of {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}}, {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}, and
 {{PublicKeyCredential/[[Store]](credential, sameOriginWithAncestors)}}.
 
+Calling {{CredentialsContainer}}'s {{CredentialsContainer/preventSilentAccess()}} method
+will have no effect on {{PublicKeyCredential}} credentials, since they always require user interaction.
+
 
 ### `CredentialCreationOptions` Dictionary Extension ### {#sctn-credentialcreationoptions-extension}
 
@@ -2763,18 +2766,6 @@ This [=internal method=] accepts two arguments:
 When this method is invoked, the user agent MUST execute the following algorithm:
 
 1. Throw a "{{NotSupportedError}}" {{DOMException}}.
-
-</div>
-
-###  Preventing Silent Access to an Existing Credential - PublicKeyCredential's `[[preventSilentAccess]](credential, sameOriginWithAncestors)` Method ### {#sctn-preventSilentAccessCredential}
-
-<div link-for-hint="PublicKeyCredential/[[preventSilentAccess]](credential, sameOriginWithAncestors)">
-
-Calling the <dfn for="PublicKeyCredential" method>\[[preventSilentAccess]](credential, sameOriginWithAncestors)</dfn> method
-will have no effect on authenticators that require an [=authorization gesture=],
-but setting that flag may potentially exclude authenticators that can operate without user intervention.
-
-This [=internal method=] accepts no arguments.
 
 </div>
 


### PR DESCRIPTION
Fixes issue #1956.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1991.html" title="Last updated on Oct 25, 2023, 5:59 PM UTC (2803185)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1991/28d90b2...2803185.html" title="Last updated on Oct 25, 2023, 5:59 PM UTC (2803185)">Diff</a>