### PR TITLE
Fix incorrect reference in Add Virtual Authenticator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7862,7 +7862,7 @@ The [=remote end steps=] are:
  1. For each enumerable [=own property=] in |parameters|:
     1. Let |key| be the name of the property.
     1. Let |value| be the result of [=getting a property=] named |key| from |parameters|.
-    1. If there is no matching `key` for |key| in |parameters|, return a [=WebDriver error=] with
+    1. If there is no matching `key` for |key| in [=Authenticator Configuration=], return a [=WebDriver error=] with
         [=WebDriver error code=] [=invalid argument=].
     1. If |value| is not one of the `valid values` for that |key|, return a [=WebDriver error=] with [=WebDriver error code=]
         [=invalid argument=].


### PR DESCRIPTION
[§11.3. Add Virtual Authenticator](https://w3c.github.io/webauthn/#sctn-automation-add-virtual-authenticator) currently reads:

>[...]
>3. For each enumerable [own property](https://tc39.github.io/ecma262/#sec-own-property) in _parameters_:
>
>    1. Let _key_ be the name of the property.
>    2. Let _value_ be the result of [getting a property](https://w3c.github.io/webdriver/#dfn-getting-properties) named _key_ from _parameters_.
>    3. If there is no matching `key` for _key_ in _parameters_, return a [WebDriver error](https://w3c.github.io/webdriver/#dfn-error) with [WebDriver error code](https://w3c.github.io/webdriver/#dfn-error-code) [invalid argument](https://w3c.github.io/webdriver/#dfn-invalid-argument).
>    4. If _value_ is not one of the `valid values` for that _key_, return a [WebDriver error](https://w3c.github.io/webdriver/#dfn-error) with [WebDriver error code](https://w3c.github.io/webdriver/#dfn-error-code) [invalid argument](https://w3c.github.io/webdriver/#dfn-invalid-argument).
>    5. [Set a property](https://w3c.github.io/webdriver/#dfn-set-a-property) _key_ to _value_ on _authenticator_.
>[...]

The third step seems like it was intended to instead refer to [Authenticator Configuration](https://w3c.github.io/webauthn/#authenticator-configuration) as the set of valid keys:

>    3. If there is no matching `key` for _key_ in [Authenticator Configuration](https://w3c.github.io/webauthn/#authenticator-configuration), return a [WebDriver error](https://w3c.github.io/webdriver/#dfn-error) with [WebDriver error code](https://w3c.github.io/webdriver/#dfn-error-code) [invalid argument](https://w3c.github.io/webdriver/#dfn-invalid-argument).

The subsequent step 5 checks that all properties of [Authenticator Configuration](https://w3c.github.io/webauthn/#authenticator-configuration) are defined in _parameters_, so it seems it would make sense that step 3.3 would perform the opposite check, which would make the combination of both a set equality check rather than just a subset check.

@nsatragno Is the above assessment accurate?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2001.html" title="Last updated on Nov 23, 2023, 10:02 AM UTC (a6ee5a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2001/f8163ea...a6ee5a0.html" title="Last updated on Nov 23, 2023, 10:02 AM UTC (a6ee5a0)">Diff</a>