### PR TITLE
Add note about typical autocomplete combos for conditional UI

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2413,7 +2413,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 </dt>
         ::  <div class="note">
                 Note: The `"webauthn"` [=autofill detail token=] must appear immediately after the last [=autofill detail token=]
-                of type "Normal" or "Contact":
+                of type "Normal" or "Contact". For example:
 
                 - `"username webauthn"`
                 - `"current-password webauthn"`

--- a/index.bs
+++ b/index.bs
@@ -172,6 +172,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: document.domain; url:dom-document-domain
         urlPrefix: form-control-infrastructure.html
             text: autofill detail token; url: autofill-detail-tokens
+            text: non-autofill credential type; url: non-autofill-credential-type
 
 spec: url; urlPrefix: https://url.spec.whatwg.org
     type: dfn

--- a/index.bs
+++ b/index.bs
@@ -2410,8 +2410,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
                   and the user interacts with an <{input}> or <{textarea}> form control with an <{input/autocomplete}> attribute whose value
                   contains `"webauthn"` as the last [=autofill detail token=],
                 </dt>
-            <div class="note">
-                Note: The following are examples of typical values for the <{input/autocomplete}> attribute with the `"webauthn"`
+        ::  <div class="note">
+                Note: The following are example values for the <{input/autocomplete}> attribute with the `"webauthn"`
                 [=autofill detail token=] in the correct position:
 
                 - `"username webauthn"`
@@ -2421,7 +2421,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 of these tokens can be confirmed in the [=autofill detail token=] section of the the WHATWG HTML standard.
             </div>
 
-        ::  1. If |silentlyDiscoveredCredentials| is not [=list/empty=]:
+            1. If |silentlyDiscoveredCredentials| is not [=list/empty=]:
 
                 1. Prompt the user to optionally select a [=DiscoverableCredentialMetadata=] (|credentialMetadata|) from |silentlyDiscoveredCredentials|.
 

--- a/index.bs
+++ b/index.bs
@@ -2408,8 +2408,18 @@ When this method is invoked, the user agent MUST execute the following algorithm
                 <dt id="GetAssn-ConditionalMediation-Interact-FormControl">
                   If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is {{CredentialMediationRequirement/conditional}}
                   and the user interacts with an <{input}> or <{textarea}> form control with an <{input/autocomplete}> attribute whose value
-                  contains a `"webauthn"` [=autofill detail token=],
+                  contains `"webauthn"` as the last [=autofill detail token=],
                 </dt>
+            <div class="note">
+                Note: The following are examples of typical values for the <{input/autocomplete}> attribute with the `"webauthn"`
+                [=autofill detail token=] in the correct position:
+
+                - `"username webauthn"`
+                - `"current-password webauthn"`
+
+                These examples are likely to trigger conditional UI across the greatest number of user agents. The expected ordering
+                of these tokens can be confirmed in the [=autofill detail token=] section of the the WHATWG HTML standard.
+            </div>
 
         ::  1. If |silentlyDiscoveredCredentials| is not [=list/empty=]:
 

--- a/index.bs
+++ b/index.bs
@@ -2407,18 +2407,15 @@ When this method is invoked, the user agent MUST execute the following algorithm
             <!-- this needs to be indented 2 more levels to get it to render properly -->
                 <dt id="GetAssn-ConditionalMediation-Interact-FormControl">
                   If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is {{CredentialMediationRequirement/conditional}}
-                  and the user interacts with an <{input}> or <{textarea}> form control with an <{input/autocomplete}> attribute whose value
-                  contains `"webauthn"` as the last [=autofill detail token=],
+                  and the user interacts with an <{input}> or <{textarea}> form control with an <{input/autocomplete}> attribute whose
+                  [=non-autofill credential type=] is `"webauthn"`,
                 </dt>
         ::  <div class="note">
-                Note: The following are example values for the <{input/autocomplete}> attribute with the `"webauthn"`
-                [=autofill detail token=] in the correct position:
+                Note: The `"webauthn"` [=autofill detail token=] must appear immediately after the last [=autofill detail token=]
+                of type "Normal" or "Contact":
 
                 - `"username webauthn"`
                 - `"current-password webauthn"`
-
-                These examples are likely to trigger conditional UI across the greatest number of user agents. The expected ordering
-                of these tokens can be confirmed in the [=autofill detail token=] section of the the WHATWG HTML standard.
             </div>
 
             1. If |silentlyDiscoveredCredentials| is not [=list/empty=]:


### PR DESCRIPTION
This PR includes a new note detailing two simple examples of "correct" `autocomplete` attributes that should reliably trigger conditional UI across most browsers.

Fixes #1982.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1992.html" title="Last updated on Nov 15, 2023, 8:19 PM UTC (139405f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1992/28d90b2...139405f.html" title="Last updated on Nov 15, 2023, 8:19 PM UTC (139405f)">Diff</a>