### PR TITLE
Acceptable UV caching time affordance extension added

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7600,7 +7600,7 @@ For example: Do not ask the user for a fresh [=user verification=] for sign-in i
 :: The maxTimeSinceLastUV denotes the maximum acceptable number of milliseconds elapsed since the last time the user was successfully verified.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
-      uint maxTimeSinceLastUV;
+      unsigned long long maxTimeSinceLastUV;
     };
     </xmp>
 
@@ -7611,7 +7611,7 @@ For example: Do not ask the user for a fresh [=user verification=] for sign-in i
 :: Returns the number of milliseconds elapsed since the last time the user was successfully verified as returned by the [=authenticator=].
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-      uint timeSinceLastUV;
+      unsigned long long timeSinceLastUV;
     };
     </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -7580,7 +7580,7 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 
-### User verification caching extension (<dfn>userVerificationCaching</dfn>) ### {#sctn-user-verification-caching-extension}
+### User verification caching extension (userVerificationCaching) ### {#sctn-user-verification-caching-extension}
 
 In some cases it is good enough for the [=[RP]=] to know whether the user was verified by the authenticator "recently".
 

--- a/index.bs
+++ b/index.bs
@@ -7588,8 +7588,6 @@ This extension allows the [=[RP]=] to specify such [=user verification=] caching
 
 For example: Do not ask the user for a fresh [=user verification=] for sign-in if the user was verified by this authenticator within the past 300 seconds.
 
-#### Extension Definition #### {#sctn-user-verification-cacing-extension-definition}
-
 : Extension identifier
 :: `userVerificationCaching`
 

--- a/index.bs
+++ b/index.bs
@@ -9244,22 +9244,6 @@ for their contributions as our W3C Team Contacts.
     "date": "June 2019"
   },
 
-  "RFC9052": {
-    "authors": ["Jim Schaad"],
-    "title": "CBOR Object Signing and Encryption (COSE): Structures and Process",
-    "href": "https://datatracker.ietf.org/doc/rfc9052/",
-    "status": "IETF Internet Standard",
-    "date": "August 2022"
-  },
-
-  "RFC9053": {
-    "authors": ["Jim Schaad"],
-    "title": "CBOR Object Signing and Encryption (COSE): Initial Algorithms",
-    "href": "https://datatracker.ietf.org/doc/rfc9053/",
-    "status": "RFC Informational",
-    "date": "August 2022"
-  },
-
   "ISOBiometricVocabulary": {
     "authors": ["ISO/IEC JTC1/SC37"],
     "title": "Information technology — Vocabulary — Biometrics",

--- a/index.bs
+++ b/index.bs
@@ -7582,14 +7582,11 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
 
 ### User verification caching extension (<dfn>userVerificationCaching</dfn>) ### {#sctn-user-verification-caching-extension}
 
-In some cases it is good enough for the [=RP=] to know whether
-    the user was verified by the authenticator "recently".
-    This extension allows the [=RP=] to specify such [=user verification=]
-    caching time, i.e. the time for which the
-    [=user verification=] status can be "cached" by the [=authenticator=].
+In some cases it is good enough for the [=RP=] to know whether the user was verified by the authenticator "recently".
 
-For example: Do not ask the user for a fresh [=user verification=] for sign-in
-    if the user was verified by this authenticator within the past 300 seconds.
+This extension allows the [=RP=] to specify such [=user verification=] caching time, i.e. the time for which the [=user verification=] status can be "cached" by the [=authenticator=].
+
+For example: Do not ask the user for a fresh [=user verification=] for sign-in if the user was verified by this authenticator within the past 300 seconds.
 
 #### Extension Definition #### {#sctn-user-verification-cacing-extension-definition}
 
@@ -7600,10 +7597,10 @@ For example: Do not ask the user for a fresh [=user verification=] for sign-in
 :: [=authentication extension|authentication=]
 
 : Client extension input
-:: The maximum [=user verification=] caching time denotes the maximum acceptable number of seconds elapsed since the last time the user was successfully verified.
+:: The maxTimeSinceLastUV denotes the maximum acceptable number of milliseconds elapsed since the last time the user was successfully verified.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
-      unsigned short maxUVC;
+      uint maxTimeSinceLastUV;
     };
     </xmp>
 
@@ -7611,33 +7608,31 @@ For example: Do not ask the user for a fresh [=user verification=] for sign-in
 :: None, except creating the [=authenticator extension input=] from the client extension input.
 
 : Client extension output
-:: Returns a JSON object denoting the maximum acceptable number of seconds elapsed since the last time the user was successfully verified as returned by the [=authenticator=].
+:: Returns the number of milliseconds elapsed since the last time the user was successfully verified as returned by the [=authenticator=].
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-      unsigned short maxUVC;
+      uint timeSinceLastUV;
     };
     </xmp>
 
 : Authenticator extension input
-:: The maxUVC time in seconds, encoded in CBOR.
+:: The maximum acceptable time in milliseconds elapsed since last user verification, encoded in CBOR.
 
     ```
     $$extensionInput //= (
-      maxUVC: uint .size 2
+      mtslUV: uint .size 4
     )
     ```
 
 : Authenticator extension processing
-:: When user verification is requested, the [=authenticator=] triggers user verification only if more seconds have elapsed since the last time the user was verified
-    than indicated by the maxUVC extension.
+:: When user verification is requested, the [=authenticator=] triggers user verification only if more milliseconds have elapsed since the last time the user was verified than indicated by the maxTimeSinceLastUV value in the extension.
 
 : Authenticator extension output
-:: If no fresh user verification needed to be triggered triggered, the authenticator reports the maxUVC time back to the [=RP=] to ensure the [=RP=] is aware
-    that no fresh user verification was triggered.
+:: If no fresh user verification needed to be triggered triggered, the authenticator reports the time last last user verification time back to the [=RP=] to ensure the [=RP=] is aware that no fresh user verification was triggered.  It is up to the authenticator to decide whether to return the real elapsed time, or a "rounded" value. If user verification was requested, this value SHALL not exceed the value originally provided in the extension input.
 
     ```
     $$extensionOutput //= (
-      maxUVC: uint .size 2
+      tslUV: uint .size 4
     )
     ```
 

--- a/index.bs
+++ b/index.bs
@@ -7580,6 +7580,68 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 
+### User verification caching extension (<dfn>userVerificationCaching</dfn>) ### {#sctn-user-verification-caching-extension}
+
+In some cases it is good enough for the [=RP=] to know whether
+    the user was verified by the authenticator "recently".
+    This extension allows the [=RP=] to specify such [=user verification=]
+    caching time, i.e. the time for which the
+    [=user verification=] status can be "cached" by the [=authenticator=].
+
+For example: Do not ask the user for a fresh [=user verification=] for sign-in
+    if the user was verified by this authenticator within the past 300 seconds.
+
+#### Extension Definition #### {#sctn-user-verification-cacing-extension-definition}
+
+: Extension identifier
+:: `userVerificationCaching`
+
+: Operation applicability
+:: [=authentication extension|authentication=]
+
+: Client extension input
+:: The maximum [=user verification=] caching time denotes the maximum acceptable number of seconds elapsed since the last time the user was successfully verified.
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientInputs {
+      unsigned short maxUVC;
+    };
+    </xmp>
+
+: Client extension processing
+:: None, except creating the [=authenticator extension input=] from the client extension input.
+
+: Client extension output
+:: Returns a JSON object denoting the maximum acceptable number of seconds elapsed since the last time the user was successfully verified as returned by the [=authenticator=].
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientOutputs {
+      unsigned short maxUVC;
+    };
+    </xmp>
+
+: Authenticator extension input
+:: The maxUVC time in seconds, encoded in CBOR.
+
+    ```
+    $$extensionInput //= (
+      maxUVC: uint .size 2
+    )
+    ```
+
+: Authenticator extension processing
+:: When user verification is requested, the [=authenticator=] triggers user verification only if more seconds have elapsed since the last time the user was verified
+    than indicated by the maxUVC extension.
+
+: Authenticator extension output
+:: If no fresh user verification needed to be triggered triggered, the authenticator reports the maxUVC time back to the [=RP=] to ensure the [=RP=] is aware
+    that no fresh user verification was triggered.
+
+    ```
+    $$extensionOutput //= (
+      maxUVC: uint .size 2
+    )
+    ```
+
+
 # User Agent Automation # {#sctn-automation}
 
 For the purposes of user agent automation and [=web application=] testing, this document defines a number of [[WebDriver]] [=extension commands=].
@@ -9187,6 +9249,22 @@ for their contributions as our W3C Team Contacts.
     "href": "https://tools.ietf.org/html/rfc8610",
     "status": "IETF Proposed Standard",
     "date": "June 2019"
+  },
+
+  "RFC9052": {
+    "authors": ["Jim Schaad"],
+    "title": "CBOR Object Signing and Encryption (COSE): Structures and Process",
+    "href": "https://datatracker.ietf.org/doc/rfc9052/",
+    "status": "IETF Internet Standard",
+    "date": "August 2022"
+  },
+
+  "RFC9053": {
+    "authors": ["Jim Schaad"],
+    "title": "CBOR Object Signing and Encryption (COSE): Initial Algorithms",
+    "href": "https://datatracker.ietf.org/doc/rfc9053/",
+    "status": "RFC Informational",
+    "date": "August 2022"
   },
 
   "ISOBiometricVocabulary": {

--- a/index.bs
+++ b/index.bs
@@ -7582,9 +7582,9 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
 
 ### User verification caching extension (<dfn>userVerificationCaching</dfn>) ### {#sctn-user-verification-caching-extension}
 
-In some cases it is good enough for the [=RP=] to know whether the user was verified by the authenticator "recently".
+In some cases it is good enough for the [=[RP]=] to know whether the user was verified by the authenticator "recently".
 
-This extension allows the [=RP=] to specify such [=user verification=] caching time, i.e. the time for which the [=user verification=] status can be "cached" by the [=authenticator=].
+This extension allows the [=[RP]=] to specify such [=user verification=] caching time, i.e. the time for which the [=user verification=] status can be "cached" by the [=authenticator=].
 
 For example: Do not ask the user for a fresh [=user verification=] for sign-in if the user was verified by this authenticator within the past 300 seconds.
 
@@ -7628,7 +7628,7 @@ For example: Do not ask the user for a fresh [=user verification=] for sign-in i
 :: When user verification is requested, the [=authenticator=] triggers user verification only if more milliseconds have elapsed since the last time the user was verified than indicated by the maxTimeSinceLastUV value in the extension.
 
 : Authenticator extension output
-:: If no fresh user verification needed to be triggered triggered, the authenticator reports the time last last user verification time back to the [=RP=] to ensure the [=RP=] is aware that no fresh user verification was triggered.  It is up to the authenticator to decide whether to return the real elapsed time, or a "rounded" value. If user verification was requested, this value SHALL not exceed the value originally provided in the extension input.
+:: If no fresh user verification needed to be triggered triggered, the authenticator reports the time last last user verification time back to the [=[RP]=] to ensure the [=[RP]=] is aware that no fresh user verification was triggered.  It is up to the authenticator to decide whether to return the real elapsed time, or a "rounded" value. If user verification was requested, this value SHALL not exceed the value originally provided in the extension input.
 
     ```
     $$extensionOutput //= (


### PR DESCRIPTION
The current behavior of some Passkey Providers to “cache” the user verification status cannot be modeled in FIDO/WebAuthn today and hence might surprise relying parties.

This PR adds the user verification extension that allows the RP to indicate its willingness to accept cached user verification for a given time.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2021.html" title="Last updated on Mar 27, 2024, 9:19 PM UTC (f342836)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2021/73b3562...f342836.html" title="Last updated on Mar 27, 2024, 9:19 PM UTC (f342836)">Diff</a>