### PR TITLE
Adding flexibility in client origin scheme validation to align with real world implementations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1341,7 +1341,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         Note: An [=RP ID=] is based on a [=host=]'s [=domain=] name. It does not itself include a [=scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
 
             - The [=RP ID=] must be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
-            - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`, or considered a [=secure contexts|secure context=].
+            - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`, or considered a [=secure context=].
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
         For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`.

--- a/index.bs
+++ b/index.bs
@@ -1341,7 +1341,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         Note: An [=RP ID=] is based on a [=host=]'s [=domain=] name. It does not itself include a [=scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
 
             - The [=RP ID=] must be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
-            - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`, or considered a [=secure context=].
+            - One of the following is true:
+                - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] is `https`.
+                - The [=determines the set of origins on which the public key credential may be exercised|origin=] is `localhost` and the [=scheme=] is `http`.
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
         For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`.

--- a/index.bs
+++ b/index.bs
@@ -1341,7 +1341,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         Note: An [=RP ID=] is based on a [=host=]'s [=domain=] name. It does not itself include a [=scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
 
             - The [=RP ID=] must be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
-            - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`, or considered [=a secure context|secure contexts=] .
+            - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`, or considered a [=secure contexts|secure context=].
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
         For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`.

--- a/index.bs
+++ b/index.bs
@@ -1341,7 +1341,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
         Note: An [=RP ID=] is based on a [=host=]'s [=domain=] name. It does not itself include a [=scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
 
             - The [=RP ID=] must be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
-            - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`.
+            - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`, or considered [=a secure context|secure contexts=] .
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
         For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`.

--- a/index.bs
+++ b/index.bs
@@ -1338,12 +1338,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [[#sctn-getAssertion]].
 
     <div class="note" id="note-pkcredscope">
-        Note: An [=RP ID=] is based on a [=host=]'s [=domain=] name. It does not itself include a [=scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
+        Note: An [=RP ID=] is based on a [=host=]'s [=domain=] name. It does not itself include a [=origin/scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
 
             - The [=RP ID=] must be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
-            - One of the following is true:
-                - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] is `https`.
-                - The [=determines the set of origins on which the public key credential may be exercised|origin=] is `localhost` and the [=scheme=] is `http`.
+            - One of the following must be true:
+                - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=origin/scheme=] is `https`.
+                - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=origin/host=] is `localhost` and its [=origin/scheme=] is `http`.
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
         For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`.

--- a/index.bs
+++ b/index.bs
@@ -1338,7 +1338,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     [[#sctn-getAssertion]].
 
     <div class="note" id="note-pkcredscope">
-        Note: An [=RP ID=] is based on a [=host=]'s [=domain=] name. It does not itself include a [=origin/scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
+        Note: An [=RP ID=] is based on a [=origin/host=]'s [=domain=] name. It does not itself include a [=origin/scheme=] or [=port=], as an [=origin=] does. The [=RP ID=] of a [=public key credential=] determines its <dfn>scope</dfn>. I.e., it <dfn>determines the set of origins on which the public key credential may be exercised</dfn>, as follows:
 
             - The [=RP ID=] must be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
             - One of the following must be true:


### PR DESCRIPTION
I suggest adding a little bit of flexibility to the requirements on validating the scheme to be `https`. This is in response to the real world implementation by clients, where clients (browsers, chrome) allow webauthn on `localhost` running on the `http`-scheme. We've been receiving negative feedback for following this part of the spec. I wanted to suggest adding just a little bit of flexibility here, hopefully without opening a can of DNS worms. 


I might be sticking my shin out here, since I know the topic of localhost has been brought up in previous calls with varying (dis)-agreement. E.g issue #1204 morphed into a discussion on DNS. 

Either I'm misinterpreting the current writing, but to me it's quite clear about not allowing `http` in any case. 

Original:
![CleanShot 2024-01-29 at 10 31 55](https://github.com/w3c/webauthn/assets/357283/8446eaa4-2303-4030-a7cf-306b74387c48)

Updated:
![image](https://github.com/w3c/webauthn/assets/357283/c0200116-f896-4f11-b78b-511bf0deb5c5)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/abergs/webauthn/pull/2018.html" title="Last updated on Feb 21, 2024, 5:57 PM UTC (9f8fa53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2018/73b3562...abergs:9f8fa53.html" title="Last updated on Feb 21, 2024, 5:57 PM UTC (9f8fa53)">Diff</a>