### PR TITLE
Mark SPK's `signatures` output as required.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7253,7 +7253,7 @@ The weight that [=[RPS]=] give to the presence of a signature from a supplementa
 :: A sequence of {{ArrayBuffer}}s containing the signatures returned as the [=unsigned extension output=].
     <xmp class="idl">
     dictionary AuthenticationExtensionsSupplementalPubKeysOutputs {
-        sequence<ArrayBuffer> signatures;
+        required sequence<ArrayBuffer> signatures;
     };
 
     partial dictionary AuthenticationExtensionsClientOutputs {


### PR DESCRIPTION
AuthenticationExtensionsSupplementalPubKeysOutputs.signatures should always be present in the client extension outputs since it's the only field and SPK makes no sense without the signatures.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2011.html" title="Last updated on Jan 2, 2024, 10:32 PM UTC (296ca55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2011/a83c764...296ca55.html" title="Last updated on Jan 2, 2024, 10:32 PM UTC (296ca55)">Diff</a>