### PR TITLE
Fix references to credential private key that should be credential source

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4573,7 +4573,7 @@ modality</dfn> as follows:
 
 Note that a [=discoverable credential capable=] [=authenticator=] MAY support both storage strategies. In this case, the [=authenticator=] MAY
 at its discretion use different storage strategies for different [=public key credential|credentials=], though subject to the
-{{AuthenticatorSelectionCriteria/residentKey}} or {{AuthenticatorSelectionCriteria/requireResidentKey}} options of
+{{AuthenticatorSelectionCriteria/residentKey}} and {{AuthenticatorSelectionCriteria/requireResidentKey}} options of
 {{CredentialsContainer/create()}}.
 
 

--- a/index.bs
+++ b/index.bs
@@ -4551,13 +4551,14 @@ An [=authenticator=] can store a [=public key credential source=] in one of two 
  1. In persistent storage embedded in the [=authenticator=], [=client=] or [=client device=], e.g., in a secure element.
     This is a technical requirement for a [=client-side discoverable public key credential source=].
 
- 1. By encrypting (i.e., wrapping) the [=credential private key=] such that only this [=authenticator=] can decrypt (i.e., unwrap) it and letting the resulting
-    ciphertext be the [=credential ID=] for the [=public key credential source=]. The [=credential ID=] is stored by the [=[RP]=]
+ 1. By encrypting (i.e., wrapping) the [=public key credential source=]
+    such that only this [=authenticator=] can decrypt (i.e., unwrap) it and letting the resulting
+    ciphertext be the [=credential ID=] of the [=public key credential source=]. The [=credential ID=] is stored by the [=[RP]=]
     and returned to the [=authenticator=] via the {{PublicKeyCredentialRequestOptions/allowCredentials}} option of
-    {{CredentialsContainer/get()}}, which allows the [=authenticator=] to decrypt and use the [=credential private key=].
+    {{CredentialsContainer/get()}}, which allows the [=authenticator=] to decrypt and use the [=public key credential source=].
 
-    This enables the [=authenticator=] to have unlimited storage capacity for [=credential private keys=], since the encrypted
-    [=credential private keys=] are stored by the [=[RP]=] instead of by the [=authenticator=] - but it means that a
+    This enables the [=authenticator=] to have unlimited credential storage capacity, since the encrypted
+    [=public key credential sources=] are stored by the [=[RP]=] instead of by the [=authenticator=] - but it means that a
     [=credential=] stored in this way must be retrieved from the [=[RP]=] before the [=authenticator=] can use it.
 
 Which of these storage strategies an [=authenticator=] supports defines the [=authenticator=]'s <dfn>credential storage
@@ -4568,7 +4569,7 @@ modality</dfn> as follows:
     credential capable</dfn>.
 
 - An [=authenticator=] has the <dfn>server-side credential storage modality</dfn> if it does not have the [=client-side credential storage
-    modality=], i.e., it only supports storing [=credential private keys=] as a ciphertext in the [=credential ID=].
+    modality=], i.e., it only supports storing [=public key credential sources=] as a ciphertext in the [=credential ID=].
 
 Note that a [=discoverable credential capable=] [=authenticator=] MAY support both storage strategies. In this case, the [=authenticator=] MAY
 at its discretion use different storage strategies for different [=public key credential|credentials=], though subject to the


### PR DESCRIPTION
Fixes #2002.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2003.html" title="Last updated on Nov 28, 2023, 12:15 PM UTC (dbf6ca2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2003/f8163ea...dbf6ca2.html" title="Last updated on Nov 28, 2023, 12:15 PM UTC (dbf6ca2)">Diff</a>