### PR TITLE
Add backup flags to virtual authenticator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7765,9 +7765,13 @@ Each stored [=virtual authenticator=] has the following properties:
 
     Note: This property has no effect if the [=Virtual Authenticator=] does not support the [=User Verification Method=] extension.
 : |defaultBackupEligibility|
-:: Determines the default state of the [=backup eligibility=] [=flag=] ([=BE=]) for any newly created [=Public Key Credential Source=].
+:: Determines the default state of the [=backup eligibility=] [=credential property=] for any newly created [=Public Key Credential Source=].
+    This value MUST be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
+    operation with this [=virtual authenticator=].
 : |defaultBackupState|
-:: Determines the default state of the [=backup state=] [=flag=] ([=BS=]) for any newly created [=Public Key Credential Source=].
+:: Determines the default state of the [=backup state=] [=credential property=] for any newly created [=Public Key Credential Source=].
+    This value MUST be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
+    operation with this [=virtual authenticator=].
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
@@ -8011,6 +8015,8 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>
                     The simulated [=backup eligibility=] for the [=public key credential source=]. If unset, the value will default to the
                     [=virtual authenticator=]'s |defaultBackupEligibility| property.
+                    This value MUST be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing an [=authenticatorGetAssertion=]
+                    operation with this [=public key credential source=].
                 </td>
                 <td>boolean</td>
             </tr>
@@ -8019,6 +8025,8 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>
                     The simulated [=backup state=] for the [=public key credential source=]. If unset, the value will default to the
                     [=virtual authenticator=]'s |defaultBackupState| property.
+                    This value MUST be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing an [=authenticatorGetAssertion=]
+                    operation with this [=public key credential source=].
                 </td>
                 <td>boolean</td>
             </tr>
@@ -8074,8 +8082,8 @@ The [=remote end steps=] are:
     :: |rpId|
     : [=public key credential source/userHandle=]
     :: |userHandle|
- 1. Set |credential|'s [=backup eligibility=] [=credential property=] to |backupEligibility|.
- 1. Set |credential|'s [=backup state=] [=credential property=] to |backupState|.
+ 1. Set the |credential|'s [=backup eligibility=] [=credential property=] to |backupEligibility|.
+ 1. Set the |credential|'s [=backup state=] [=credential property=] to |backupState|.
  1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'
      |signCount| or `0` if |signCount| is `null`.
  1. If |largeBlob| is not `null`, set the [=large, per-credential blob=] associated to the |credential| to |largeBlob|.

--- a/index.bs
+++ b/index.bs
@@ -8277,13 +8277,13 @@ The [=remote end steps=] are:
  1. Let |credential| be the [=public key credential source=] managed by |authenticator| matched by |credentialId|.
  1. If |credential| is empty, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Let |backupEligibility| be the |parameters|' |backupEligibility| property.
- 1. If |backupEligibility| is defined, set the [=backup eligibility=] [=credential property=] of |credential| to its value.
+ 1. If |backupEligibility| is defined, set the [=backup eligibility=] [=credential property=] of |credential| to the value of |backupEligibility|.
 
     Note: Normally, the |backupEligibility| property is permanent to a [=public key credential source=].
     [=Set Credential Properties=] allows changing it for testing and debugging purposes.
 
  1. Let |backupState| be the |parameters|' |backupState| property.
- 1. If |backupState| is defined, set the [=backup state=] [=credential property=] of |credential| to its value.
+ 1. If |backupState| is defined, set the [=backup state=] [=credential property=] of |credential| to the value of |backupState|.
  1. Return [=success=].
 
 # IANA Considerations # {#sctn-IANA}

--- a/index.bs
+++ b/index.bs
@@ -7764,6 +7764,10 @@ Each stored [=virtual authenticator=] has the following properties:
 :: A {{UvmEntries}} array to be set as the [=authenticator extension output=] when processing the [=User Verification Method=] extension.
 
     Note: This property has no effect if the [=Virtual Authenticator=] does not support the [=User Verification Method=] extension.
+: |defaultBackupEligibility|
+:: Determines the default state of the [=backup eligibility=] [=flag=] ([=BE=]) for any newly created [=Public Key Credential Source=].
+: |defaultBackupState|
+:: Determines the default state of the [=backup state=] [=flag=] ([=BS=]) for any newly created [=Public Key Credential Source=].
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
 
@@ -7847,6 +7851,18 @@ The <dfn>Authenticator Configuration</dfn> is a JSON [=Object=] passed to the [=
                 <td>{{UvmEntries}}</td>
                 <td>Up to 3 [=User Verification Method=] entries</td>
                 <td>Empty array</td>
+            </tr>
+            <tr>
+                <td>|defaultBackupEligibility|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[FALSE]</td>
+            </tr>
+            <tr>
+                <td>|defaultBackupState|</td>
+                <td>boolean</td>
+                <td>[TRUE], [FALSE]</td>
+                <td>[FALSE]</td>
             </tr>
         </tbody>
     </table>
@@ -7990,6 +8006,22 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 </td>
                 <td>string</td>
             </tr>
+            <tr>
+                <td>|backupEligibility|</td>
+                <td>
+                    The simulated [=backup eligibility=] for the [=public key credential source=]. If unset, the value will default to the
+                    [=virtual authenticator=]'s |defaultBackupEligibility| property.
+                </td>
+                <td>boolean</td>
+            </tr>
+            <tr>
+                <td>|backupState|</td>
+                <td>
+                    The simulated [=backup state=] for the [=public key credential source=]. If unset, the value will default to the
+                    [=virtual authenticator=]'s |defaultBackupState| property.
+                </td>
+                <td>boolean</td>
+            </tr>
         </tbody>
     </table>
 </figure>
@@ -8026,6 +8058,10 @@ The [=remote end steps=] are:
      1. If |largeBlob| is failure, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. Otherwise:
      1. Let |largeBlob| be `null`.
+ 1. Let |backupEligibility| be the |parameters|' |backupEligibility| property.
+ 1. If |backupEligibility| is not defined, set |backupEligibility| to the value of the |authenticator|'s |defaultBackupEligibility|.
+ 1. Let |backupState| be the |parameters|' |backupState| property.
+ 1. If |backupState| is not defined, set |backupState| to the value of the |authenticator|'s |defaultBackupState|.
  1. Let |credential| be a new [=Client-side discoverable Public Key Credential Source=] if |isResidentCredential| is [TRUE]
      or a [=Server-side Public Key Credential Source=] otherwise whose items are:
     : [=public key credential source/type=]
@@ -8038,6 +8074,8 @@ The [=remote end steps=] are:
     :: |rpId|
     : [=public key credential source/userHandle=]
     :: |userHandle|
+ 1. Set |credential|'s [=backup eligibility=] [=credential property=] to |backupEligibility|.
+ 1. Set |credential|'s [=backup state=] [=credential property=] to |backupState|.
  1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'
      |signCount| or `0` if |signCount| is `null`.
  1. If |largeBlob| is not `null`, set the [=large, per-credential blob=] associated to the |credential| to |largeBlob|.
@@ -8169,6 +8207,75 @@ The [=remote end steps=] are:
      [=invalid argument=].
  1. Let |authenticator| be the [=Virtual Authenticator=] identified by |authenticatorId|.
  1. Set the |authenticator|'s |isUserVerified| property to the |parameters|' |isUserVerified| property.
+ 1. Return [=success=].
+
+## <dfn>Set Credential Properties</dfn> ## {#sctn-automation-set-credential-properties}
+
+The [=Set Credential Properties=] [=extension command=] allows setting the |backupEligibility| and |backupState| [=credential properties=] of
+a [=Virtual Authenticator=]'s [=public key credential source=]. It is defined as follows:
+
+<figure id="table-setFlags" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>HTTP Method</th>
+                <th>URI Template</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>POST</td>
+                <td>`/session/{session id}/webauthn/authenticator/{authenticatorId}/credentials/{credentialId}/props`</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The <dfn>Set Credential Properties Parameters</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|.
+It contains the following |key| and |value| pairs:
+
+<figure id="table-setCredentialPropertiesParameters" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Description</th>
+                <th>Value Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>|backupEligibility|</td>
+                <td>The [=backup eligibility=] [=credential property=].</td>
+                <td>boolean</td>
+            </tr>
+            <tr>
+                <td>|backupState|</td>
+                <td>The [=backup state=] [=credential property=].</td>
+                <td>boolean</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
+The [=remote end steps=] are:
+
+ 1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
+     [=invalid argument=].
+
+     Note: |parameters| is a [=Set Credential Properties Parameters=] object.
+ 1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
+     Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |credential| be the [=public key credential source=] managed by |authenticator| matched by |credentialId|.
+ 1. If |credential| is empty, return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
+ 1. Let |backupEligibility| be the |parameters|' |backupEligibility| property.
+ 1. If |backupEligibility| is defined, set the [=backup eligibility=] [=credential property=] of |credential| to its value.
+
+    Note: Normally, the |backupEligibility| property is permanent to a [=public key credential source=].
+    [=Set Credential Properties=] allows changing it for testing and debugging purposes.
+
+ 1. Let |backupState| be the |parameters|' |backupState| property.
+ 1. If |backupState| is defined, set the [=backup state=] [=credential property=] of |credential| to its value.
  1. Return [=success=].
 
 # IANA Considerations # {#sctn-IANA}

--- a/index.bs
+++ b/index.bs
@@ -7766,11 +7766,11 @@ Each stored [=virtual authenticator=] has the following properties:
     Note: This property has no effect if the [=Virtual Authenticator=] does not support the [=User Verification Method=] extension.
 : |defaultBackupEligibility|
 :: Determines the default state of the [=backup eligibility=] [=credential property=] for any newly created [=Public Key Credential Source=].
-    This value SHOULD be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
+    This value MUST be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
     operation with this [=virtual authenticator=].
 : |defaultBackupState|
 :: Determines the default state of the [=backup state=] [=credential property=] for any newly created [=Public Key Credential Source=].
-    This value SHOULD be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
+    This value MUST be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
     operation with this [=virtual authenticator=].
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
@@ -8015,7 +8015,7 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>
                     The simulated [=backup eligibility=] for the [=public key credential source=]. If unset, the value will default to the
                     [=virtual authenticator=]'s |defaultBackupEligibility| property.
-                    The simulated [=backup eligibility=] SHOULD be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing
+                    The simulated [=backup eligibility=] MUST be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing
                     an [=authenticatorGetAssertion=] operation with this [=public key credential source=].
                 </td>
                 <td>boolean</td>
@@ -8025,7 +8025,7 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>
                     The simulated [=backup state=] for the [=public key credential source=]. If unset, the value will default to the
                     [=virtual authenticator=]'s |defaultBackupState| property.
-                    The simulated [=backup state=] SHOULD be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing
+                    The simulated [=backup state=] MUST be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing
                     an [=authenticatorGetAssertion=] operation with this [=public key credential source=].
                 </td>
                 <td>boolean</td>

--- a/index.bs
+++ b/index.bs
@@ -7766,11 +7766,11 @@ Each stored [=virtual authenticator=] has the following properties:
     Note: This property has no effect if the [=Virtual Authenticator=] does not support the [=User Verification Method=] extension.
 : |defaultBackupEligibility|
 :: Determines the default state of the [=backup eligibility=] [=credential property=] for any newly created [=Public Key Credential Source=].
-    This value MUST be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
+    This value SHOULD be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
     operation with this [=virtual authenticator=].
 : |defaultBackupState|
 :: Determines the default state of the [=backup state=] [=credential property=] for any newly created [=Public Key Credential Source=].
-    This value MUST be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
+    This value SHOULD be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing an [=authenticatorMakeCredential=]
     operation with this [=virtual authenticator=].
 
 ## <dfn>Add Virtual Authenticator</dfn> ## {#sctn-automation-add-virtual-authenticator}
@@ -8015,8 +8015,8 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>
                     The simulated [=backup eligibility=] for the [=public key credential source=]. If unset, the value will default to the
                     [=virtual authenticator=]'s |defaultBackupEligibility| property.
-                    This value MUST be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing an [=authenticatorGetAssertion=]
-                    operation with this [=public key credential source=].
+                    The simulated [=backup eligibility=] SHOULD be reflected by the [=BE=] [=authenticator data=] [=flag=] when performing
+                    an [=authenticatorGetAssertion=] operation with this [=public key credential source=].
                 </td>
                 <td>boolean</td>
             </tr>
@@ -8025,8 +8025,8 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 <td>
                     The simulated [=backup state=] for the [=public key credential source=]. If unset, the value will default to the
                     [=virtual authenticator=]'s |defaultBackupState| property.
-                    This value MUST be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing an [=authenticatorGetAssertion=]
-                    operation with this [=public key credential source=].
+                    The simulated [=backup state=] SHOULD be reflected by the [=BS=] [=authenticator data=] [=flag=] when performing
+                    an [=authenticatorGetAssertion=] operation with this [=public key credential source=].
                 </td>
                 <td>boolean</td>
             </tr>


### PR DESCRIPTION
Allow setting and changing the backup eligibility (BE) and backup state (BS) flags through the virtual authenticator API.

Fixed: #1987


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nsatragno/webauthn/pull/1999.html" title="Last updated on Nov 22, 2023, 6:16 PM UTC (b0c79de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/1999/f8163ea...nsatragno:b0c79de.html" title="Last updated on Nov 22, 2023, 6:16 PM UTC (b0c79de)">Diff</a>