### PR TITLE
Fix Bikeshed lint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8666,7 +8666,7 @@ the [=[RP]=] MUST validate the {{CollectedClientData/origin}} member of the [=cl
 
 The [=[RP]=] MUST NOT accept unexpected values of {{CollectedClientData/origin}},
 as doing so could allow a malicious website to obtain valid [=credentials=].
-Although the [=scope=] of [=WebAuthn credentials=] prevents their use on domains
+Although the [=scope=] of WebAuthn credentials prevents their use on domains
 outside the [=RP ID=] they were registered for,
 the [=[RP]=]'s origin validation serves as an additional layer of protection
 in case a faulty [=authenticator=] fails to enforce credential [=scope=].

--- a/index.bs
+++ b/index.bs
@@ -6813,8 +6813,7 @@ This [=client extension|client=] [=registration extension=] and [=authentication
 
     <div dfn-type="dict-member" dfn-for="CredentialPropertiesOutput">
         :   <dfn>rk</dfn>
-        ::  This OPTIONAL property, known abstractly as the <dfn dfn-type="dfn">resident key credential property</dfn>
-            (i.e., <dfn dfn-type="dfn">client-side discoverable credential property</dfn>),
+        ::  This OPTIONAL property, known abstractly as the <dfn dfn-type="dfn">resident key credential property</dfn>,
             is a Boolean value indicating whether the {{PublicKeyCredential}} returned as a result of a [=registration ceremony=]
             is a [=client-side discoverable credential=].
             If {{rk}} is [TRUE], the credential is a [=discoverable credential=].


### PR DESCRIPTION
- Remove autolink to nonexistent term "WebAuthn credentials" 
- Delete unused term "client-side discoverable credential property"

Fixes these Bikeshed lints:

```
LINE ~8667: No 'dfn' refs found for 'webauthn credentials'.
[=WebAuthn credentials=]
```

```
LINT: Unexported dfn that's not referenced locally - did you mean to export it?
<dfn data-dfn-type="dfn" data-dfn-for="CredentialPropertiesOutput" id="credentialpropertiesoutput-client-side-discoverable-credential-property" data-lt="client-side discoverable credential property" data-noexport="by-default">client-side discoverable credential property<a href="#credentialpropertiesoutput-client-side-discoverable-credential-property" class="self-link"></a></dfn>
<dfn data-dfn-type="dfn" data-dfn-for="CredentialPropertiesOutput" id="credentialpropertiesoutput-client-side-discoverable-credential-property" data-lt="client-side discoverable credential property" data-noexport="by-default">client-side discoverable credential property<a href="#credentialpropertiesoutput-client-side-discoverable-credential-property" class="self-link"></a></dfn>
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2015.html" title="Last updated on Jan 10, 2024, 1:36 PM UTC (3aa0247)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2015/a83c764...3aa0247.html" title="Last updated on Jan 10, 2024, 1:36 PM UTC (3aa0247)">Diff</a>