### PR TITLE
Clarify connection between credential record and PublicKeyCredentialDescriptor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3828,13 +3828,17 @@ Note: The {{PublicKeyCredentialType}} enumeration is deliberately not referenced
 This dictionary identifies a specific [=public key credential=].
 It is used in {{CredentialsContainer/create()}} to prevent creating duplicate credentials on the same [=authenticator=],
 and in {{CredentialsContainer/get()}} to determine if and how the credential can currently be reached by the [=client=].
-It mirrors some fields of the {{PublicKeyCredential}} object returned by
+
+The [=credential descriptor for a credential record=] is a subset of the properties of that [=credential record=],
+and mirrors some fields of the {{PublicKeyCredential}} object returned by
 {{CredentialsContainer/create()}} and {{CredentialsContainer/get()}}.
 
 <div dfn-type="dict-member" dfn-for="PublicKeyCredentialDescriptor">
     :   <dfn>type</dfn>
     ::  This member contains the type of the [=public key credential=] the caller is referring to. The value SHOULD be a member of {{PublicKeyCredentialType}} but [=client platforms=] MUST ignore any {{PublicKeyCredentialDescriptor}} with an unknown {{PublicKeyCredentialDescriptor/type}}.
 
+        This SHOULD be set to the value of the [$credential record/type$] item of the [=credential record=]
+        representing the identified [=public key credential source=].
         This mirrors the {{Credential/type}} field of {{PublicKeyCredential}}.
 
         Note: If all {{PublicKeyCredentialDescriptor}} elements in {{PublicKeyCredentialRequestOptions/allowCredentials}} are ignored then that MUST result in an error since an empty {{PublicKeyCredentialRequestOptions/allowCredentials}} is semantically distinct.
@@ -3842,19 +3846,18 @@ It mirrors some fields of the {{PublicKeyCredential}} object returned by
     :   <dfn>id</dfn>
     ::  This member contains the [=credential ID=] of the [=public key credential=] the caller is referring to.
 
+        This SHOULD be set to the value of the [$credential record/id$] item of the [=credential record=]
+        representing the identified [=public key credential source=].
         This mirrors the {{PublicKeyCredential/rawId}} field of {{PublicKeyCredential}}.
 
     :   <dfn>transports</dfn>
     ::  This OPTIONAL member contains a hint as to how the [=client=] might communicate with the [=managing authenticator=] of the
         [=public key credential=] the caller is referring to. The values SHOULD be members of {{AuthenticatorTransport}} but [=client platforms=] MUST ignore unknown values.
 
+        This SHOULD be set to the value of the [$credential record/transports$] item of the [=credential record=]
+        representing the identified [=public key credential source=].
         This mirrors the <code>{{PublicKeyCredential/response}}.{{AuthenticatorAttestationResponse/getTransports()}}</code> method
-        of a {{PublicKeyCredential}} structure created by a {{CredentialsContainer/create()}} operation.
-        When [[#sctn-registering-a-new-credential|registering a new credential]],
-        the [=[RP]=] SHOULD store the value returned from {{AuthenticatorAttestationResponse/getTransports()}}.
-        When creating a {{PublicKeyCredentialDescriptor}} for that credential,
-        the [=[RP]=] SHOULD retrieve that stored value
-        and set it as the value of the {{PublicKeyCredentialDescriptor/transports}} member.
+        of the {{PublicKeyCredential}} structure created by a {{CredentialsContainer/create()}} operation.
 </div>
 
 


### PR DESCRIPTION
Fixes #2016.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2031.html" title="Last updated on Feb 28, 2024, 12:57 PM UTC (70981d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2031/1a72b38...70981d9.html" title="Last updated on Feb 28, 2024, 12:57 PM UTC (70981d9)">Diff</a>