### PR TITLE
Disambiguate "this value" in authenticatorDisplayName description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6849,8 +6849,9 @@ This [=client extension|client=] [=registration extension=] and [=authentication
             and SHOULD allow the user to modify a vendor-provided default response.
 
             If the [=[RP]=] includes an <code>[$credential record/authenticatorDisplayName$]</code>
-            [=struct/item=] in its [=credential records=], the [=[RP]=] MAY offer this value, if
-            present, as a default value for the
+            [=struct/item=] in its [=credential records=],
+            the [=[RP]=] MAY offer this {{authenticatorDisplayName}} extension output,
+            if present, as a default value for the
             <code>[$credential record/authenticatorDisplayName$]</code> of the new
             [=credential record=] it stores after a [=registration ceremony=].
 


### PR DESCRIPTION
Fixes this review comment which still remains unaddressed: https://github.com/w3c/webauthn/pull/1880#discussion_r1323097728


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2005.html" title="Last updated on Dec 4, 2023, 10:14 AM UTC (c034bd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2005/84feb40...c034bd9.html" title="Last updated on Dec 4, 2023, 10:14 AM UTC (c034bd9)">Diff</a>