### PR TITLE
Precisize that it's assertions that don't sign the credential ID

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8342,7 +8342,7 @@ are grouped into respective subsections.
 
 ## Credential ID Unsigned ## {#sctn-credentialIdSecurity}
 
-The [=credential ID=] is not signed.
+The [=credential ID=] accompanying an [=authentication assertion=] is not signed.
 This is not a problem because all that would happen if an [=authenticator=] returns
 the wrong [=credential ID=], or if an attacker intercepts and manipulates the [=credential ID=], is that the [=[WRP]=] would not look up the correct
 [=credential public key=] with which to verify the returned signed [=authenticator data=]


### PR DESCRIPTION
Fixes #2028.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2029.html" title="Last updated on Feb 28, 2024, 11:03 AM UTC (fdfeb07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2029/1a72b38...fdfeb07.html" title="Last updated on Feb 28, 2024, 11:03 AM UTC (fdfeb07)">Diff</a>