### PR TITLE
Correct capitalization on "Github"

### DIFF
--- a/.bikeshed-include/status-CR.include
+++ b/.bikeshed-include/status-CR.include
@@ -13,7 +13,7 @@
     implementations, each may independently be removed or made informative at Proposed Recommendation.
   </p>
   <p>
-    We have had two informal interoperability tests with implementations in three browsers. There is no preliminary implementation 
+    We have had two informal interoperability tests with implementations in three browsers. There is no preliminary implementation
     report at this time.
   </p>
   <p>
@@ -21,7 +21,7 @@
     as a Working Draft. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
-    <a href="https://github.com/w3c/webauthn/issues">Github issues</a>.
+    <a href="https://github.com/w3c/webauthn/issues">GitHub issues</a>.
     Discussions may also be found in the
     <a href="http://lists.w3.org/Archives/Public/public-webauthn/">public-webauthn@w3.org archives</a>.
   </p>

--- a/.bikeshed-include/status-ED.include
+++ b/.bikeshed-include/status-ED.include
@@ -11,7 +11,7 @@
     as an Editors' Draft. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
-    <a href="https://github.com/w3c/webauthn/issues">Github issues</a>.
+    <a href="https://github.com/w3c/webauthn/issues">GitHub issues</a>.
     Discussions may also be found in the
     <a href="http://lists.w3.org/Archives/Public/public-webauthn/">public-webauthn@w3.org archives</a>.
   </p>

--- a/.bikeshed-include/status-WD.include
+++ b/.bikeshed-include/status-WD.include
@@ -8,7 +8,7 @@
     as a Working Draft. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
-    <a href="https://github.com/w3c/webauthn/issues">Github issues</a>.
+    <a href="https://github.com/w3c/webauthn/issues">GitHub issues</a>.
     Discussions may also be found in the
     <a href="http://lists.w3.org/Archives/Public/public-webauthn/">public-webauthn@w3.org archives</a>.
   </p>


### PR DESCRIPTION
This PR fixes #2007 by changing "Github" to "GitHub".