### PR TITLE
Resolve conflicts between spk (#1957) and PR #1970

### DIFF
--- a/.github/workflows/build-validate-publish.yml
+++ b/.github/workflows/build-validate-publish.yml
@@ -7,9 +7,9 @@ on:
 jobs:
   main:
     name: Build, Validate, and Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages

--- a/index.bs
+++ b/index.bs
@@ -7183,7 +7183,7 @@ A usage example is thus:
 
 Another example of supplemental keys:
 
-> Say that a sign-in request appears at a website along with some geolocation signal that has not been seen for this [=user account=] before, and is outside of the typical usage hours observed for the account. The risk may be deemed high enough not to allow the request, even with an assertion by a [=multi-device credential=] on its own. But if a signature from a supplimental key that is device-bound, and that is <i>well established</i> for this user can also be presented, then that may tip the balance.
+> Say that a sign-in request appears at a website along with some geolocation signal that has not been seen for this [=user account=] before, and is outside of the typical usage hours observed for the account. The risk may be deemed high enough not to allow the request, even with an assertion by a [=multi-device credential=] on its own. But if a signature from a supplemental key that is device-bound, and that is <i>well established</i> for this user can also be presented, then that may tip the balance.
 
 The weight that [=[RPS]=] give to the presence of a signature from a supplemental key may be based on information learned from its optional attestation. An attestation can indicate the level of protection enjoyed by a hardware-bound key, or the policies for other types of supplemental key.
 
@@ -7197,19 +7197,19 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
 : Client extension input
 :: <xmp class="idl">
-    dictionary AuthenticationExtensionsSupplementalPublicKeysInputs {
+    dictionary AuthenticationExtensionsSupplementalPubKeysInputs {
         required sequence<DOMString> scopes;
         DOMString attestation = "indirect";
         sequence<DOMString> attestationFormats = [];
     };
 
     partial dictionary AuthenticationExtensionsClientInputs {
-        AuthenticationExtensionsSupplementalPublicKeysInputs supplementalPubKeys;
+        AuthenticationExtensionsSupplementalPubKeysInputs supplementalPubKeys;
     };
     </xmp>
-    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsSupplementalPublicKeysInputs">
+    <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsSupplementalPubKeysInputs">
         :   <dfn>scopes</dfn>
-        ::  This required member specifies the scopes of supplemental public keys that the [=[RP]=] requests. Values are taken from the `scope` group in the CDDL below. (I.e. currently valid values are `provider` and `device`.) Specifying the scopes that a [=[RP]=] can use allows an [=authenticator=] to avoid the work of generating superfluous supplemental keys.
+        ::  This required member MUST be non-empty. It specifies the scopes of supplemental public keys that the [=[RP]=] requests. Values are taken from the CDDL below (i.e., currently defined values are `provider` and `device`); authenticators silently ignore unrecognized values. Specifying the scopes that a [=[RP]=] can use allows an [=authenticator=] to avoid the work of generating superfluous supplemental keys.
 
         :   <dfn>attestation</dfn>
         ::  The [=[RP]=] MAY use this OPTIONAL member to specify a preference regarding [=attestation conveyance=].
@@ -7231,14 +7231,14 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 :: If {{AuthenticationExtensionsClientInputs/supplementalPubKeys}} is present, the client creates the authenticator extension input from the client extension input.
 
 : Client extension output
-:: An ArrayBuffer containing the signature returned as the [=unsigned extension output=].
+:: A sequence of {{ArrayBuffer}}s containing the signatures returned as the [=unsigned extension output=].
     <xmp class="idl">
-    dictionary AuthenticationExtensionsSupplementalPublicKeysOutputs {
+    dictionary AuthenticationExtensionsSupplementalPubKeysOutputs {
         sequence<ArrayBuffer> signatures;
     };
 
     partial dictionary AuthenticationExtensionsClientOutputs {
-        AuthenticationExtensionsSupplementalPublicKeysOutputs supplementalPubKeys;
+        AuthenticationExtensionsSupplementalPubKeysOutputs supplementalPubKeys;
     };
     </xmp>
 
@@ -7248,9 +7248,17 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
     ```
     supplementalPublicKeyInputs = {
-      scopes: [tstr],
+      scopes: [+
+        ; A key that has a broader scope than a single device, but still more
+        ; limited than a multi-device credential. The precise scope is specified
+        ; by the attestation of this supplemental public key.
+        "provider" /
+
+        ; A key with "device" scope MUST NOT leave the device on which it is
+        ; created.
+        "device"],
       attestation: tstr,
-      attestationFormats: [tstr],
+      attestationFormats: [* tstr],
     }
     $$extensionInput //= (
       supplementalPubKeys: supplementalPublicKeyInputs,
@@ -7258,7 +7266,7 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
     ```
 
 : Authenticator extension output
-:: The supplemental public key attestation objects, defined by the `attObjForSupplementalPublicKey` type:
+:: The supplemental public key attestation objects, defined by the `attObjForSupplementalPubKey` type:
 
     ```
     $$extensionOutput //= (
@@ -7266,39 +7274,21 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
         ; lexicographically by scope and MUST NOT include more than one element
         ; with a given scope.
 
-        supplementalPubKeys: [attObjForSupplementalPublicKey],
-    )
-
-    scope = (
-      ; A key that has a broader scope than a single device, but still more
-      ; limited than a multi-device credential. The precise scope is specified
-      ; by the attestation of this supplemental public key.
-
-      provider: true //
-
-      ; A key with "device" scope MUST NOT leave the device on which it is
-      ; created. The value of this key communicates whether the key is scoped to
-      ; the entire device, or a loosely-defined, narrower scope called "per-app".
-      ; For example, a "device-wide" key is expected to be the same between an
-      ; app and a browser on the same device, while a "per-app" key would
-      ; probably not be.
-      ;
-      ; Whether device-wide or not, keys are still device-bound. I.e. a
-      ; per-app key does not enjoy lesser protection from extraction.
-
-      device: "device-wide" / "per-app"
+        supplementalPubKeys: [+ attObjForSupplementalPubKey],
     )
 
     ; This object conveys an attested supplemental public key and is analogous
     ; to \`attObj\`.
-    attObjForSupplementalPublicKey = {
+    attObjForSupplementalPubKey = {
         aaguid:  bstr,  ; AAGUID (16 bytes fixed-length)
                         ; https://www.w3.org/TR/webauthn/#aaguid
 
         spk:     bstr,  ; The public key (self-describing variable length,
                         ; COSE_Key format, CBOR-encoded)).
 
-        scope,          ; see scope group, above.
+        ; See the definition of `scopes` in `supplementalPublicKeyInputs`.
+
+        scope: "provider" / "device",
 
         ; An authenticator-generated random nonce for inclusion in the attestation
         ; signature. If the authenticator chooses to not generate a nonce, it sets this
@@ -7312,7 +7302,7 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
         ; Attestation statement formats define the \`fmt\` and \`attStmt\` members of
         ; $$attStmtType.
         ; Note that \`fmt\` and \`attStmt\` are top-level members of
-        ; \`attObjForSupplementalPublicKey\`.
+        ; \`attObjForSupplementalPubKey\`.
         ;
         ; In summary, the \`attStmt\` will (typically) contain:
         ;   (1) a SIGNATURE value calculated (using the attestation private key)
@@ -7342,13 +7332,21 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
     ```
 
 : Unsigned extension output
-:: A CBOR array of byte strings containing the signatures generated with the supplemental private keys, in the same order as in the authenticator extension output.
+:: A non-empty CBOR array of byte strings containing the signatures generated with the supplemental private keys, in the same order as in the authenticator extension output.
+
+    ```
+    supplementalPublicKeyOutputs = [+ bstr]
+
+    $$unsignedExtensionOutputs //= (
+      supplementalPubKeys: supplementalPublicKeyOutputs,
+    )
+    ```
 
 : Authenticator extension processing
 :: For both [=authenticatorMakeCredential=] and [=authenticatorGetAssertion=] operations:
     1. Create or select the [=public key credential source=] as usual (see [[#sctn-op-make-cred]], or [[#sctn-op-get-assertion]] as appropriate).
 
-    1. Let |scopes| be the [=set=] of all supplemental public key scopes that the [=authenticator=] supports. Updates |scopes| to be the [=set/intersection=] of itself and {{AuthenticationExtensionsSupplementalPublicKeysInputs/scopes}}. If |scopes| is empty, terminate these processing steps with no extension output.
+    1. Let |scopes| be the [=set=] of all supplemental public key scopes that the [=authenticator=] supports. Update |scopes| to be the [=set/intersection=] of itself and {{AuthenticationExtensionsSupplementalPubKeysInputs/scopes}}. If |scopes| is empty, terminate these processing steps with no extension output.
 
     1. Let |spks| and |spkSigs| be empty arrays.
 
@@ -7358,17 +7356,17 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
         1. If a supplemental key with scope |scope| does not already exist for this {[=public key credential source/id|Credential ID=], [=public key credential source/rpId|RP ID=], [=public key credential source/rpId|userHandle=]} tuple on the [=authenticator=], create it using the same public key algorithm as that used by the [=user credential=]'s [=credential key pair=], otherwise locate the existing supplemental key.
 
-        1. Let |attFormat| be the chosen [=attestation statement format=], and |attAaguid| be a 16-byte value, based on the value of {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestation}} in the extension input:
+        1. Let |attFormat| be the chosen [=attestation statement format=], and |attAaguid| be a 16-byte value, based on the value of {{AuthenticationExtensionsSupplementalPubKeysInputs/attestation}} in the extension input:
 
             <dl class="switch">
                 : none
                 :: |attFormat| is "none" or "self", at the authenticator's discretion, and |attAaguid| is 16 zero bytes. (Note that, since the [=supplemental public key=] is already exercised during {{CredentialsContainer/create()|navigator.credentials.create()}} calls, the proof-of-possession property provided by "self" attestation is superfluous in that context.)
 
                 : indirect, direct
-                :: |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID. (Since the [=supplemental public key=]'s scope is different from the [=user credential=], it will often have a different attestation. For example, the attestation for a [=supplemental public key=] with &ldquo;device&rdquo; scope can be tied to hardware roots of trust, although it does not have to be.)
+                :: |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPubKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID. (Since the [=supplemental public key=]'s scope is different from the [=user credential=], it will often have a different attestation. For example, the attestation for a [=supplemental public key=] with &ldquo;device&rdquo; scope can be tied to hardware roots of trust, although it does not have to be.)
 
                 : enterprise
-                :: The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. [=Authenticators=] MUST NOT provide such an attestation unless the user agent or authenticator configuration expressly permits it for the requested [=RP ID=]. If <i>not</i> permitted, then follow the steps for `direct` attestation. Otherwise |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID.
+                :: The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. [=Authenticators=] MUST NOT provide such an attestation unless the user agent or authenticator configuration expressly permits it for the requested [=RP ID=]. If <i>not</i> permitted, then follow the steps for `direct` attestation. Otherwise |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPubKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID.
 
                     Note: CTAP2 does not currently provide for an <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#makecred-enterpriseattestation">enterpriseAttestation</a> signal during an <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetAssertion">authenticatorGetAssertion</a> call. Until that is changed, <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#platform-managed-enterprise-attestation">platform-managed enterprise attestation</a> will not work in that context with CTAP2 [=authenticators=].
             </dl>
@@ -7381,7 +7379,7 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
             Note: |randomNonce|'s purpose is to randomize the [=attestation signature=] value for [=supplemental public keys=]. If this is not done, then an [=attestation signature=] value remains constant for all such signatures issued on behalf of this [=user credential=], possibly exposing the [=authenticator=]'s [=attestation private key=] to side-channel attacks. The randomness-generation mechanism should be carefully chosen by the authenticator implementer.
 
-        1. Let |supplementalPubKey| be a [=CBOR=] map as defined by `attObjForSupplementalPublicKey` above, with keys and values as follows:
+        1. Let |supplementalPubKey| be a [=CBOR=] map as defined by `attObjForSupplementalPubKey` above, with keys and values as follows:
 
             Note: as with all CBOR structures used in this specification, the [=CTAP2 canonical CBOR encoding form=] MUST be used.
 
@@ -7397,7 +7395,7 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
                 Note: The details of the `$$attStmtType` values are dependent upon the particular [=attestation statement=] format. See [[#sctn-attestation-formats]].
 
-            1. If the `$$attStmtType` [=group socket=] contains uniquely identifying information then let `epAtt` be [TRUE]. Otherwise omit the `epAtt` field. (This field can only be [TRUE] when the {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestation}} field of the extension input is "enterprise" and either the user-agent or the authenticator permits uniquely identifying attestation for the requested RP ID.)
+            1. If the `$$attStmtType` [=group socket=] contains uniquely identifying information then let `epAtt` be [TRUE]. Otherwise omit the `epAtt` field. (This field can only be [TRUE] when the {{AuthenticationExtensionsSupplementalPubKeysInputs/attestation}} field of the extension input is "enterprise" and either the user-agent or the authenticator permits uniquely identifying attestation for the requested RP ID.)
 
         1. Append |supplementalPubKey| to |spks|.
 
@@ -7415,15 +7413,15 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
 ##### AAGUIDs ##### {#sctn-supplemental-public-keys-attestation-aaguid}
 
-The [=/AAGUID=] included in the <code>[=supplementalPubKeys=]</code> extension output, if non-zero, aids a [=[RP]=] in validating the [=attestation statement=] of the supplemental public key. Its interpretation depends on the scope of the key. It may differ from the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] of a [=multi-device credential=]. Thus the AAGUID of [=supplemental public key=] MAY be different in a single response and either, or both, may be zero depending on the options requested and authenticator behaviour.
+Any non-zero [=/AAGUID=]s included in the <code>[=supplementalPubKeys=]</code> extension output aid a [=[RP]=] in validating the [=attestation statement=] of the supplemental public key. The interpretation of each AAGUID depends on the scope of the corresponding key. Some or all may differ from the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] of a [=multi-device credential=]. Thus the AAGUID of a [=supplemental public key=] MAY be different in a single response and either, or both, may be zero depending on the options requested and authenticator behaviour.
 
 ##### Attestation calculations ##### {#sctn-supplemental-public-keys-attestation-calculations}
 
-When computing attestations, the process in [[#sctn-generating-an-attestation-object]] takes two inputs: `authData` and `hash`. When calculating an attestation for a supplemental public key, the typical value for `hash` hashes over the attestation signature itself, which is impossible. Also the attestation of a supplemental public key is potentially used repeatedly, thus may want to be cached. But signing over values that include [=[RP]=]-chosen nonces, like the [=hash of the serialized client data=], makes that impossible.
+When computing attestations, the process in [[#sctn-generating-an-attestation-object]] takes two inputs: `authData` and `hash`. When calculating an attestation for a supplemental public key, the typical value for `authHash` contains the attestation signature itself, which is impossible. Also the attestation of a supplemental public key is potentially used repeatedly, thus may want to be cached. But signing over values that include [=[RP]=]-chosen nonces, like the [=hash of the serialized client data=], makes that impossible.
 
 Therefore when calculating an attestation for a supplemental public key, the inputs are:
 
-    * For `authData`, substitute the concatenation of the byte string h'64657669636520626f756e64206b6579206174746573746174696f6e2073696700ffffffff' and the value of |aaguid| from the extension output.
+    * For `authData`, substitute the concatenation of the byte string h'737570706c656d656e74616c5075624b657973206174746573746174696f6e2e00ffffffff' and the value of |aaguid| from the extension output.
     * For `hash`, substitute the concatenation of the |spk| and |nonce| fields from the extension output. (The nonce MAY be empty.)
 
 The attestation signature is thus typically calculated over the bytes of <code>(h'64657669636520626f756e64206b6579206174746573746174696f6e2073696700ffffffff' || |aaguid| || |spk| || |nonce|)</code>. The 37-byte prefix ensures domain separation: it takes the place of the RP ID hash, flags, and signature counter fields in those messages and ensures that no attestation signature for a supplemental public key can be confused with a signature for a [=user credential=].
@@ -7470,17 +7468,17 @@ then the below verification steps are performed in the context of [step 19](#reg
 of [[#sctn-registering-a-new-credential]] using these variables established therein: |credential|, |clientExtensionResults|, |authData|, and |hash|.
 [=[RP]=] policy may specify whether a response without a `supplementalPubKeys` extension output is acceptable.
 
-1. Verify that the {{AuthenticationExtensionsClientOutputs/supplementalPubKeys}} member of |clientExtensionResults| exists, and contains the {{AuthenticationExtensionsSupplementalPublicKeysOutputs/signatures}} field. Let |signatures| be the value of that field.
+1. Verify that the {{AuthenticationExtensionsClientOutputs/supplementalPubKeys}} member of |clientExtensionResults| exists, and contains the {{AuthenticationExtensionsSupplementalPubKeysOutputs/signatures}} field. Let |signatures| be the value of that field.
 
 1. Let |attObjsForSupplementalPublicKey| be the value of the `supplementalPubKeys` member of the [=authenticator extension output=] from |authData|.
 
 1. If the [=list/size=] of |attObjsForSupplementalPublicKey| is not equal to the [=list/size=] of |signatures| then abort the registration process with an error.
 
-1. [=list/Iterate=] over the indices of |attObjsForSupplementalPublicKey| (which, after the check in the previous step, must also be the indices of |signatures|). Then, for each (|attObjForSupplementalPublicKey|, |signature|) from the two lists:
+1. [=list/Iterate=] over the indices of |attObjsForSupplementalPublicKey| (which, after the check in the previous step, must also be the indices of |signatures|). Then, for each (|attObjForSupplementalPubKey|, |signature|) from the two lists:
 
-    1. Extract the contained fields from |attObjForSupplementalPublicKey|: |aaguid|, |spk|, |nonce|, |fmt| and |attStmt|. Also let |scope| reflect the scope, specified by the member of the `scope` group that is present.
+    1. Extract the contained fields from |attObjForSupplementalPubKey|: |aaguid|, |spk|, |nonce|, |fmt| and |attStmt|. Also let |scope| reflect the scope, specified by the member of the `scope` group that is present.
 
-        Note: The latter |attObjForSupplementalPublicKey| fields are referenced exclusively in the below steps and are not to be confused with other fields with the same names in other portions of the top-level [=attestation object=].
+        Note: The latter |attObjForSupplementalPubKey| fields are referenced exclusively in the below steps and are not to be confused with other fields with the same names in other portions of the top-level [=attestation object=].
 
     1. Verify that |signature| is a valid signature over the [=assertion signature=] [input](#fig-signature) (i.e. `authData` and `hash`) by the [=supplemental public key=] |spk|. (The signature algorithm is the same as for the [=user credential=].)
 
@@ -7521,17 +7519,17 @@ of [[#sctn-verifying-assertion]] using these variables established therein: |cre
 
 1. Let |recognizedSpks| be a new [=set/empty=] [=set=].
 
-1. Verify that the {{AuthenticationExtensionsClientOutputs/supplementalPubKeys}} member of |clientExtensionResults| exists, and contains the {{AuthenticationExtensionsSupplementalPublicKeysOutputs/signatures}} field. Let |signatures| be the value of that field.
+1. Verify that the {{AuthenticationExtensionsClientOutputs/supplementalPubKeys}} member of |clientExtensionResults| exists, and contains the {{AuthenticationExtensionsSupplementalPubKeysOutputs/signatures}} field. Let |signatures| be the value of that field.
 
-1. Let |attObjsForSupplementalPublicKeys| be the value of the `supplementalPubKeys` member of the [=authenticator extension output=] from |authData|.
+1. Let |attObjsForSupplementalPubKeys| be the value of the `supplementalPubKeys` member of the [=authenticator extension output=] from |authData|.
 
-1. If the [=list/size=] of |attObjsForSupplementalPublicKeys| is not equal to the [=list/size=] of |signatures| then abort the authentication process with an error.
+1. If the [=list/size=] of |attObjsForSupplementalPubKeys| is not equal to the [=list/size=] of |signatures| then abort the authentication process with an error.
 
-1. [=list/Iterate=] over the indices of |attObjsForSupplementalPublicKeys| (which, after the check in the previous step, must also be the indices of |signatures|). Then, for each (|attObjForSupplementalPublicKey|, |signature|) from the two lists:
+1. [=list/Iterate=] over the indices of |attObjsForSupplementalPubKeys| (which, after the check in the previous step, must also be the indices of |signatures|). Then, for each (|attObjForSupplementalPubKey|, |signature|) from the two lists:
 
-    1. Extract the contained fields from |attObjForSupplementalPublicKey|: |aaguid|, |spk|, |nonce|, |fmt|, |attStmt|. Also let |scope| reflect the scope, specified by the member of the `scope` group that is present.
+    1. Extract the contained fields from |attObjForSupplementalPubKey|: |aaguid|, |spk|, |nonce|, |fmt|, |attStmt|. Also let |scope| reflect the scope, specified by the member of the `scope` group that is present.
 
-        Note: The latter |attObjForSupplementalPublicKey| fields are referenced exclusively in the below steps and are not to be confused with other fields with the same names in other portions of [=authenticator data=].
+        Note: The latter |attObjForSupplementalPubKey| fields are referenced exclusively in the below steps and are not to be confused with other fields with the same names in other portions of [=authenticator data=].
 
     1. Verify that |signature| is a valid signature over the [=assertion signature=] [input](#fig-signature) (i.e. `authData` and `hash`) by the [=supplemental public key=] |spk|. (The signature algorithm is the same as for the [=user credential=].)
 
@@ -7553,7 +7551,7 @@ of [[#sctn-verifying-assertion]] using these variables established therein: |cre
 
                 If |fmt|'s value is "none" then there is no attestation signature to verify and this is a known [=supplemental public key=] with a valid signature. Append |spkRecord| to |recognizedSpks| and continue to the next iteration, if any.
 
-                Otherwise, let |spkRecord| be |matchedSpkRecords|[0]. If the |attStmt| in |attObjForSupplementalPublicKey|:
+                Otherwise, let |spkRecord| be |matchedSpkRecords|[0]. If the |attStmt| in |attObjForSupplementalPubKey|:
                     <dl class="switch">
                         : equals |spkRecord|.[$supplementalPubKeys record/attStmt$] by binary equality:
                         :: This is a known [=supplemental public key=] with a valid signature and valid attestation. Append |spkRecord| to |recognizedSpks| and continue to the next iteration, if any.

--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Previous Version: https://www.w3.org/TR/2019/REC-webauthn-1-20190304/
 Shortname: webauthn
 Level: 3
 Include MDN Panels: maybe
-Editor: Michael B. Jones, w3cid 38745, independent, michael_b_jones@hotmail.com
+Editor: Michael B. Jones, w3cid 38745, Self-Issued Consulting, michael_b_jones@hotmail.com
 Editor: Akshay Kumar, w3cid 99318, Microsoft, akshayku@microsoft.com
 Editor: Emil Lundberg, w3cid 102508, Yubico, emil@yubico.com
 Former Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
@@ -37,6 +37,7 @@ Former Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
 !Contributors: <a href="mailto:mandyam@qti.qualcomm.com">Giridhar Mandyam</a> (Qualcomm)
 !Contributors: <a href="mailto:mattmil3@cisco.com">Matthew Miller</a> (Cisco)
 !Contributors: <a href="mailto:nsatragno@google.com">Nina Satragno</a> (Google)
+!Contributors: <a href="mailto:kieun.shin@sk.com">Ki-Eun Shin</a> (SK Telecom)
 !Contributors: <a href="mailto:nick.steele@agilebits.com">Nick Steele</a> (1Password)
 !Contributors: <a href="mailto:jiewen_tan@apple.com">Jiewen Tan</a> (Apple)
 !Contributors: <a href="mailto:sweeden@au1.ibm.com">Shane Weeden</a> (IBM)
@@ -188,12 +189,6 @@ spec: credential-management-1; urlPrefix: https://w3c.github.io/webappsec-creden
         text: CredentialCreationOptions; url: dictdef-credentialcreationoptions
     type: dictionary
         text: CredentialRequestOptions; url: dictdef-credentialrequestoptions
-    for: Credential
-        type: method
-            text: [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)
-            text: [[Create]](origin, options, sameOriginWithAncestors)
-            text: [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)
-            text: [[Store]](credential, sameOriginWithAncestors)
     for: CredentialsContainer
         type: method
             text: create(); url: dom-credentialscontainer-create
@@ -916,7 +911,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     and the data it emits. This includes such things as [=credential IDs=], [=credential key pairs=], [=signature counters=], etc.
 
     An [=attestation statement=] is provided within an [=attestation object=] during a [=registration=] ceremony. See also [[#sctn-attestation]]
-    and [Figure 6](#fig-attStructs). Whether or how the [=client=] conveys the [=attestation statement=] and [=AAGUID=]
+    and [Figure 6](#fig-attStructs). Whether or how the [=client=] conveys the [=attestation statement=] and [=authData/attestedCredentialData/aaguid=]
     portions of the [=attestation object=] to the [=[RP]=] is described by [=attestation conveyance=].
 
 : <dfn>Attestation Certificate</dfn>
@@ -1186,6 +1181,17 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             when the [=public key credential source=] was [=registration|registered=].
             Storing this in combination with the above [$credential record/attestationObject$] [=struct/item=]
             enables the [=[RP]=] to re-verify the [=attestation signature=] at a later time.
+
+        :   <dfn>authenticatorDisplayName</dfn>
+        ::  A [=human palatability|human-palatable=] description of the [=public key credential source=].
+
+            If used, the [=[RP]=] SHOULD use this to describe the [=credential record=] in the user's account settings.
+            The [=[RP]=] SHOULD allow the user to choose this value, and MAY allow the user to modify it at will.
+
+            The [=credProps|Credential Properties Extension=] defines the [=credential property=]
+            {{CredentialPropertiesOutput/authenticatorDisplayName}}
+            which, when available, MAY be offered as a default for this value.
+            The [=[RP]=] MAY also derive a default value from the authenticator's [=attestation statement=], if any.
     </dl>
 
     [=WebAuthn extensions=] MAY define additional [=struct/items=] needed to process the extension.
@@ -1461,21 +1467,21 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This section normatively specifies the API for creating and using [=public key credentials=]. The basic
 idea is that the credentials belong to the user and are [=managing authenticator|managed=] by a [=[WAA]=], with which the [=[WRP]=] interacts through the [=client platform=]. [=[RP]=] scripts can (with the [=user consent|user's consent=]) request the
-browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration">Figure <span class="figure-num-following"/></a>, below.
+browser to create a new credential for future use by the [=[RP]=]. See <a href="#fig-registration">Figure <span class="figure-num-following"></span></a>, below.
 
 
 <figure id="fig-registration">
-    <img src="images/webauthn-registration-flow-01.svg"/>
+    <img src="images/webauthn-registration-flow-01.svg"></img>
     <figcaption>Registration Flow</figcaption>
 </figure>
 
 
 Scripts can also request the user’s permission to perform
-[=authentication=] operations with an existing credential. See <a href="#fig-authentication">Figure <span class="figure-num-following"/></a>, below.
+[=authentication=] operations with an existing credential. See <a href="#fig-authentication">Figure <span class="figure-num-following"></span></a>, below.
 
 
 <figure id="fig-authentication">
-    <img src="images/webauthn-authentication-flow-01.svg"/>
+    <img src="images/webauthn-authentication-flow-01.svg"></img>
     <figcaption>Authentication Flow</figcaption>
 </figure>
 
@@ -1523,7 +1529,7 @@ that are returned to the caller when a new credential is created, or a new asser
     interface PublicKeyCredential : Credential {
         [SameObject] readonly attribute ArrayBuffer              rawId;
         [SameObject] readonly attribute AuthenticatorResponse    response;
-        [SameObject] readonly attribute DOMString?               authenticatorAttachment;
+        readonly attribute DOMString?                            authenticatorAttachment;
         AuthenticationExtensionsClientOutputs getClientExtensionResults();
         static Promise<boolean> isConditionalMediationAvailable();
         PublicKeyCredentialJSON toJSON();
@@ -1611,7 +1617,9 @@ that are returned to the caller when a new credential is created, or a new asser
 
 <xmp class="idl">
     typedef DOMString Base64URLString;
-    typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCredentialJSON;
+    // The structure of this object will be either
+    // RegistrationResponseJSON or AuthenticationResponseJSON
+    typedef object PublicKeyCredentialJSON;
 
     dictionary RegistrationResponseJSON {
         required Base64URLString id;
@@ -1689,8 +1697,8 @@ that are returned to the caller when a new credential is created, or a new asser
 
 {{PublicKeyCredential}}'s [=interface object=] inherits {{Credential}}'s implementation of
 {{Credential/[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)}}, and defines its own
-implementation of {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}}, {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}, and
-{{Credential/[[Store]](credential, sameOriginWithAncestors)}}.
+implementation of each of {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}}, {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}, and
+{{PublicKeyCredential/[[Store]](credential, sameOriginWithAncestors)}}.
 
 
 ### `CredentialCreationOptions` Dictionary Extension ### {#sctn-credentialcreationoptions-extension}
@@ -2018,9 +2026,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                         </dl>
 
-                1. Let |attestationFormats| be a list of strings, initialized to the value of <code>|options|.{{PublicKeyCredentialCreationOptions/attestationFormats}}</code>.
+                1. Let |attestationFormats| be a list of strings, initialized to the value of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/attestationFormats}}</code>.
 
-                1. If <code>|options|.{{PublicKeyCredentialCreationOptions/attestation}}</code>
+                1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/attestation}}</code>
 
                         <dl class="switch">
 
@@ -2123,17 +2131,17 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                             :   {{AttestationConveyancePreference/none}}
                             ::  Replace potentially uniquely identifying information with non-identifying versions of the
                                 same:
-                                  1. If the [=AAGUID=] in the [=attested credential data=] is 16 zero bytes, <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> is "packed", and "x5c" is absent from <code>|credentialCreationData|.[=attestationObjectResult=]</code>, then [=self attestation=] is being used and no further action is needed.
+                                  1. If the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] is 16 zero bytes, <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> is "packed", and "x5c" is absent from <code>|credentialCreationData|.[=attestationObjectResult=]</code>, then [=self attestation=] is being used and no further action is needed.
                                   1. Otherwise
-                                      1. Replace the [=AAGUID=] in the [=attested credential data=] with 16 zero bytes.
+                                      1. Replace the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] with 16 zero bytes.
                                       1. Set the value of <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> to "none", and set the value of <code>|credentialCreationData|.[=attestationObjectResult=].attStmt</code> to be an empty [=CBOR=] map. (See [[#sctn-none-attestation]] and [[#sctn-generating-an-attestation-object]]).
 
                             :   {{AttestationConveyancePreference/indirect}}
-                            ::  The client MAY replace the [=AAGUID=] and [=attestation statement=] with a more privacy-friendly
+                            ::  The client MAY replace the [=authData/attestedCredentialData/aaguid=] and [=attestation statement=] with a more privacy-friendly
                                 and/or more easily verifiable version of the same data (for example, by employing an [=Anonymization CA=]).
 
                             :   {{AttestationConveyancePreference/direct}} or {{AttestationConveyancePreference/enterprise}}
-                            ::  Convey the [=authenticator=]'s [=AAGUID=] and [=attestation statement=], unaltered, to the [=[RP]=].
+                            ::  Convey the [=authenticator=]'s [=/AAGUID=] and [=attestation statement=], unaltered, to the [=[RP]=].
                         </dl>
 
                     1.  Let |attestationObject| be a new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the
@@ -2638,7 +2646,7 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
             </dl>
 
     1. Let |enterpriseAttestationPossible| be a Boolean value, as follows. If
-        <code>|options|.{{PublicKeyCredentialRequestOptions/attestation}}</code>
+        <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/attestation}}</code>
 
             <dl class="switch">
 
@@ -2650,9 +2658,9 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
             </dl>
 
-    1. Let |attestationFormats| be a list of strings, initialized to the value of <code>|options|.{{PublicKeyCredentialRequestOptions/attestationFormats}}</code>.
+    1. Let |attestationFormats| be a list of strings, initialized to the value of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/attestationFormats}}</code>.
 
-    1. If <code>|options|.{{PublicKeyCredentialRequestOptions/attestation}}</code>
+    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/attestation}}</code>
 
             <dl class="switch">
 
@@ -2729,8 +2737,10 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
 <div link-for-hint="PublicKeyCredential/[[Store]](credential, sameOriginWithAncestors)">
 
-The <dfn for="PublicKeyCredential" method>\[[Store]](credential, sameOriginWithAncestors)</dfn> method is not supported
-for Web Authentication's {{PublicKeyCredential}} type, so it always throws an error.
+The {{Credential/[[Store]](credential, sameOriginWithAncestors)}} method is not supported
+for Web Authentication's {{PublicKeyCredential}} type,
+so its implementation of the <dfn for="PublicKeyCredential" method>\[[Store]](credential, sameOriginWithAncestors)</dfn>
+[=internal method=] always throws an error.
 
 Note: This algorithm is synchronous; the {{Promise}} resolution/rejection is handled by
 {{CredentialsContainer/store()|navigator.credentials.store()}}.
@@ -2791,7 +2801,7 @@ Note: Invoking this method from a [=browsing context=] where the [=Web Authentic
 <div link-for-hint="WebAuthentication/isPasskeyPlatformAuthenticatorAvailable">
 
 [=[WRPS]=] use this method to determine whether they can create a new [=passkey=] using a [=user-verifying platform authenticator=] or a {{AuthenticatorTransport/hybrid}} authenticator.
-Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the 
+Upon invocation, the [=client=] employs a [=client platform=]-specific procedure to discover available [=user-verifying platform authenticators=] and the
 availability of {{AuthenticatorTransport/hybrid}} transport.
 If one or both are discovered, the promise is resolved with the value of [TRUE].
 If neither is discovered, the promise is resolved with the value of [FALSE].
@@ -3201,10 +3211,14 @@ associated with or [=scoped=] to, respectively.
                 on {{PublicKeyCredentialEntity/name}}'s value prior to displaying the value to the user or
                 including the value as a parameter of the [=authenticatorMakeCredential=] operation.
 
-          - When inherited by {{PublicKeyCredentialUserEntity}}, it is a [=human palatability|human-palatable=] identifier for a
-            [=user account=]. It is intended only for display, i.e., aiding the user in determining the difference between user
-            accounts with similar {{PublicKeyCredentialUserEntity/displayName}}s. For example, "alexm", "alex.mueller@example.com"
-            or "+14255551234".
+          - When inherited by {{PublicKeyCredentialUserEntity}}, it is a
+            [=human palatability|human-palatable=] identifier for a [=user account=]. This
+            identifier is the primary value displayed to users by [=Clients=] to help users
+            understand with which [=user account=] a credential is associated.
+
+            Examples of suitable values for this identifier include, "alexm", "+14255551234",
+            "alex.mueller@example.com", "alex.mueller@example.com (prod-env)",
+            or "alex.mueller@example.com (ОАО Примертех)".
 
               - The [=[RP]=] MAY let the user choose this value. The [=[RP]=] SHOULD perform enforcement,
                 as prescribed in Section 3.4.3 of [[!RFC8265]] for the UsernameCasePreserved Profile of the PRECIS
@@ -3272,8 +3286,12 @@ credential.
         with more than one [=user account=] at the [=[RP]=].
 
     :   <dfn>displayName</dfn>
-    ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for display. For example, "Alex Müller" or "田中倫". The
-        [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice more than necessary.
+    ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for
+        display. The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice
+        more than necessary. If no suitable or [=human palatability|human-palatable=] name is
+        available, the [=[RP]=] SHOULD set this value to an empty string.
+
+        Examples of suitable values for this identifier include, "Alex Müller", "Alex Müller (ACME Co.)" or "田中倫".
 
         - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
@@ -3451,7 +3469,7 @@ Note: The {{AttestationConveyancePreference}} enumeration is deliberately not re
     :   <dfn>enterprise</dfn>
     ::  The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. User agents MUST NOT provide such an attestation unless the user agent or authenticator configuration permits it for the requested [=RP ID=].
 
-        If permitted, the user agent SHOULD signal to the authenticator (at [invocation time](#CreateCred-InvokeAuthnrMakeCred)) that enterprise attestation is requested, and convey the resulting [=AAGUID=] and [=attestation statement=], unaltered, to the [=[RP]=].
+        If permitted, the user agent SHOULD signal to the authenticator (at [invocation time](#CreateCred-InvokeAuthnrMakeCred)) that enterprise attestation is requested, and convey the resulting [=/AAGUID=] and [=attestation statement=], unaltered, to the [=[RP]=].
 </div>
 
 
@@ -3874,6 +3892,8 @@ It mirrors some fields of the {{PublicKeyCredential}} object returned by
 
         This mirrors the {{Credential/type}} field of {{PublicKeyCredential}}.
 
+        Note: If all {{PublicKeyCredentialDescriptor}} elements in {{PublicKeyCredentialRequestOptions/allowCredentials}} are ignored then that MUST result in an error since an empty {{PublicKeyCredentialRequestOptions/allowCredentials}} is semantically distinct.
+
     :   <dfn>id</dfn>
     ::  This member contains the [=credential ID=] of the [=public key credential=] the caller is referring to.
 
@@ -4085,11 +4105,12 @@ considered more trustworthy than the rest of the authenticator.
 Each authenticator stores a <dfn for=authenticator>credentials map</dfn>, a [=map=] from ([=rpId=], [=public key credential source/userHandle=]) to
 [=public key credential source=].
 
-Additionally, each authenticator has an AAGUID, which is a 128-bit identifier indicating the type (e.g. make and model) of the
-authenticator. The AAGUID MUST be chosen by the manufacturer to be identical across all substantially identical authenticators
-made by that manufacturer, and different (with high probability) from the AAGUIDs of all other types of authenticators.
-The AAGUID for a given type of authenticator SHOULD be randomly generated to ensure this. The [=[RP]=] MAY use the AAGUID to infer certain
-properties of the authenticator, such as certification level and strength of key protection, using information from other sources.
+Additionally, each authenticator has an Authenticator Attestation Globally Unique Identifier or <dfn>AAGUID</dfn>, which is a 128-bit identifier
+indicating the type (e.g. make and model) of the authenticator. The AAGUID MUST be chosen by its maker to be identical across all substantially identical
+authenticators made by that maker, and different (with high probability) from the AAGUIDs of all other types of authenticators. The AAGUID for a given type
+of authenticator SHOULD be randomly generated to ensure this. The [=[RP]=] MAY use the AAGUID to infer certain properties of the authenticator, such as
+certification level and strength of key protection, using information from other sources. The [=[RP]=] MAY use the AAGUID to attempt to identify the maker of
+the authenticator without requesting and verifying [=attestation=], but the AAGUID is not provably authentic without [=attestation=].
 
 The primary function of the authenticator is to provide [=WebAuthn signatures=], which are bound to various contextual data. These
 data are observed and added at different levels of the stack as a signature request passes from the server to the
@@ -4144,7 +4165,7 @@ The [=authenticator data=] has a compact but extensible encoding. This is desire
 limited capabilities and low power requirements, with much simpler software stacks than the [=client platform=].
 
 The [=authenticator data=] structure is a byte array of 37 bytes or more,
-laid out as shown in <a href="#table-authData">Table <span class="table-ref-following"/></a>.
+laid out as shown in <a href="#table-authData">Table <span class="table-ref-following"></span></a>.
 
 
 <figure id="table-authData" class="table">
@@ -4239,10 +4260,10 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
 - If the authenticator does not include any [=authData/extensions|extension data=], it MUST set the [=authData/flags/ED=] [=flag=] to zero, and to one if
     [=authData/extensions|extension data=] is included.
 
-<a href="#fig-authData">Figure <span class="figure-num-following"/></a> shows a visual representation of the [=authenticator data=] structure.
+<a href="#fig-authData">Figure <span class="figure-num-following"></span></a> shows a visual representation of the [=authenticator data=] structure.
 
 <figure id="fig-authData">
-    <img src="images/fido-signature-formats-figure1.svg"/>
+    <img src="images/fido-signature-formats-figure1.svg"></img>
     <figcaption>[=Authenticator data=] layout.</figcaption>
 </figure>
 
@@ -4298,11 +4319,11 @@ the same procedure as other [=assertion signatures=] generated by the [=authenti
 ### Credential Backup State ### {#sctn-credential-backup}
 
 Credential [=backup eligibility=] and current [=backup state=] is conveyed by the [=authData/flags/BE=] and [=authData/flags/BS=] [=flags=] in the [=authenticator data=], as
-defined in <a href="#table-authData">Table <span class="table-ref-previous"/></a>.
+defined in <a href="#table-authData">Table <span class="table-ref-previous"></span></a>.
 
 The value of the [=authData/flags/BE=] [=flag=] is set during [=authenticatorMakeCredential=] operation and MUST NOT change.
 
-The value of the [=authData/flags/BS=] [=flag=] may change over time based on the current state of the [=public key credential source=]. <a href="#table-backupStates">Table <span class="table-ref-following"/></a> below defines
+The value of the [=authData/flags/BS=] [=flag=] may change over time based on the current state of the [=public key credential source=]. <a href="#table-backupStates">Table <span class="table-ref-following"></span></a> below defines
 valid combinations and their meaning.
 
 <figure id="table-backupStates" class="table">
@@ -4404,7 +4425,7 @@ The above examples illustrate the primary <dfn>authenticator type</dfn> characte
 - Whether the authenticator is [=discoverable credential capable=] &mdash; the [=credential storage modality=].
 
 These characteristics are independent and may in theory be combined in any way,
-but <a href="#table-authenticatorTypes">Table <span class="table-ref-following"/></a>
+but <a href="#table-authenticatorTypes">Table <span class="table-ref-following"></span></a>
 lists and names some [=authenticator types=] of particular interest.
 
 
@@ -4470,7 +4491,7 @@ typically a PIN or [=biometric recognition=].
 The [=authenticator=] can thus act as two kinds of [=authentication factor=],
 which enables [=multi-factor=] authentication while eliminating the need to share a password with the [=[RP]=].
 
-The combinations not named in <a href="#table-authenticatorTypes">Table <span class="table-ref-previous"/></a>
+The combinations not named in <a href="#table-authenticatorTypes">Table <span class="table-ref-previous"></span></a>
 have less distinguished use cases:
 
 
@@ -4830,13 +4851,13 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     specified in [[#sctn-authenticator-data]] including |processedExtensions|, if any, as
     the <code>[=authData/extensions=]</code> and excluding <code>[=attestedCredentialData=]</code>. This |authenticatorData| MUST include [=attested credential data=] if, and only if, |attestationFormat| is not `none`.
 1. Let |signature| be the [=assertion signature=] of the concatenation <code>|authenticatorData| || |hash|</code> using the
-    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature">Figure <span class="figure-num-following"/></a>, below. A simple,
+    [=public key credential source/privateKey=] of |selectedCredential| as shown in <a href="#fig-signature">Figure <span class="figure-num-following"></span></a>, below. A simple,
     undelimited
     concatenation is safe to use here because the [=authenticator data=] describes its own length. The [=hash of the serialized
     client data=] (which potentially has a variable length) is always the last element.
 
     <figure id="fig-signature">
-        <img src="images/fido-signature-formats-figure2.svg"/>
+        <img src="images/fido-signature-formats-figure2.svg"></img>
         <figcaption>Generating an [=assertion signature=].</figcaption>
     </figure>
 
@@ -4941,10 +4962,10 @@ Authenticators may be required to store arbitrary strings chosen by a [=[RP]=], 
 
 Each arbitrary string in the API will have some accommodation for the potentially limited resources available to an [=authenticator=]. If string value truncation is the chosen accommodation then authenticators MAY truncate in order to make the string fit within a length equal or greater than the specified minimum supported length. Such truncation SHOULD also respect UTF-8 sequence boundaries or [=grapheme cluster=] boundaries [[UAX29]]. This defines the maximum truncation permitted and authenticators MUST NOT truncate further.
 
-For example, in <a href="#fig-stringTruncation">figure <span class="figure-num-following"/></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
+For example, in <a href="#fig-stringTruncation">figure <span class="figure-num-following"></span></a> the string is 65 bytes long. If truncating to 64 bytes then the final 0x88 byte must be removed purely because of space reasons. Since that leaves a partial UTF-8 sequence the remainder of that sequence may also be removed. Since that leaves a partial [=grapheme cluster=] an authenticator may remove the remainder of that cluster.
 
 <figure id="fig-stringTruncation">
-    <img src="images/string-truncation.svg"/>
+    <img src="images/string-truncation.svg"></img>
     <figcaption>The end of a UTF-8 encoded string showing the positions of different truncation boundaries.</figcaption>
 </figure>
 
@@ -4987,14 +5008,14 @@ or otherwise perform [=None|no attestation=].
 
 All this information is returned by [=authenticators=] any time a new [=public key credential=] is generated, and optionally when exercised, in the overall form of an
 <dfn>attestation object</dfn>. The relationship of the [=attestation object=] with [=authenticator data=] (containing
-[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs">figure <span class="figure-num-following"/></a>, below.
+[=attested credential data=]) and the [=attestation statement=] is illustrated in <a href="#fig-attStructs">figure <span class="figure-num-following"></span></a>, below.
 
 If an [=authenticator=] employs [=self attestation=] or [=None|no attestation=], then no provenance information is provided
 for the [=[RP]=] to base a trust decision on.
 In these cases, the [=authenticator=] provides no guarantees about its operation to the [=[RP]=].
 
 <figure id="fig-attStructs">
-    <img src="images/fido-attestation-structures.svg"/>
+    <img src="images/fido-attestation-structures.svg"></img>
     <figcaption>[=Attestation object=] layout illustrating the included [=authenticator data=] from a {{CredentialsContainer/create()|create()}} operation (containing [=attested credential
     data=]) and the [=attestation statement=].</figcaption>
 </figure>
@@ -5053,7 +5074,7 @@ Attestations in [=assertions=] could be helpful in at least the following situat
 ### Attested Credential Data ### {#sctn-attested-credential-data}
 
 <dfn>Attested credential data</dfn> is a variable-length byte array added to the [=authenticator data=] when generating an [=attestation
-object=] for a credential. Its format is shown in <a href="#table-attestedCredentialData">Table <span class="table-ref-following"/></a>.
+object=] for a credential. Its format is shown in <a href="#table-attestedCredentialData">Table <span class="table-ref-following"></span></a>.
 
 <figure id="table-attestedCredentialData" class="table">
     <table class="complex data longlastcol" dfn-for="authData/attestedCredentialData">
@@ -5065,7 +5086,7 @@ object=] for a credential. Its format is shown in <a href="#table-attestedCreden
         <tr>
             <td><dfn>aaguid</dfn></td>
             <td>16</td>
-            <td>The AAGUID of the authenticator.</td>
+            <td>The [=/AAGUID=] of the authenticator.</td>
         </tr>
         <tr>
             <td><dfn>credentialIdLength</dfn></td>
@@ -5459,7 +5480,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         If validation is successful, obtain a list of acceptable trust anchors (i.e. attestation root certificates)
         for that attestation type and attestation statement format |fmt|, from a trusted source or from policy. For
         example, the FIDO Metadata Service [[FIDOMetadataService]] provides one way to obtain such information, using the
-        <code>[=aaguid=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|.
+        <code>[=authData/attestedCredentialData/aaguid=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|.
     </li>
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
@@ -5709,7 +5730,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
         Note: Each [=attestation statement format=] specifies its own [=verification procedure=]. See [[#sctn-defined-attestation-formats]] for the initially-defined formats, and [[!IANA-WebAuthn-Registries]] for the up-to-date list.
 
-    1. If validation is successful, obtain a list of acceptable trust anchors (i.e. attestation root certificates) for that attestation type and attestation statement format |fmt|, from a trusted source or from policy. The [=aaguid=] in the [=attested credential data=] can be used to guide this lookup.
+    1. If validation is successful, obtain a list of acceptable trust anchors (i.e. attestation root certificates) for that attestation type and attestation statement format |fmt|, from a trusted source or from policy. The [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] can be used to guide this lookup.
 
     <li id='authn-ceremony-update-credential-record'>
         Update |credentialRecord| with new state values:
@@ -5838,7 +5859,7 @@ implementable by [=authenticators=] with limited resources (e.g., secure element
                 attestation public key in |attestnCert| with the algorithm specified in |alg|.
             - Verify that |attestnCert| meets the requirements in [[#sctn-packed-attestation-cert-requirements]].
             - If |attestnCert| contains an extension with OID `1.3.6.1.4.1.45724.1.1.4` (`id-fido-gen-ce-aaguid`) verify that the
-                value of this extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
+                value of this extension matches the <code>[=authData/attestedCredentialData/aaguid=]</code> in |authenticatorData|.
             - Optionally, inspect |x5c| and consult externally provided knowledge to determine whether |attStmt| conveys a
                 [=Basic=] or [=AttCA=] attestation.
             - If successful, return implementation-specific values representing [=attestation type=] [=Basic=], [=AttCA=] or
@@ -5987,7 +6008,7 @@ engine.
         algorithm specified in |alg|.
     - Verify that |aikCert| meets the requirements in [[#sctn-tpm-cert-requirements]].
     - If |aikCert| contains an extension with OID `1.3.6.1.4.1.45724.1.1.4` (`id-fido-gen-ce-aaguid`) verify that the value of this
-        extension matches the <code>[=aaguid=]</code> in |authenticatorData|.
+        extension matches the <code>[=authData/attestedCredentialData/aaguid=]</code> in |authenticatorData|.
     - If successful, return implementation-specific values representing [=attestation type=] [=AttCA=] and [=attestation trust
         path=] |x5c|.
 
@@ -6308,6 +6329,45 @@ This attestation statement format is exclusively used by Apple for certain types
     4. Verify that |nonce| equals the value of the extension with OID `1.2.840.113635.100.8.2` in |credCert|.
     5. Verify that the [=credential public key=] equals the Subject Public Key of |credCert|.
     6. If successful, return implementation-specific values representing attestation type [=Anonymization CA=] and attestation trust path |x5c|.
+
+## Compound Attestation Statement Format ## {#sctn-compound-attestation}
+
+The "compound" attestation statement format is used to pass multiple, self-contained attestation statements in a single ceremony.
+
+
+: Attestation statement format identifier
+:: compound
+
+: Attestation types supported
+:: Any. See [[#sctn-attestation-types]].
+
+: Syntax
+:: The syntax of a compound attestation statement is defined as follows:
+
+    ```
+    $$attStmtType //= (
+                          fmt: "compound",
+                          attStmt: [2* nonCompoundAttStmt]
+                      )
+
+    nonCompoundAttStmt = { $$attStmtType } .within { fmt: text .ne "compound" }
+    ```
+
+: Signing procedure
+:: Not applicable
+
+: Verification procedure
+:: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
+    as follows:
+    1. [=list/For each=] |subStmt| of |attStmt|, evaluate the [=verification procedure=]
+        corresponding to the [=attestation statement format identifier=] <code>|subStmt|.fmt</code>
+        with [=verification procedure inputs=] |subStmt|, |authenticatorData| and |clientDataHash|.
+
+        If validation fails for one or more |subStmt|, decide the appropriate result based on [=[RP]=] policy.
+
+    2. If sufficiently many (as determined by [=[RP]=] policy) [=list/items=] of |attStmt| verify successfully,
+        return implementation-specific values representing any combination of outputs from successful [=verification procedures=].
+
 
 # <dfn>WebAuthn Extensions</dfn> # {#sctn-extensions}
 
@@ -6715,9 +6775,6 @@ During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a popu
 
 This [=client extension|client=] [=registration extension=] facilitates reporting certain [=credential properties=] known by the [=client=] to the requesting [=[WRP]=] upon creation of a [=public key credential source=] as a result of a [=registration ceremony=].
 
-At this time, one [=credential property=] is defined: the [=resident key credential property=]
-(i.e., [=client-side discoverable credential property=]).
-
 : Extension identifier
 :: `credProps`
 
@@ -6741,6 +6798,7 @@ At this time, one [=credential property=] is defined: the [=resident key credent
     <xmp class="idl">
     dictionary CredentialPropertiesOutput {
         boolean rk;
+        USVString authenticatorDisplayName;
     };
 
     partial dictionary AuthenticationExtensionsClientOutputs {
@@ -6759,6 +6817,24 @@ At this time, one [=credential property=] is defined: the [=resident key credent
             If {{rk}} is not present, it is not known whether the credential is a [=discoverable credential=] or a [=server-side credential=].
 
             Note: some [=authenticators=] create [=discoverable credentials=] even when not requested by the [=client platform=]. Because of this, [=client platforms=] may be forced to omit the {{rk}} property because they lack the assurance to be able to set it to [FALSE]. [=[RPS]=] should assume that, if the `credProps` extension is supported, then [=client platforms=] will endeavour to populate the {{rk}} property. Therefore a missing {{rk}} indicates that the created credential is most likely a [=non-discoverable credential=].
+
+        :   <dfn>authenticatorDisplayName</dfn>
+        ::  This OPTIONAL property is a [=human palatability|human-palatable=] description of the credential's [=managing authenticator=],
+            chosen by the user.
+
+            The [=client=] MUST allow the user to choose this value,
+            MAY or MAY not present that choice during [=registration ceremonies=],
+            and MAY reuse the same value for multiple credentials with the same [=managing authenticator=] across multiple [=[RPS]=].
+
+            The [=client=] MAY query the [=authenticator=], by some unspecified mechanism, for this value.
+            The [=authenticator=] MAY allow the user to configure the response to such a query.
+            The [=authenticator=] vendor MAY provide a default response to such a query.
+            The [=client=] MAY consider a user-configured response chosen by the user,
+            and SHOULD allow the user to modify a vendor-provided default response.
+
+            If the [=[RP]=] includes an <code>[$credential record/authenticatorDisplayName$]</code> [=struct/item=] in [=credential records=],
+            the [=[RP]=] MAY offer this value, if present,
+            as a default value for the <code>[$credential record/authenticatorDisplayName$]</code> of the new [=credential record=].
     </div>
 
 
@@ -6823,8 +6899,6 @@ Note: this extension may be implemented for [=authenticators=] that do not use [
            * If <code>{{AuthenticationExtensionsPRFInputs/eval}}.{{AuthenticationExtensionsPRFValues/second}}</code> is present, let `salt2` be the value of <code>SHA-256(UTF8Encode("WebAuthn PRF") || 0x00 || {{AuthenticationExtensionsPRFInputs/eval}}.{{AuthenticationExtensionsPRFValues/second}})</code>.
        1. Set {{AuthenticationExtensionsPRFOutputs/enabled}} to the value of `hmac-secret` in the authenticator extensions output. If not present, set {{AuthenticationExtensionsPRFOutputs/enabled}} to [FALSE].
        1. Set {{AuthenticationExtensionsPRFOutputs/results}} to the decrypted PRF result(s), if any.
-
-Note: If PRF results are obtained during [=registration=] then the [=[RP]=] MUST inspect the [=UV=] bit in the [=flags=] of the response in order to determine the correct value of {{PublicKeyCredentialRequestOptions/userVerification}} for future [=assertions=]. Otherwise results from [=assertions=] may be inconsistent with those from the [=registration=].
 
 : Client extension processing ([=authentication extension|authentication=])
 ::
@@ -7291,10 +7365,10 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
                 :: |attFormat| is "none" or "self", at the authenticator's discretion, and |attAaguid| is 16 zero bytes. (Note that, since the [=supplemental public key=] is already exercised during {{CredentialsContainer/create()|navigator.credentials.create()}} calls, the proof-of-possession property provided by "self" attestation is superfluous in that context.)
 
                 : indirect, direct
-                :: |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=AAGUID=], which MAY be the [=authenticator's=] AAGUID. (Since the [=supplemental public key=]'s scope is different from the [=user credential=], it will often have a different attestation. For example, the attestation for a [=supplemental public key=] with &ldquo;device&rdquo; scope can be tied to hardware roots of trust, although it does not have to be.)
+                :: |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID. (Since the [=supplemental public key=]'s scope is different from the [=user credential=], it will often have a different attestation. For example, the attestation for a [=supplemental public key=] with &ldquo;device&rdquo; scope can be tied to hardware roots of trust, although it does not have to be.)
 
                 : enterprise
-                :: The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. [=Authenticators=] MUST NOT provide such an attestation unless the user agent or authenticator configuration expressly permits it for the requested [=RP ID=]. If <i>not</i> permitted, then follow the steps for `direct` attestation. Otherwise |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=AAGUID=], which MAY be the [=authenticator's=] AAGUID.
+                :: The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. [=Authenticators=] MUST NOT provide such an attestation unless the user agent or authenticator configuration expressly permits it for the requested [=RP ID=]. If <i>not</i> permitted, then follow the steps for `direct` attestation. Otherwise |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID.
 
                     Note: CTAP2 does not currently provide for an <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#makecred-enterpriseattestation">enterpriseAttestation</a> signal during an <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetAssertion">authenticatorGetAssertion</a> call. Until that is changed, <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#platform-managed-enterprise-attestation">platform-managed enterprise attestation</a> will not work in that context with CTAP2 [=authenticators=].
             </dl>
@@ -7341,7 +7415,7 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
 ##### AAGUIDs ##### {#sctn-supplemental-public-keys-attestation-aaguid}
 
-The [=AAGUID=] included in the <code>[=supplementalPubKeys=]</code> extension output, if non-zero, aids a [=[RP]=] in validating the [=attestation statement=] of the supplemental public key. Its interpretation depends on the scope of the key. It may differ from the [=AAGUID=] in the [=attested credential data=] of a [=multi-device credential=]. Thus the AAGUID of [=supplemental public key=] MAY be different in a single response and either, or both, may be zero depending on the options requested and authenticator behaviour.
+The [=/AAGUID=] included in the <code>[=supplementalPubKeys=]</code> extension output, if non-zero, aids a [=[RP]=] in validating the [=attestation statement=] of the supplemental public key. Its interpretation depends on the scope of the key. It may differ from the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] of a [=multi-device credential=]. Thus the AAGUID of [=supplemental public key=] MAY be different in a single response and either, or both, may be zero depending on the options requested and authenticator behaviour.
 
 ##### Attestation calculations ##### {#sctn-supplemental-public-keys-attestation-calculations}
 
@@ -7371,8 +7445,8 @@ The [=supplementalPubKeys=] extension adds the following [=struct/item=] to [=cr
 
         <dl dfn-for="supplementalPubKeys record" dfn-type="abstract-op">
             :   <dfn>aaguid</dfn>
-            ::  The [=AAGUID=] included with the supplemental public key.
-                This MAY be different from the [=AAGUID=] in the [$credential record/attestationObject$], if any, of the containing [=credential record=].
+            ::  The [=/AAGUID=] included with the supplemental public key.
+                This MAY be different from the [=authData/attestedCredentialData/aaguid=] in the [$credential record/attestationObject$], if any, of the containing [=credential record=].
 
             :   <dfn>spk</dfn>
             ::  The public key portion of the supplemental public key.
@@ -8830,7 +8904,6 @@ Yoshikazu Nojima,
 Kimberly Paulhamus,
 Adam Powers,
 Yaron Sheffer,
-Ki-Eun Shin,
 Anne van Kesteren,
 Johan Verrept,
 and
@@ -9005,10 +9078,10 @@ for their contributions as our W3C Team Contacts.
 
   "FIDO-CTAP": {
     "authors": ["J. Bradley", "J. Hodges", "M. B. Jones", "A. Kumar", "R. Lindemann", "J. Verrept"],
-    "title": "Client to Authenticator Protocol",
-    "href": "https://fidoalliance.org/specs/fido-v2.1-rd-20210309/fido-client-to-authenticator-protocol-v2.1-rd-20210309.html",
-    "status": "FIDO Alliance Review Draft",
-    "date": "9 March 2021"
+    "title": "Client to Authenticator Protocol (CTAP)",
+    "href": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html",
+    "status": "FIDO Alliance Proposed Standard",
+    "date": "15 June 2021"
   },
 
   "FIDO-UAF-AUTHNR-CMDS": {


### PR DESCRIPTION
PR #1970 made `[=AAGUID=]` autolinks ambiguous, requiring them to be disamgiguated as either `[=AAGUID=]` or `[=authData/attestedCredentialData/aaguid=]`. This PR resolves the conflicts with PR #1957 caused by this.

Conflicts:

```diff
diff --git a/index.bs b/index.bs
index 2ea7e3d..966772e 100644
--- a/index.bs
+++ b/index.bs
@@ -7356,9 +7356,17 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
     1. [=map/For each=] |scope| in |scopes|:
 
+<<<<<<< HEAD
         1. If a supplemental key with scope |scope| does not already exist for this {[=public key credential source/id|Credential ID=], [=public key credential source/rpId|RP ID=], [=public key credential source/rpId|userHandle=]} tuple on the [=authenticator=], create it using the same public key algorithm as that used by the [=user credential=]'s [=credential key pair=], otherwise locate the existing supplemental key.
 
         1. Let |attFormat| be the chosen [=attestation statement format=], and |attAaguid| be a 16-byte value, based on the value of {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestation}} in the extension input:
+=======
+            : indirect, direct
+            :: |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsDevicePublicKeyInputs/attestationFormats}}, and |attAaguid| is the [=authenticator's=] [=/AAGUID=]. (Since the [=hardware-bound device key pair=] is specific to a particular authenticator, its attestation can be tied to hardware roots of trust, although they do not have to be. This is in contrast to the associated [=user credential=]'s attestation, if it is a [=multi-device credential=].)
+
+            : enterprise
+            :: The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. [=Authenticators=] MUST NOT provide such an attestation unless the user agent or authenticator configuration expressly permits it for the requested [=RP ID=]. If <i>not</i> permitted, then |attFormat| is "none" and |attAaguid| is 16 zero bytes. Otherwise |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsDevicePublicKeyInputs/attestationFormats}}, and |attAaguid| is the [=authenticator's=] [=/AAGUID=]. (Again, since the [=hardware-bound device key pair=] is specific to a particular authenticator, the attestation may be tied to hardware roots of trust.)
+>>>>>>> main
 
             <dl class="switch">
                 : none
@@ -7403,7 +7411,11 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
         1. Let |spkSig| be the result of signing the [=assertion signature=] [input](#fig-signature) with the supplemental private key.
 
+<<<<<<< HEAD
             Note: the [=assertion signature=] [input](#fig-signature), and thus |spkSig|, covers the [=[RP]=]'s {{PublicKeyCredentialCreationOptions/challenge}} because it includes the [=hash of the serialized client data=]. Thus the [=[RP]=] knows that |spkSig| is a fresh signature.
+=======
+The [=/AAGUID=] included in the <code>[=devicePubKey=]</code> extension output, if non-zero, identifies the make or model of hardware that is storing the [=device-bound key=]. This is distinct from the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] of a [=multi-device credential=], which likely identifies something broader since such credentials are not bound to a single device. Thus the two AAGUIDs MAY be different in a single response and either, or both, may be zero depending on the options requested and authenticator behaviour.
+>>>>>>> main
 
         1. Append |spkSig| to |spkSigs|.
 
@@ -7445,8 +7457,13 @@ The [=supplementalPubKeys=] extension adds the following [=struct/item=] to [=cr
 
         <dl dfn-for="supplementalPubKeys record" dfn-type="abstract-op">
             :   <dfn>aaguid</dfn>
+<<<<<<< HEAD
             ::  The [=AAGUID=] included with the supplemental public key.
                 This MAY be different from the [=AAGUID=] in the [$credential record/attestationObject$], if any, of the containing [=credential record=].
+=======
+            ::  The [=/AAGUID=] of the [=device-bound key=]'s [=managing authenticator=].
+                This MAY be different from the [=authData/attestedCredentialData/aaguid=] in the [$credential record/attestationObject$], if any, of the containing [=credential record=].
+>>>>>>> main
 
             :   <dfn>spk</dfn>
             ::  The public key portion of the supplemental public key.
```

Resolution:
```diff
diff --git a/index.bs b/index.bs
index c0fc031..fe14aee 100644
--- a/index.bs
+++ b/index.bs
@@ -7291,10 +7365,10 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
                 :: |attFormat| is "none" or "self", at the authenticator's discretion, and |attAaguid| is 16 zero bytes. (Note that, since the [=supplemental public key=] is already exercised during {{CredentialsContainer/create()|navigator.credentials.create()}} calls, the proof-of-possession property provided by "self" attestation is superfluous in that context.)
 
                 : indirect, direct
-                :: |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=AAGUID=], which MAY be the [=authenticator's=] AAGUID. (Since the [=supplemental public key=]'s scope is different from the [=user credential=], it will often have a different attestation. For example, the attestation for a [=supplemental public key=] with &ldquo;device&rdquo; scope can be tied to hardware roots of trust, although it does not have to be.)
+                :: |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID. (Since the [=supplemental public key=]'s scope is different from the [=user credential=], it will often have a different attestation. For example, the attestation for a [=supplemental public key=] with &ldquo;device&rdquo; scope can be tied to hardware roots of trust, although it does not have to be.)
 
                 : enterprise
-                :: The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. [=Authenticators=] MUST NOT provide such an attestation unless the user agent or authenticator configuration expressly permits it for the requested [=RP ID=]. If <i>not</i> permitted, then follow the steps for `direct` attestation. Otherwise |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=AAGUID=], which MAY be the [=authenticator's=] AAGUID.
+                :: The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. [=Authenticators=] MUST NOT provide such an attestation unless the user agent or authenticator configuration expressly permits it for the requested [=RP ID=]. If <i>not</i> permitted, then follow the steps for `direct` attestation. Otherwise |attFormat| is an [=attestation statement format=] appropriate for this [=authenticator=] based on {{AuthenticationExtensionsSupplementalPublicKeysInputs/attestationFormats}}, and |attAaguid| is the corresponding [=/AAGUID=], which MAY be the [=authenticator's=] AAGUID.
 
                     Note: CTAP2 does not currently provide for an <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#makecred-enterpriseattestation">enterpriseAttestation</a> signal during an <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetAssertion">authenticatorGetAssertion</a> call. Until that is changed, <a href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#platform-managed-enterprise-attestation">platform-managed enterprise attestation</a> will not work in that context with CTAP2 [=authenticators=].
             </dl>
@@ -7341,7 +7415,7 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 
 ##### AAGUIDs ##### {#sctn-supplemental-public-keys-attestation-aaguid}
 
-The [=AAGUID=] included in the <code>[=supplementalPubKeys=]</code> extension output, if non-zero, aids a [=[RP]=] in validating the [=attestation statement=] of the supplemental public key. Its interpretation depends on the scope of the key. It may differ from the [=AAGUID=] in the [=attested credential data=] of a [=multi-device credential=]. Thus the AAGUID of [=supplemental public key=] MAY be different in a single response and either, or both, may be zero depending on the options requested and authenticator behaviour.
+The [=/AAGUID=] included in the <code>[=supplementalPubKeys=]</code> extension output, if non-zero, aids a [=[RP]=] in validating the [=attestation statement=] of the supplemental public key. Its interpretation depends on the scope of the key. It may differ from the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] of a [=multi-device credential=]. Thus the AAGUID of [=supplemental public key=] MAY be different in a single response and either, or both, may be zero depending on the options requested and authenticator behaviour.
 
 ##### Attestation calculations ##### {#sctn-supplemental-public-keys-attestation-calculations}
 
@@ -7371,8 +7445,8 @@ The [=supplementalPubKeys=] extension adds the following [=struct/item=] to [=cr
 
         <dl dfn-for="supplementalPubKeys record" dfn-type="abstract-op">
             :   <dfn>aaguid</dfn>
-            ::  The [=AAGUID=] included with the supplemental public key.
-                This MAY be different from the [=AAGUID=] in the [$credential record/attestationObject$], if any, of the containing [=credential record=].
+            ::  The [=/AAGUID=] included with the supplemental public key.
+                This MAY be different from the [=authData/attestedCredentialData/aaguid=] in the [$credential record/attestationObject$], if any, of the containing [=credential record=].
 
             :   <dfn>spk</dfn>
             ::  The public key portion of the supplemental public key.
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/1996.html" title="Last updated on Nov 15, 2023, 10:20 PM UTC (aedfab0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1996/28d90b2...aedfab0.html" title="Last updated on Nov 15, 2023, 10:20 PM UTC (aedfab0)">Diff</a>