### PR TITLE
Fix indentation of step to invoke authenticatorMakeCredential

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2053,24 +2053,23 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                     1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
 
-                    <!-- Note: this next step is actually a step on the same level as the above, but bikeshed wanted it indented this much
-                    in order to render it as a numbered step. If outdented, it (today) is rendered either as a bullet in the midst
-                    of a numbered list or is mis-numbered -->
-                        <li id='CreateCred-InvokeAuthnrMakeCred'>
-
-                            <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
-                            Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
-                                |clientDataHash|,
-                                <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
-                                <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
-                                |requireResidentKey|,
-                                |userVerification|,
-                                |credTypesAndPubKeyAlgs|,
-                                |excludeCredentialDescriptorList|,
-                                |enterpriseAttestationPossible|,
-                                |attestationFormats|,
-                                and |authenticatorExtensions| as parameters.
-                        </li>
+                <!-- Note: this next step is actually a step on the same level as the above, but bikeshed wanted it indented this much
+                in order to render it as a numbered step. If outdented, it (today) is rendered either as a bullet in the midst
+                of a numbered list or is mis-numbered -->
+                    <li id='CreateCred-InvokeAuthnrMakeCred'>
+                        <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
+                        Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
+                            |clientDataHash|,
+                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
+                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
+                            |requireResidentKey|,
+                            |userVerification|,
+                            |credTypesAndPubKeyAlgs|,
+                            |excludeCredentialDescriptorList|,
+                            |enterpriseAttestationPossible|,
+                            |attestationFormats|,
+                            and |authenticatorExtensions| as parameters.
+                    </li>
 
                 1. [=set/Append=] |authenticator| to |issuedRequests|.
 


### PR DESCRIPTION
Fixes #2025.
The current indentation renders this step as a sub-step of "For each credential descriptor C in pkOptions.excludeCredentials", meaning the operation is to be invoked once per `excludeCredentials` entry and not at all if `excludeCredentials` is empty. The indentation appears to have been broken in commit b44009c0bc24ed76f79c94c4bf6a3d5a111439ae (originally 7acc1d5ccb24306956acdeb31e995e8f7c486353) in PR #1366, caused by a mix of tab and space characters being replaced with just spaces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2027.html" title="Last updated on Feb 16, 2024, 7:31 PM UTC (e239ee5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2027/99cbcfa...e239ee5.html" title="Last updated on Feb 16, 2024, 7:31 PM UTC (e239ee5)">Diff</a>