### PR TITLE
Fix references to reserved tokenBinding member

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3714,15 +3714,17 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     ::  This OPTIONAL member contains the inverse of the `sameOriginWithAncestors` argument value
         that was passed into the [=internal method=].
 
-    :   \[RESERVED] <dfn dfn>tokenBinding</dfn>
+        <!-- Setting explicit dfn ID (this becomes the fragment part of the anchor URL) for backwards compatibility;
+             without this Bikeshed generates the ID "collectedclientdata-tokenbinding". -->
+    :   \[RESERVED] <dfn dfn id="dom-collectedclientdata-tokenbinding">tokenBinding</dfn>
     ::  This OPTIONAL member contains information about the state of the [=Token Binding=] protocol [[!TokenBinding]] used when communicating
         with the [=[RP]=]. Its absence indicates that the client doesn't support token binding
 
-        Note: While [=Token Binding=] was present in Level 1 and Level 2 of WebAuthn, its use is not expected in Level 3. The {{CollectedClientData/tokenBinding}} field is reserved so that it will not be reused for a different purpose.
+        Note: While [=Token Binding=] was present in Level 1 and Level 2 of WebAuthn, its use is not expected in Level 3. The [=CollectedClientData/tokenBinding=] field is reserved so that it will not be reused for a different purpose.
 
         <div dfn-type="dict-member" dfn-for="TokenBinding">
             :   <dfn>status</dfn>
-            ::  This member SHOULD be a member of {{TokenBindingStatus}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the {{CollectedClientData/tokenBinding}} [=map/exist|member does not exist=]. When known, this member is one of the following:
+            ::  This member SHOULD be a member of {{TokenBindingStatus}} but [=client platforms=] MUST ignore unknown values, treating an unknown value as if the [=CollectedClientData/tokenBinding=] [=map/exist|member does not exist=]. When known, this member is one of the following:
 
                 <div dfn-type="enum-value" dfn-for="TokenBindingStatus">
                     :   <dfn>supported</dfn>


### PR DESCRIPTION
Commit 5f45d34abe3e6826f1e676c35a3dc5d349bec2ad in PR #1661 changed the definition type of `CollectedClientData/tokenBinding` from "dict-member" to "dfn" to resolve Bikeshed errors about the member not existing in the `CollectedClientData` definition.

However, autolinks to the reserved `tokenBinding` member still use the `{{foo}}` syntax, which is only for IDL types, so the autolinks no longer resolve. This results in Bikeshed instead pulling these autolinks as external refs from the spec database instead of internal refs, which results in an entry being added to the "terms defined elsewhere" index: "[WEBAUTHN-3] defines the following terms: tokenBinding". The changed definition type also changes the generated link anchor from `#dom-collectedclientdata-tokenbinding` to `#collectedclientdata-tokenbinding`.

This fixes these issues by declaring the link anchor explicitly, for backwards compatibility, and by changing the autolinks to use the `[=foo=]` syntax for autolinks to "dfn"-type definitions.

This also fixes the following Bikeshed lint:

```
LINT: Unexported dfn that's not referenced locally - did you mean to export it?
<dfn data-dfn-type="dfn" data-dfn-for="CollectedClientData" id="collectedclientdata-tokenbinding" data-lt="tokenBinding" data-noexport="by-default">tokenBinding<a href="#collectedclientdata-tokenbinding" class="self-link"></a></dfn>
<dfn data-dfn-type="dfn" data-dfn-for="CollectedClientData" id="collectedclientdata-tokenbinding" data-lt="tokenBinding" data-noexport="by-default">tokenBinding<a href="#collectedclientdata-tokenbinding" class="self-link"></a></dfn>
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2014.html" title="Last updated on Jan 10, 2024, 1:20 PM UTC (7650f7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2014/a83c764...7650f7c.html" title="Last updated on Jan 10, 2024, 1:20 PM UTC (7650f7c)">Diff</a>