### PR TITLE
Adding example of localhost as allowed host/origin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1344,7 +1344,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`.
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
-        For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`. Another example of a valid origin is `http://localhost:8000`, due to the origin being `localhost`
+        For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`. Another example of a valid origin is `http://localhost:8000`, due to the origin being `localhost`.
 
         This is done in order to match the behavior of pervasively deployed ambient credentials (e.g., cookies, [[RFC6265]]).
         Please note that this is a greater relaxation of "same-origin" restrictions than what

--- a/index.bs
+++ b/index.bs
@@ -1344,7 +1344,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`.
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
-        For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`.
+        For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`. Another example of a valid origin is `http://localhost:8000`, due to being considered a [=secure context=].
 
         This is done in order to match the behavior of pervasively deployed ambient credentials (e.g., cookies, [[RFC6265]]).
         Please note that this is a greater relaxation of "same-origin" restrictions than what

--- a/index.bs
+++ b/index.bs
@@ -1344,7 +1344,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=scheme=] must be `https`.
             - The [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=port=] is unrestricted.
 
-        For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`. Another example of a valid origin is `http://localhost:8000`, due to being considered a [=secure context=].
+        For example, given a [=[RP]=] whose origin is `https://login.example.com:1337`, then the following [=RP ID=]s are valid: `login.example.com` (default) and `example.com`, but not `m.login.example.com` and not `com`. Another example of a valid origin is `http://localhost:8000`, due to the origin being `localhost`
 
         This is done in order to match the behavior of pervasively deployed ambient credentials (e.g., cookies, [[RFC6265]]).
         Please note that this is a greater relaxation of "same-origin" restrictions than what


### PR DESCRIPTION
This PR extends #2018 (and is irrelevant if #2018 is not merged) by adding an example of a valid origin for localhost. I expect people will have varying opinions on this, but since @MasterKale and I both thought of adding it, I thought I'd at least type it up and post it. 

Marking as draft until dependency on #2018 is merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/abergs/webauthn/pull/2019.html" title="Last updated on Feb 21, 2024, 8:25 PM UTC (bb1948a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2019/73b3562...abergs:bb1948a.html" title="Last updated on Feb 21, 2024, 8:25 PM UTC (bb1948a)">Diff</a>