### PR TITLE
Improved version of extension for Transaction Confirmation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7669,23 +7669,25 @@ This extension allows for a simple form of transaction authorization. A
 :: A single USVString prompt.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
-      USVString txAuthSimple2;
+      USVString txAuthSimple;
     };
     </xmp>
 
 : Client extension processing
-:: If (and only if) the authenticator doesn't support this extension (to be determined by the platform via the response to CTAP getClientInfo), then the Client is expected to display
-    the transaction text to the user and to include the transaction text in the collectedClientData structure as described below.
-    If the authenticator supports this extension, then the client SHALL pass-through the extension to the
-    authenticator and not perform any other client processing.
+:: If this extension is present, the client SHALL
+       1. use a dialog to the user that makes sense in the context of approving a transaction (as opposed to sign in).
+       1. display the transaction text to the user. The client SHOULD
+             indicate that the transaction text originates from a specific relying party
+	     (as opposed to the platform itself).
+	     
+       1. use the {{CollectedClientTxAuthSimple2Data}} structure containing the transaction text instead of using
+             the {{CollectedClientData}} structure.
+	     
+       1. pass-through the extension to the authenticator (see "client extension output" below)
+       1. pass-through the "authenticator extension output" to the caller as part of the assertion
 
 
     <div class="issue">
-      Mention that the client shouldn't prompt the user for "sign-in" but instead for approving a transaction.
-
-      Should we always let the client use CollectedClientTxAuthSimple2Data instead of CollectedClientData to have more consistency (or only if the client displayed it)?
-      If yes: Should the client verify it matches the transactionText returned by the authenticator (if that exists)?
-
       Should we keep the "type" on "authenticate" or change to something closer to transaction (SPC uses 'payment.get')?
 
       Should we change the name back to txAuthSimple - cannot really hurt - but makes it easier for authenticators already implementing it.
@@ -7728,7 +7730,7 @@ This extension allows for a simple form of transaction authorization. A
 :: Returns the authenticator extension output string UTF-8 decoded into a USVString.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-      USVString txAuthSimple2;
+      USVString txAuthSimple;
     };
     </xmp>
 
@@ -7741,11 +7743,12 @@ txAuthSimpleInput = (tstr)
 </pre>
 
 : Authenticator extension processing
-:: The authenticator MUST display the prompt to the user before performing either [=user verification=] or [=test of user
+:: The authenticator MUST display the transaction text to the user
+    before performing either [=user verification=] or [=test of user
     presence=]. The authenticator MAY insert line breaks if needed.
 
 : Authenticator extension output
-:: A single CBOR string, representing the prompt as displayed (including any eventual line breaks).
+:: A single CBOR string, representing the transaction text (excluding any eventual line breaks that were inserted).
 
 <pre>
 CDDL:

--- a/index.bs
+++ b/index.bs
@@ -7687,12 +7687,6 @@ This extension allows for a simple form of transaction authorization. A
        1. pass-through the "authenticator extension output" to the caller as part of the assertion
 
 
-    <div class="issue">
-      Should we keep the "type" on "authenticate" or change to something closer to transaction (SPC uses 'payment.get')?
-
-      Should we change the name back to txAuthSimple - cannot really hurt as no platform supports it today and authenticator implementations don't have to change.
-    </div>
-
     <xmp class="idl">
         dictionary CollectedClientTxAuthSimpleData : CollectedClientData {
             required CollectedClientAdditionalTxAuthSimpleData transactionText;
@@ -9360,6 +9354,22 @@ for their contributions as our W3C Team Contacts.
     "href": "https://tools.ietf.org/html/rfc8610",
     "status": "IETF Proposed Standard",
     "date": "June 2019"
+  },
+
+  "RFC9052": {
+    "authors": ["Jim Schaad"],
+    "title": "CBOR Object Signing and Encryption (COSE): Structures and Process",
+    "href": "https://datatracker.ietf.org/doc/rfc9052/",
+    "status": "IETF Internet Standard",
+    "date": "August 2022"
+  },
+
+  "RFC9053": {
+    "authors": ["Jim Schaad"],
+    "title": "CBOR Object Signing and Encryption (COSE): Initial Algorithms",
+    "href": "https://datatracker.ietf.org/doc/rfc9053/",
+    "status": "RFC Informational",
+    "date": "August 2022"
   },
 
   "ISOBiometricVocabulary": {

--- a/index.bs
+++ b/index.bs
@@ -7652,6 +7652,96 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 
+### Simple Transaction Authorization Extension (txAuthSimple2) ### {#sctn-simple-txauth-extension2}
+
+This extension allows for a simple form of transaction authorization. A
+   [=[RP]=] can specify a prompt string, intended for display by the platform and by the authenticator (if supported).
+   With this approach, [=Relying Parties=] can use the feature independently of the capabilities of the authenticator used by the user,
+   while still benefitting from the increased security level if the authenticator itself supports showing the transaction text.
+
+: Extension identifier
+:: `txAuthSimple2`
+
+: Operation applicability
+:: [=authentication extension|Authentication=]
+
+: Client extension input
+:: A single USVString prompt.
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientInputs {
+      USVString txAuthSimple2;
+    };
+    </xmp>
+
+: Client extension processing
+:: If (and only if) the authenticator doesn't support this extension (to be determined by the platform via the response to CTAP getClientInfo), then the Client is expected to display
+    the transaction text to the user and to include the transaction text in the collectedClientData structure as described below.
+    If the authenticator supports this extension, then the client SHALL pass-through the extension to the
+    authenticator and not perform any other client processing.
+
+    <xmp class="idl">
+        dictionary CollectedClientTxAuthSimple2Data : CollectedClientData {
+            required CollectedClientAdditionalTxAuthSimple2Data transactionText;
+        };
+    </xmp>
+
+    The {{CollectedClientTxAuthSimple2Data}} dictionary inherits from
+    {{CollectedClientData}}. It contains the following additional field:
+
+    <dl dfn-type="dict-member" dfn-for="CollectedClientTxAuthSimple2Data">
+        :  <dfn>transactionText</dfn> member
+        :: The full context of the transaction to sign.
+    </dl>
+
+
+    <xmp class="idl">
+        dictionary CollectedClientAdditionalTxAuthSimple2Data {
+            required USVString rpId;
+            required USVString transactionText;
+        };
+    </xmp>
+
+    The {{CollectedClientAdditionalTxAuthSimple2Data}} dictionary contains the following
+    fields:
+
+    <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalTxAuthSimple2Data">
+        :  <dfn>rpId</dfn> member
+        :: The id of the [=Relying Party=] that created the credential.
+
+        :  <dfn>transactionText</dfn> member
+        :: The full context of the transaction that the user is intended to approve.
+    </dl>
+
+: Client extension output
+:: Returns the authenticator extension output string UTF-8 decoded into a USVString.
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientOutputs {
+      USVString txAuthSimple2;
+    };
+    </xmp>
+
+: Authenticator extension input
+:: If the authenticator supports this extension, then the client provides the extension input encoded as a CBOR text string (major type 3).
+
+<pre>
+CDDL:
+txAuthSimpleInput = (tstr)
+</pre>
+
+: Authenticator extension processing
+:: The authenticator MUST display the prompt to the user before performing either [=user verification=] or [=test of user
+    presence=]. The authenticator MAY insert line breaks if needed.
+
+: Authenticator extension output
+:: A single CBOR string, representing the prompt as displayed (including any eventual line breaks).
+
+<pre>
+CDDL:
+txAuthSimpleOutput = (tstr)
+</pre>
+
+
+
 # User Agent Automation # {#sctn-automation}
 
 For the purposes of user agent automation and [=web application=] testing, this document defines a number of [[WebDriver]] [=extension commands=].

--- a/index.bs
+++ b/index.bs
@@ -7674,22 +7674,20 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
-      USVString confirmationPrompt;
+      USVString confirmation;
     };
     </xmp>
 
 : Client extension processing
-:: If this extension is present, the client SHALL
-       1. use a dialog to the user that makes the user aware of the confirmation to be provided (as opposed to doing a simple sign in).
-       1. display the confirmation prompt to the user. The client SHOULD
-             indicate that the confirmation prompt originates from a specific relying party
-             (as opposed to the platform itself).
+::   1. use a dialog to the user that makes the user aware of the confirmation to be provided (as opposed to doing a simple sign in).
+     1. display the confirmation prompt to the user. The client SHOULD
+           indicate that the confirmation prompt originates from a specific relying party
+           (as opposed to the platform itself).
      
-       1. use the {{CollectedClientConfirmationData}} structure containing the confirmation prompt instead of using
-             the {{CollectedClientData}} structure.
+     1. use the {{CollectedClientConfirmationData}} structure containing the confirmation prompt instead of using the {{CollectedClientData}} structure.
      
-       1. pass-through the extension to the authenticator (see "client extension output" below)
-       1. pass-through the "authenticator extension output" to the caller as part of the assertion
+     1. pass-through the extension to the authenticator (see "client extension output" below)
+     1. pass-through the "authenticator extension output" to the caller as part of the assertion
 
 
     <xmp class="idl">
@@ -7722,20 +7720,21 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
     </dl>
 
 : Client extension output
-:: Returns the authenticator extension output string UTF-8 decoded into a USVString.
+:: Returns the value [TRUE] to indicate to the [[RP]=] that the extension was acted upon.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-      USVString confirmationPrompt;
+      boolean confirmation;
     };
     </xmp>
 
 : Authenticator extension input
 :: The client provides the extension input encoded as a CBOR text string (major type 3).
 
-<pre>
-CDDL:
-confirmationPromptInput = (tstr)
-</pre>
+    ```
+    $$extensionInput //= (
+      confirmation = tstr,
+    )
+    ```
 
 : Authenticator extension processing
 :: The authenticator supporting this extension MUST display the confirmation prompt to the user
@@ -7743,29 +7742,23 @@ confirmationPromptInput = (tstr)
     presence=]. The authenticator MAY wrap lines that are too wide to be shown if needed.
 
 : Authenticator extension output
-:: If the authenticator supports this extension (and only then): A single CBOR string, representing the
-    confirmation prompt.
+:: A single CBOR text string, representing the confirmation prompt.
 
-<pre>
-CDDL:
-confirmationPromptOutput = (tstr)
-</pre>
+    ```
+    $$extensionOutput //= (
+      confirmation = tstr,
+    )
+    ```
 
 #### `confirmation` Extension Output Verification Procedures #### {#sctn-confirmation-extension-verification}
 
-Verifying the <code>[=confirmation=]</code> extension output is performed by the [=[RP]=] whenever a the use of <code>[=confirmatione=]</code> was requested.
-
-##### Authentication (`get()`) ##### {#sctn-confirmation-extension-verification-get}
-
-This extension is only specified to be used in conjunction with a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
-
-If the [=[RP]=] requested the `confirmation` extension in a {{CredentialsContainer/get()|navigator.credentials.get()}} call, then the below verification step are performed in the context of [step 19](#authn-ceremony-verify-extension-outputs)
+The following verification steps are performed in the context of [step 19](#authn-ceremony-verify-extension-outputs)
 of [[#sctn-verifying-assertion]] using these variables established therein: |credential|, |clientExtensionResults|, |authData|, |hash|, and |credentialRecord|.
 [=[RP]=] policy may specify whether a response without a `confirmation` extension output is acceptable.
 
-1. Verify that the {{AuthenticationExtensionsClientOutputs/confirmation}} member of |clientExtensionResults| exists.
-1. Verify that the {{AuthenticationExtensionsClientOutputs/confirmation}} member contains the confirmation prompt that is expected (i.e., that was used when requesting the `confirmation` extension.
-
+1. Verify that the `confirmation` key exists in the [=authData/extensions=] in |authData|.
+1. Verify that the `confirmation` value in the [=authData/extensions=] in |authData| equals the confirmation prompt that is expected (i.e., that was used when requesting the `confirmation` extension).
+1. If processing a response without the `confirmation` extension is acceptable by policy: Fall back to <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorResponse/clientDataJSON}}</code> entry if authenticator extension output is absent.
 
 
 # User Agent Automation # {#sctn-automation}
@@ -9370,22 +9363,6 @@ for their contributions as our W3C Team Contacts.
     "href": "https://tools.ietf.org/html/rfc8610",
     "status": "IETF Proposed Standard",
     "date": "June 2019"
-  },
-
-  "RFC9052": {
-    "authors": ["Jim Schaad"],
-    "title": "CBOR Object Signing and Encryption (COSE): Structures and Process",
-    "href": "https://datatracker.ietf.org/doc/rfc9052/",
-    "status": "IETF Internet Standard",
-    "date": "August 2022"
-  },
-
-  "RFC9053": {
-    "authors": ["Jim Schaad"],
-    "title": "CBOR Object Signing and Encryption (COSE): Initial Algorithms",
-    "href": "https://datatracker.ietf.org/doc/rfc9053/",
-    "status": "RFC Informational",
-    "date": "August 2022"
   },
 
   "ISOBiometricVocabulary": {

--- a/index.bs
+++ b/index.bs
@@ -7735,7 +7735,7 @@ This extension allows for a simple form of transaction authorization. A
     </xmp>
 
 : Authenticator extension input
-:: If the authenticator supports this extension, then the client provides the extension input encoded as a CBOR text string (major type 3).
+:: The client provides the extension input encoded as a CBOR text string (major type 3).
 
 <pre>
 CDDL:
@@ -7743,12 +7743,13 @@ txAuthSimpleInput = (tstr)
 </pre>
 
 : Authenticator extension processing
-:: The authenticator MUST display the transaction text to the user
+:: The authenticator supporting this extension MUST display the transaction text to the user
     before performing either [=user verification=] or [=test of user
-    presence=]. The authenticator MAY insert line breaks if needed.
+    presence=]. The authenticator MAY insert line breaks when displaying the text if needed.
 
 : Authenticator extension output
-:: A single CBOR string, representing the transaction text (excluding any eventual line breaks that were inserted).
+:: If the authenticator supports this extension (and only then): A single CBOR string, representing the
+    transaction text (excluding any eventual line breaks that were inserted).
 
 <pre>
 CDDL:

--- a/index.bs
+++ b/index.bs
@@ -7652,7 +7652,7 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 
-### Simple Transaction Authorization Extension (txAuthSimple2) ### {#sctn-simple-txauth-extension2}
+### Simple Transaction Authorization Extension (txAuthSimple) ### {#sctn-simple-txauth-extension}
 
 This extension allows for a simple form of transaction authorization. A
    [=[RP]=] can specify a prompt string, intended for display by the platform and by the authenticator (if supported).
@@ -7660,7 +7660,7 @@ This extension allows for a simple form of transaction authorization. A
    while still benefitting from the increased security level if the authenticator itself supports showing the transaction text.
 
 : Extension identifier
-:: `txAuthSimple2`
+:: `txAuthSimple`
 
 : Operation applicability
 :: [=authentication extension|Authentication=]
@@ -7680,7 +7680,7 @@ This extension allows for a simple form of transaction authorization. A
              indicate that the transaction text originates from a specific relying party
              (as opposed to the platform itself).
      
-       1. use the {{CollectedClientTxAuthSimple2Data}} structure containing the transaction text instead of using
+       1. use the {{CollectedClientTxAuthSimpleData}} structure containing the transaction text instead of using
              the {{CollectedClientData}} structure.
      
        1. pass-through the extension to the authenticator (see "client extension output" below)
@@ -7694,31 +7694,31 @@ This extension allows for a simple form of transaction authorization. A
     </div>
 
     <xmp class="idl">
-        dictionary CollectedClientTxAuthSimple2Data : CollectedClientData {
-            required CollectedClientAdditionalTxAuthSimple2Data transactionText;
+        dictionary CollectedClientTxAuthSimpleData : CollectedClientData {
+            required CollectedClientAdditionalTxAuthSimpleData transactionText;
         };
     </xmp>
 
-    The {{CollectedClientTxAuthSimple2Data}} dictionary inherits from
+    The {{CollectedClientTxAuthSimpleData}} dictionary inherits from
     {{CollectedClientData}}. It contains the following additional field:
 
-    <dl dfn-type="dict-member" dfn-for="CollectedClientTxAuthSimple2Data">
+    <dl dfn-type="dict-member" dfn-for="CollectedClientTxAuthSimpleData">
         :  <dfn>transactionText</dfn> member
         :: The full context of the transaction to sign.
     </dl>
 
 
     <xmp class="idl">
-        dictionary CollectedClientAdditionalTxAuthSimple2Data {
+        dictionary CollectedClientAdditionalTxAuthSimpleData {
             required USVString rpId;
             required USVString transactionText;
         };
     </xmp>
 
-    The {{CollectedClientAdditionalTxAuthSimple2Data}} dictionary contains the following
+    The {{CollectedClientAdditionalTxAuthSimpleData}} dictionary contains the following
     fields:
 
-    <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalTxAuthSimple2Data">
+    <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalTxAuthSimpleData">
         :  <dfn>rpId</dfn> member
         :: The id of the [=Relying Party=] that created the credential.
 

--- a/index.bs
+++ b/index.bs
@@ -7532,7 +7532,7 @@ See also [[#sctn-supplemental-public-keys-extension-usage]] for further details.
 ##### Authentication (`get()`) ##### {#sctn-supplemental-public-keys-extension-verification-get}
 
 If the [=[RP]=] requested the `supplementalPubKeys` extension in a {{CredentialsContainer/get()|navigator.credentials.get()}} call,
-then the below verification steps are performed in the context of [step 17](#authn-ceremony-verify-extension-outputs)
+then the below verification steps are performed in the context of [step 19](#authn-ceremony-verify-extension-outputs)
 of [[#sctn-verifying-assertion]] using these variables established therein: |credential|, |clientExtensionResults|, |authData|, |hash|, and |credentialRecord|.
 [=[RP]=] policy may specify whether a response without a `supplementalPubKeys` extension output is acceptable.
 
@@ -7708,7 +7708,6 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 
     <xmp class="idl">
         dictionary CollectedClientAdditionalTxAuthSimpleData {
-            required USVString rpId;
             required USVString transactionText;
         };
     </xmp>
@@ -7717,9 +7716,6 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
     fields:
 
     <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalTxAuthSimpleData">
-        :  <dfn>rpId</dfn> member
-        :: The id of the [=Relying Party=] that created the credential.
-
         :  <dfn>transactionText</dfn> member
         :: The full context of the transaction that the user is intended to approve.
     </dl>
@@ -7753,6 +7749,21 @@ txAuthSimpleInput = (tstr)
 CDDL:
 txAuthSimpleOutput = (tstr)
 </pre>
+
+#### `txAuthSimple` Extension Output Verification Procedures #### {#sctn-txauthsimple-extension-verification}
+
+Verifying the <code>[=txAuthSimple=]</code> extension output is performed by the [=[RP]=] whenever a the use of <code>[=txAuthSimple=]</code> was requested.
+
+##### Authentication (`get()`) ##### {#sctn-txauthsimple-extension-verification-get}
+
+This extension is only specified to be used in conjunction with a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
+
+If the [=[RP]=] requested the `txAuthSimple` extension in a {{CredentialsContainer/get()|navigator.credentials.get()}} call, then the below verification step are performed in the context of [step 19](#authn-ceremony-verify-extension-outputs)
+of [[#sctn-verifying-assertion]] using these variables established therein: |credential|, |clientExtensionResults|, |authData|, |hash|, and |credentialRecord|.
+[=[RP]=] policy may specify whether a response without a `txAuthSimple` extension output is acceptable.
+
+1. Verify that the {{AuthenticationExtensionsClientOutputs/txAuthSimple}} member of |clientExtensionResults| exists.
+1. Verify that the {{AuthenticationExtensionsClientOutputs/txAuthSimple}} member contains the transaction text that is expected (i.e., that was used when requesting the `txAuthSimple` extension.
 
 
 

--- a/index.bs
+++ b/index.bs
@@ -7678,11 +7678,11 @@ This extension allows for a simple form of transaction authorization. A
        1. use a dialog to the user that makes sense in the context of approving a transaction (as opposed to sign in).
        1. display the transaction text to the user. The client SHOULD
              indicate that the transaction text originates from a specific relying party
-	     (as opposed to the platform itself).
-	     
+             (as opposed to the platform itself).
+     
        1. use the {{CollectedClientTxAuthSimple2Data}} structure containing the transaction text instead of using
              the {{CollectedClientData}} structure.
-	     
+     
        1. pass-through the extension to the authenticator (see "client extension output" below)
        1. pass-through the "authenticator extension output" to the caller as part of the assertion
 
@@ -7690,7 +7690,7 @@ This extension allows for a simple form of transaction authorization. A
     <div class="issue">
       Should we keep the "type" on "authenticate" or change to something closer to transaction (SPC uses 'payment.get')?
 
-      Should we change the name back to txAuthSimple - cannot really hurt - but makes it easier for authenticators already implementing it.
+      Should we change the name back to txAuthSimple - cannot really hurt as no platform supports it today and authenticator implementations don't have to change.
     </div>
 
     <xmp class="idl">

--- a/index.bs
+++ b/index.bs
@@ -7652,7 +7652,7 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 
-### Simple Confirmation Extension (confirmation) ### {#sctn-simple-txauth-extension}
+### Confirmation Extension (confirmation) ### {#sctn-simple-txauth-extension}
 
 This extension allows for capturing user confirmation. A
    [=[RP]=] can specify a confirmation prompt string, intended for display by the platform and by the authenticator (if supported).
@@ -7670,7 +7670,7 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 :: [=authentication extension|Authentication=]
 
 : Client extension input
-:: A single USVString prompt.
+:: A single USVString confirmationPrompt.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
       USVString confirmationPrompt;
@@ -7697,7 +7697,7 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
         };
     </xmp>
 
-    The {{CollectedClientTxAuthSimpleData}} dictionary inherits from
+    The {{CollectedClientConfirmationData}} dictionary inherits from
     {{CollectedClientData}}. It contains the following additional field:
 
     <dl dfn-type="dict-member" dfn-for="CollectedClientConfirmationData">

--- a/index.bs
+++ b/index.bs
@@ -7652,7 +7652,7 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 
-### Confirmation Extension (confirmation) ### {#sctn-simple-txauth-extension}
+### Confirmation Extension (confirmation) ### {#sctn-confirmation-extension}
 
 This extension allows for capturing user confirmation. A
    [=[RP]=] can specify a confirmation prompt string, intended for display by the platform and by the authenticator (if supported).
@@ -7750,11 +7750,11 @@ CDDL:
 confirmationPromptOutput = (tstr)
 </pre>
 
-#### `confirmation` Extension Output Verification Procedures #### {#sctn-txauthsimple-extension-verification}
+#### `confirmation` Extension Output Verification Procedures #### {#sctn-confirmation-extension-verification}
 
-Verifying the <code>[=txAuthSimple=]</code> extension output is performed by the [=[RP]=] whenever a the use of <code>[=confirmatione=]</code> was requested.
+Verifying the <code>[=confirmation=]</code> extension output is performed by the [=[RP]=] whenever a the use of <code>[=confirmatione=]</code> was requested.
 
-##### Authentication (`get()`) ##### {#sctn-txauthsimple-extension-verification-get}
+##### Authentication (`get()`) ##### {#sctn-confirmation-extension-verification-get}
 
 This extension is only specified to be used in conjunction with a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 

--- a/index.bs
+++ b/index.bs
@@ -7652,19 +7652,19 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 
-### Simple Transaction Authorization Extension (txAuthSimple) ### {#sctn-simple-txauth-extension}
+### Simple Confirmation Extension (confirmation) ### {#sctn-simple-txauth-extension}
 
-This extension allows for a simple form of transaction authorization. A
-   [=[RP]=] can specify a prompt string, intended for display by the platform and by the authenticator (if supported).
+This extension allows for capturing user confirmation. A
+   [=[RP]=] can specify a confirmation prompt string, intended for display by the platform and by the authenticator (if supported).
    With this approach, [=Relying Parties=] can use the feature independently of the capabilities of the authenticator used by the user,
-   while still benefitting from the increased security level if the authenticator itself supports showing the transaction text.
+   while still benefitting from the increased security level if the authenticator itself supports showing the confirmation prompt.
 
-Authenticators could use a Trusted UI to ensure that the user indeed sees the transaction text.
+Authenticators could use a Trusted UI to ensure that the user indeed sees the confirmation prompt.
 
 Example uses cases could be "I want to move $1234 from account A to account B" or "I want to share my health data with hospital X".
 
 : Extension identifier
-:: `txAuthSimple`
+:: `confirmation`
 
 : Operation applicability
 :: [=authentication extension|Authentication=]
@@ -7673,18 +7673,18 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 :: A single USVString prompt.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
-      USVString txAuthSimple;
+      USVString confirmationPrompt;
     };
     </xmp>
 
 : Client extension processing
 :: If this extension is present, the client SHALL
-       1. use a dialog to the user that makes the user aware of the fact that a transaction is being approved (as opposed to doing a simple sign in).
-       1. display the transaction text to the user. The client SHOULD
-             indicate that the transaction text originates from a specific relying party
+       1. use a dialog to the user that makes the user aware of the confirmation to be provided (as opposed to doing a simple sign in).
+       1. display the confirmation prompt to the user. The client SHOULD
+             indicate that the confirmation prompt originates from a specific relying party
              (as opposed to the platform itself).
      
-       1. use the {{CollectedClientTxAuthSimpleData}} structure containing the transaction text instead of using
+       1. use the {{CollectedClientConfirmationData}} structure containing the confirmation prompt instead of using
              the {{CollectedClientData}} structure.
      
        1. pass-through the extension to the authenticator (see "client extension output" below)
@@ -7692,39 +7692,39 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 
 
     <xmp class="idl">
-        dictionary CollectedClientTxAuthSimpleData : CollectedClientData {
-            required CollectedClientAdditionalTxAuthSimpleData transactionText;
+        dictionary CollectedClientConfirmationData : CollectedClientData {
+            required CollectedClientAdditionalConfirmationData confirmationPrompt;
         };
     </xmp>
 
     The {{CollectedClientTxAuthSimpleData}} dictionary inherits from
     {{CollectedClientData}}. It contains the following additional field:
 
-    <dl dfn-type="dict-member" dfn-for="CollectedClientTxAuthSimpleData">
-        :  <dfn>transactionText</dfn> member
-        :: The full context of the transaction to sign.
+    <dl dfn-type="dict-member" dfn-for="CollectedClientConfirmationData">
+        :  <dfn>confirmationPrompt</dfn> member
+        :: The full context of the confirmation to give.
     </dl>
 
 
     <xmp class="idl">
-        dictionary CollectedClientAdditionalTxAuthSimpleData {
-            required USVString transactionText;
+        dictionary CollectedClientAdditionalConfirmationData {
+            required USVString confirmationPrompt;
         };
     </xmp>
 
-    The {{CollectedClientAdditionalTxAuthSimpleData}} dictionary contains the following
+    The {{CollectedClientAdditionalConfirmationData}} dictionary contains the following
     fields:
 
-    <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalTxAuthSimpleData">
-        :  <dfn>transactionText</dfn> member
-        :: The full context of the transaction that the user is intended to approve.
+    <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalConfirmationData">
+        :  <dfn>confirmationPrompt</dfn> member
+        :: The full context of the confirmation to give.
     </dl>
 
 : Client extension output
 :: Returns the authenticator extension output string UTF-8 decoded into a USVString.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-      USVString txAuthSimple;
+      USVString confirmationPrompt;
     };
     </xmp>
 
@@ -7733,37 +7733,37 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 
 <pre>
 CDDL:
-txAuthSimpleInput = (tstr)
+confirmatonPromptInput = (tstr)
 </pre>
 
 : Authenticator extension processing
-:: The authenticator supporting this extension MUST display the transaction text to the user
+:: The authenticator supporting this extension MUST display the confirmation prompt to the user
     before performing either [=user verification=] or [=test of user
-    presence=]. The authenticator MAY insert line breaks when displaying the text if needed.
+    presence=]. The authenticator MAY wrap lines that are too wide to be shown if needed.
 
 : Authenticator extension output
 :: If the authenticator supports this extension (and only then): A single CBOR string, representing the
-    transaction text (excluding any eventual line breaks that were inserted).
+    confirmation prompt.
 
 <pre>
 CDDL:
-txAuthSimpleOutput = (tstr)
+confirmationPromptOutput = (tstr)
 </pre>
 
-#### `txAuthSimple` Extension Output Verification Procedures #### {#sctn-txauthsimple-extension-verification}
+#### `confirmation` Extension Output Verification Procedures #### {#sctn-txauthsimple-extension-verification}
 
-Verifying the <code>[=txAuthSimple=]</code> extension output is performed by the [=[RP]=] whenever a the use of <code>[=txAuthSimple=]</code> was requested.
+Verifying the <code>[=txAuthSimple=]</code> extension output is performed by the [=[RP]=] whenever a the use of <code>[=confirmatione=]</code> was requested.
 
 ##### Authentication (`get()`) ##### {#sctn-txauthsimple-extension-verification-get}
 
 This extension is only specified to be used in conjunction with a {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
-If the [=[RP]=] requested the `txAuthSimple` extension in a {{CredentialsContainer/get()|navigator.credentials.get()}} call, then the below verification step are performed in the context of [step 19](#authn-ceremony-verify-extension-outputs)
+If the [=[RP]=] requested the `confirmation` extension in a {{CredentialsContainer/get()|navigator.credentials.get()}} call, then the below verification step are performed in the context of [step 19](#authn-ceremony-verify-extension-outputs)
 of [[#sctn-verifying-assertion]] using these variables established therein: |credential|, |clientExtensionResults|, |authData|, |hash|, and |credentialRecord|.
-[=[RP]=] policy may specify whether a response without a `txAuthSimple` extension output is acceptable.
+[=[RP]=] policy may specify whether a response without a `confirmation` extension output is acceptable.
 
-1. Verify that the {{AuthenticationExtensionsClientOutputs/txAuthSimple}} member of |clientExtensionResults| exists.
-1. Verify that the {{AuthenticationExtensionsClientOutputs/txAuthSimple}} member contains the transaction text that is expected (i.e., that was used when requesting the `txAuthSimple` extension.
+1. Verify that the {{AuthenticationExtensionsClientOutputs/confirmation}} member of |clientExtensionResults| exists.
+1. Verify that the {{AuthenticationExtensionsClientOutputs/confirmation}} member contains the confirmation prompt that is expected (i.e., that was used when requesting the `confirmation` extension.
 
 
 

--- a/index.bs
+++ b/index.bs
@@ -3622,11 +3622,12 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
 
 <xmp class="idl">
     dictionary CollectedClientData {
-        required DOMString           type;
-        required DOMString           challenge;
-        required DOMString           origin;
-        DOMString                    topOrigin;
-        boolean                      crossOrigin;
+        required DOMString            type;
+        required DOMString            challenge;
+        required DOMString            origin;
+        DOMString                     topOrigin;
+        boolean                       crossOrigin;
+        CollectedClientDataExtensions extensions;
     };
 
     dictionary TokenBinding {
@@ -3635,6 +3636,9 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     };
 
     enum TokenBindingStatus { "present", "supported" };
+
+    dictionary CollectedClientDataExtensions { 
+    };
 </xmp>
 
 <div dfn-type="dict-member" dfn-for="CollectedClientData">
@@ -7621,34 +7625,13 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
      1. pass-through the "authenticator extension output" to the caller as part of the assertion
 
 
+    The {{CollectedClientDataExtensions}} dictionary contains the following
+    additional field:
     <xmp class="idl">
-        dictionary CollectedClientConfirmationData : CollectedClientData {
-            required CollectedClientAdditionalConfirmationData confirmationPrompt;
+        partial dictionary CollectedClientDataExtensions {
+            USVString confirmation;
         };
     </xmp>
-
-    The {{CollectedClientConfirmationData}} dictionary inherits from
-    {{CollectedClientData}}. It contains the following additional field:
-
-    <dl dfn-type="dict-member" dfn-for="CollectedClientConfirmationData">
-        :  <dfn>confirmationPrompt</dfn> member
-        :: The full context of the confirmation to give.
-    </dl>
-
-
-    <xmp class="idl">
-        dictionary CollectedClientAdditionalConfirmationData {
-            required USVString confirmationPrompt;
-        };
-    </xmp>
-
-    The {{CollectedClientAdditionalConfirmationData}} dictionary contains the following
-    fields:
-
-    <dl dfn-type="dict-member" dfn-for="CollectedClientAdditionalConfirmationData">
-        :  <dfn>confirmationPrompt</dfn> member
-        :: The full context of the confirmation to give.
-    </dl>
 
 : Client extension output
 :: Returns the value [TRUE] to indicate to the [[RP]=] that the extension was acted upon.

--- a/index.bs
+++ b/index.bs
@@ -7679,6 +7679,15 @@ This extension allows for a simple form of transaction authorization. A
     If the authenticator supports this extension, then the client SHALL pass-through the extension to the
     authenticator and not perform any other client processing.
 
+
+    <div class="issue">
+      Mention that the client shouldn't prompt the user for "sign-in" but instead for approving a transaction.
+
+      Should we keep the "type" on "authenticate" or change to something closer to transaction (SPC uses 'payment.get')?
+
+      Should we change the name back to txAuthSimple - cannot really hurt - but makes it easier for authenticators already implementing it.
+    </div>
+
     <xmp class="idl">
         dictionary CollectedClientTxAuthSimple2Data : CollectedClientData {
             required CollectedClientAdditionalTxAuthSimple2Data transactionText;

--- a/index.bs
+++ b/index.bs
@@ -7734,7 +7734,7 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 
 <pre>
 CDDL:
-confirmatonPromptInput = (tstr)
+confirmationPromptInput = (tstr)
 </pre>
 
 : Authenticator extension processing

--- a/index.bs
+++ b/index.bs
@@ -7683,6 +7683,9 @@ This extension allows for a simple form of transaction authorization. A
     <div class="issue">
       Mention that the client shouldn't prompt the user for "sign-in" but instead for approving a transaction.
 
+      Should we always let the client use CollectedClientTxAuthSimple2Data instead of CollectedClientData to have more consistency (or only if the client displayed it)?
+      If yes: Should the client verify it matches the transactionText returned by the authenticator (if that exists)?
+
       Should we keep the "type" on "authenticate" or change to something closer to transaction (SPC uses 'payment.get')?
 
       Should we change the name back to txAuthSimple - cannot really hurt - but makes it easier for authenticators already implementing it.

--- a/index.bs
+++ b/index.bs
@@ -7659,6 +7659,10 @@ This extension allows for a simple form of transaction authorization. A
    With this approach, [=Relying Parties=] can use the feature independently of the capabilities of the authenticator used by the user,
    while still benefitting from the increased security level if the authenticator itself supports showing the transaction text.
 
+Authenticators could use a Trusted UI to ensure that the user indeed sees the transaction text.
+
+Example uses cases could be "I want to move $1234 from account A to account B" or "I want to share my health data with hospital X".
+
 : Extension identifier
 :: `txAuthSimple`
 
@@ -7675,7 +7679,7 @@ This extension allows for a simple form of transaction authorization. A
 
 : Client extension processing
 :: If this extension is present, the client SHALL
-       1. use a dialog to the user that makes sense in the context of approving a transaction (as opposed to sign in).
+       1. use a dialog to the user that makes the user aware of the fact that a transaction is being approved (as opposed to doing a simple sign in).
        1. display the transaction text to the user. The client SHOULD
              indicate that the transaction text originates from a specific relying party
              (as opposed to the platform itself).

--- a/index.bs
+++ b/index.bs
@@ -7670,7 +7670,8 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
 :: [=authentication extension|Authentication=]
 
 : Client extension input
-:: A single USVString confirmationPrompt.
+:: A single USVString confirmationPrompt.  This string might contain the following formatting tags: <code>&lt;b&gt;&lt;/b&gt;</code> to mark the text inbetween as bold and <code>&lt;br /&gt;</code> to force a line break.  Support of these formatting tags is "best effort".  Implementations not supporting it SHALL NOT display the tags in "verbatim".
+
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
       USVString confirmationPrompt;

--- a/index.bs
+++ b/index.bs
@@ -7781,7 +7781,7 @@ of [[#sctn-verifying-assertion]] using these variables established therein: |cre
 
 1. Verify that the `confirmation` key exists in the [=authData/extensions=] in |authData|.
 1. Verify that the `confirmation` value in the [=authData/extensions=] in |authData| equals the confirmation prompt that is expected (i.e., that was used when requesting the `confirmation` extension).
-1. If processing a response without the `confirmation` extension is acceptable by policy: Fall back to <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorResponse/clientDataJSON}}</code> entry if authenticator extension output is absent.
+1. If processing a response without the `confirmation` extension is acceptable by policy: Fall back to <code>|credential|.{{PublicKeyCredential/response}}.{{AuthenticatorResponse/clientDataJSON}}</code> entry and the verify the field {{AuthenticatorExtensionsClientInputs}}.{{confirmationPrompt}} in [=client data=] if authenticator extension output is absent. This field represents the value as shown by the client (and not the authenticator).
 
 
 # User Agent Automation # {#sctn-automation}

--- a/index.bs
+++ b/index.bs
@@ -7621,7 +7621,7 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
      
      1. use the {{CollectedClientConfirmationData}} structure containing the confirmation prompt instead of using the {{CollectedClientData}} structure.
      
-     1. pass-through the extension to the authenticator (see "client extension output" below)
+     1. pass-through the extension to the authenticator (see "authenticator extension input" below)
      1. pass-through the "authenticator extension output" to the caller as part of the assertion
 
 
@@ -7634,7 +7634,7 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
     </xmp>
 
 : Client extension output
-:: Returns the value [TRUE] to indicate to the [[RP]=] that the extension was acted upon.
+:: Returns the value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean confirmation;

--- a/index.bs
+++ b/index.bs
@@ -7691,7 +7691,7 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
 
 ### Confirmation Extension (confirmation) ### {#sctn-confirmation-extension}
 
-This extension allows for capturing user confirmation. A
+This <dfn>confirmation extension</dfn> allows for capturing user confirmation. A
    [=[RP]=] can specify a confirmation prompt string, intended for display by the platform and by the authenticator (if supported).
    With this approach, [=Relying Parties=] can use the feature independently of the capabilities of the authenticator used by the user,
    while still benefitting from the increased security level if the authenticator itself supports showing the confirmation prompt.
@@ -7765,6 +7765,13 @@ Example uses cases could be "I want to move $1234 from account A to account B" o
       confirmation = tstr,
     )
     ```
+
+Note: It is up to the relying party to handle the different [=user verification=] options appropriately.
+    This includes appropriate settings for {{AuthenticatorSelectionCriteria/userVerification}} and
+    appropriate processing of [=authData/flags/UV=] and [=authData/flags/UP=].
+    This [=confirmation extension=] doesn't change the way [=user verification=] is
+    handled by the [=client platform=] / [=authenticator=].
+
 
 #### `confirmation` Extension Output Verification Procedures #### {#sctn-confirmation-extension-verification}
 


### PR DESCRIPTION
supporting security keys or platform authenticators to show the transaction.  Also supports the platform to show the transaction text.
If the client displayed the transaction text but not the authenticator (for example when using a security without display), the transaction text will be only included in the collectedClientData - similar to what SPC is doing.
If the authenticator showed the transaction text, it will also be included in the extension that was signed by the authenticator (known and potentially attested entity showed the transaction text as opposed to a unknown client).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2020.html" title="Last updated on Oct 27, 2024, 2:48 PM UTC (704decb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2020/061a649...704decb.html" title="Last updated on Oct 27, 2024, 2:48 PM UTC (704decb)">Diff</a>