### PR TITLE
Fix out-of-sync numbers in algorithm step references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2023,7 +2023,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         <dl class="switch">
 
                             :   is set to {{AttestationConveyancePreference/enterprise}}
-                            ::  Let |enterpriseAttestationPossible| be [TRUE] if the user agent wishes to support enterprise attestation for <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> (see [Step 8](#CreateCred-DetermineRpId), above). Otherwise [FALSE].
+                            ::  Let |enterpriseAttestationPossible| be [TRUE] if the user agent wishes to support enterprise attestation for <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> (see [step 8](#CreateCred-DetermineRpId), above). Otherwise [FALSE].
 
                             :   otherwise
                             ::  Let |enterpriseAttestationPossible| be [FALSE].
@@ -5439,7 +5439,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             - If [=self attestation=] was used, verify that [=self attestation=] is acceptable under [=[RP]=] policy.
             - Otherwise, use the X.509 certificates returned as the [=attestation trust path=] from the [=verification procedure=]
                 to verify that the attestation public key either correctly chains up to an acceptable root certificate, or is itself an acceptable certificate
-                (i.e., it and the root certificate obtained in [Step 23](#reg-ceremony-attestation-trust-anchors) may be the same).
+                (i.e., it and the root certificate obtained in [step 23](#reg-ceremony-attestation-trust-anchors) may be the same).
     </li>
 
 1. Verify that the <code>[=credentialId=]</code> is &le; 1023 bytes. Credential IDs larger than this many bytes SHOULD cause the RP to fail this [=registration ceremony=].
@@ -6948,10 +6948,10 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
 
                Note: This is in anticipation of an authenticator capable of storing large blobs becoming available.
-               It occurs during extension processing in [Step 12](#CreateCred-process-extensions) of {{PublicKeyCredential/[[Create]]()}}.
+               It occurs during extension processing in [step 12](#CreateCred-process-extensions) of {{PublicKeyCredential/[[Create]]()}}.
                The {{AuthenticationExtensionsLargeBlobOutputs}} will be abandoned if no satisfactory authenticator becomes available.
 
-           1. If a [=create/candidate authenticator=] becomes available ([Step 21](#CreateCred-async-loop) of {{PublicKeyCredential/[[Create]]()}}) then,
+           1. If a [=create/candidate authenticator=] becomes available ([step 21](#CreateCred-async-loop) of {{PublicKeyCredential/[[Create]]()}}) then,
               before evaluating any <code>|options|</code>, [=iteration/continue=] (i.e. ignore the [=create/candidate authenticator=])
               if the [=create/candidate authenticator=] is not capable of storing large blobs.
        1. Otherwise (i.e. {{AuthenticationExtensionsLargeBlobInputs/support}} is absent or has the value {{LargeBlobSupport/preferred}}):

--- a/index.bs
+++ b/index.bs
@@ -5187,7 +5187,7 @@ calling {{CredentialsContainer/create()|navigator.credentials.create()}} they se
 [=attestation type=] as a part of [=verification procedure|verification=]. See the "Verification procedure" subsections of
 [[#sctn-defined-attestation-formats]]. See also [[#sctn-attestation-privacy]]. For all [=attestation types=] defined in this
 section other than [=self attestation|Self=] and [=None=], [=[RP]=] [=verification procedure|verification=] is followed by
-matching the [=attestation trust path|trust path=] to an acceptable root certificate per [step 23](#reg-ceremony-assess-trust)
+matching the [=attestation trust path|trust path=] to an acceptable root certificate per [step 24](#reg-ceremony-assess-trust)
 of [[#sctn-registering-a-new-credential]].
 Differentiating these [=attestation types=] becomes useful primarily as a means for determining if the [=attestation=] is acceptable
 under [=[RP]=] policy.
@@ -5434,12 +5434,12 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list -->
     <li id="reg-ceremony-assess-trust">
-        Assess the attestation trustworthiness using the outputs of the [=verification procedure=] in [step 21](#reg-ceremony-verify-attestation), as follows:
+        Assess the attestation trustworthiness using the outputs of the [=verification procedure=] in [step 22](#reg-ceremony-verify-attestation), as follows:
             - If [=None|no attestation=] was provided, verify that [=None=] attestation is acceptable under [=[RP]=] policy.
             - If [=self attestation=] was used, verify that [=self attestation=] is acceptable under [=[RP]=] policy.
             - Otherwise, use the X.509 certificates returned as the [=attestation trust path=] from the [=verification procedure=]
                 to verify that the attestation public key either correctly chains up to an acceptable root certificate, or is itself an acceptable certificate
-                (i.e., it and the root certificate obtained in [Step 22](#reg-ceremony-attestation-trust-anchors) may be the same).
+                (i.e., it and the root certificate obtained in [Step 23](#reg-ceremony-attestation-trust-anchors) may be the same).
     </li>
 
 1. Verify that the <code>[=credentialId=]</code> is &le; 1023 bytes. Credential IDs larger than this many bytes SHOULD cause the RP to fail this [=registration ceremony=].
@@ -5492,7 +5492,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         </dl>
     </li>
 
-1. If the attestation statement |attStmt| successfully verified but is not trustworthy per [step 23](#reg-ceremony-assess-trust) above,
+1. If the attestation statement |attStmt| successfully verified but is not trustworthy per [step 24](#reg-ceremony-assess-trust) above,
     the [=[RP]=] SHOULD fail the [=registration ceremony=].
 
     NOTE: However, if permitted by policy, the [=[RP]=] MAY register the [=credential ID=] and credential public key but treat the
@@ -5501,7 +5501,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         See [[FIDOSecRef]] and [[UAFProtocol]] for a more detailed discussion.
 
 Verification of [=attestation objects=] requires that the [=[RP]=] has a trusted method of determining acceptable trust anchors
-in [step 22](#reg-ceremony-attestation-trust-anchors) above.
+in [step 23](#reg-ceremony-attestation-trust-anchors) above.
 Also, if certificates are being used, the [=[RP]=] MUST have access to certificate status information for the
 intermediate CA certificates. The [=[RP]=] MUST also be able to build the attestation certificate chain if the client did not
 provide this chain in the attestation information.
@@ -6951,7 +6951,7 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
                It occurs during extension processing in [Step 12](#CreateCred-process-extensions) of {{PublicKeyCredential/[[Create]]()}}.
                The {{AuthenticationExtensionsLargeBlobOutputs}} will be abandoned if no satisfactory authenticator becomes available.
 
-           1. If a [=create/candidate authenticator=] becomes available ([Step 20](#CreateCred-async-loop) of {{PublicKeyCredential/[[Create]]()}}) then,
+           1. If a [=create/candidate authenticator=] becomes available ([Step 21](#CreateCred-async-loop) of {{PublicKeyCredential/[[Create]]()}}) then,
               before evaluating any <code>|options|</code>, [=iteration/continue=] (i.e. ignore the [=create/candidate authenticator=])
               if the [=create/candidate authenticator=] is not capable of storing large blobs.
        1. Otherwise (i.e. {{AuthenticationExtensionsLargeBlobInputs/support}} is absent or has the value {{LargeBlobSupport/preferred}}):
@@ -7414,7 +7414,7 @@ The [=supplementalPubKeys=] extension adds the following [=struct/item=] to [=cr
 ##### Registration (`create()`) ##### {#sctn-supplemental-public-keys-extension-verification-create}
 
 If the [=[RP]=] requested the `supplementalPubKeys` extension in a {{CredentialsContainer/create()|navigator.credentials.create()}} call,
-then the below verification steps are performed in the context of [step 19](#reg-ceremony-verify-extension-outputs)
+then the below verification steps are performed in the context of [step 20](#reg-ceremony-verify-extension-outputs)
 of [[#sctn-registering-a-new-credential]] using these variables established therein: |credential|, |clientExtensionResults|, |authData|, and |hash|.
 [=[RP]=] policy may specify whether a response without a `supplementalPubKeys` extension output is acceptable.
 
@@ -7455,7 +7455,7 @@ of [[#sctn-registering-a-new-credential]] using these variables established ther
             ::  The value of |attStmt|.
         </dl>
 
-        In [step 26](#reg-ceremony-store-credential-record) of [[#sctn-registering-a-new-credential]],
+        In [step 27](#reg-ceremony-store-credential-record) of [[#sctn-registering-a-new-credential]],
         add this [=supplemental public key record=] to the [$credential record/supplementalPubKeys$] member of the new [=credential record=].
 
 See also [[#sctn-supplemental-public-keys-extension-usage]] for further details.
@@ -7463,7 +7463,7 @@ See also [[#sctn-supplemental-public-keys-extension-usage]] for further details.
 ##### Authentication (`get()`) ##### {#sctn-supplemental-public-keys-extension-verification-get}
 
 If the [=[RP]=] requested the `supplementalPubKeys` extension in a {{CredentialsContainer/get()|navigator.credentials.get()}} call,
-then the below verification steps are performed in the context of [step 17](#authn-ceremony-verify-extension-outputs)
+then the below verification steps are performed in the context of [step 19](#authn-ceremony-verify-extension-outputs)
 of [[#sctn-verifying-assertion]] using these variables established therein: |credential|, |clientExtensionResults|, |authData|, |hash|, and |credentialRecord|.
 [=[RP]=] policy may specify whether a response without a `supplementalPubKeys` extension output is acceptable.
 
@@ -7579,7 +7579,7 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
             ::  The value of |attStmt|.
         </dl>
 
-        In [step 22](#authn-ceremony-update-credential-record) of [[#sctn-verifying-assertion]],
+        In [step 23](#authn-ceremony-update-credential-record) of [[#sctn-verifying-assertion]],
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
 


### PR DESCRIPTION
Fixes #2030.

Note that some of these currently appear incorrect in Chrome - see issue #1913.

Also ref: #1523, #1861, #797.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2032.html" title="Last updated on Feb 28, 2024, 1:18 PM UTC (fc39edd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2032/1a72b38...fc39edd.html" title="Last updated on Feb 28, 2024, 1:18 PM UTC (fc39edd)">Diff</a>