### PR TITLE
adds Related Origin Requests

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4119,8 +4119,8 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
     1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
     1. Split |domain| into |labels| and let |label| be the right-most one.
-    1. If |labelsSeen| [=set/contains=] |label|, [=continue=].
     1. If |callerOrigin| and |url| are [=same origin=], return [TRUE].
+    1. If |labelsSeen| [=set/contains=] |label|, [=continue=].
     1. [=set/Append=] |label| to |labelsSeen|.
     1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels|, [=break=].
 1. Return [FALSE].

--- a/index.bs
+++ b/index.bs
@@ -1836,7 +1836,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         :   supports [[#sctn-related-origins|related origin requests]]
                         ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>.
 
-                            1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is [FALSE], throw a "{{SecurityError}}" {{DOMException}}.
+                            1. Run the [$related origins validation procedure$] with arguments |callerOrigin| and |rpIdRequested|.
+                                If the result is [FALSE], throw a "{{SecurityError}}" {{DOMException}}.
 
                         :   does not support [[#sctn-related-origins|related origin requests]]
                         ::  throw a "{{SecurityError}}" {{DOMException}}.
@@ -2340,7 +2341,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
                             :   supports [[#sctn-related-origins|related origin requests]]
                             ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
 
-                                1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is [FALSE], throw a "{{SecurityError}}" {{DOMException}}.
+                                1. Run the [$related origins validation procedure$] with arguments |callerOrigin| and |rpIdRequested|.
+                                    If the result is [FALSE], throw a "{{SecurityError}}" {{DOMException}}.
 
                             :   does not support [[#sctn-related-origins|related origin requests]]
                             ::  throw a "{{SecurityError}}" {{DOMException}}.
@@ -4115,7 +4117,7 @@ For example, for the RP ID `example.com`:
 
 ### Validating Related Origins ### {#sctn-validating-relation-origin}
 
-To validate the calling origin is an authorized related origin for a given ceremony:
+The <dfn abstract-op>related origins validation procedure</dfn>, given arguments |callerOrigin| and |rpIdRequested|, is as follows:
 
 1. Let |maxLabels| be the maximum number of [=registrable origin labels=] allowed by client policy.
 1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).

--- a/index.bs
+++ b/index.bs
@@ -1839,7 +1839,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         
                                 1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
                                 1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
-                                1. If the value of the |origins| member of the JSON object is missing, or is not a list of strings, then throw a "{{SecurityError}}" {{DOMException}}.
+                                1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.
     
                             1. Let |originLabelsSeen| be an empty set.
                             1. [=set/For each=] string in |origins|:
@@ -2360,7 +2360,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                                     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
                                     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
-                                    1. If the value of the |origins| member of the JSON object is missing, or is not a list of strings, then throw a "{{SecurityError}}" {{DOMException}}.
+                                    1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.
 
                                 1. Let |originLabelsSeen| be an empty set.
                                 1. [=set/For each=] string in |origins|:

--- a/index.bs
+++ b/index.bs
@@ -4088,8 +4088,9 @@ A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) f
     - The top-level JSON object MUST contain a key named `origins` whose value MUST be an array of one or more strings containing web origins.
     - Origins with the same [=origin label=] SHOULD be listed together as the first elements in the array, with unique origins as the last elements.
 
-:: Note: When adding additional origins matching an existing [=origin label=], add them after the existing elements with the same [=origin label=] instead of at the end of the array.
-   This will ensure their processing will not impact the [=origin label=] count.
+    :: Note: When adding additional origins matching an existing [=origin label=], add them after the existing elements with the same [=origin label=] instead of at the end of the array.
+        This will ensure their processing will not impact the [=origin label=] count.
+
 
 For example, for the RP ID `example.com`:
 

--- a/index.bs
+++ b/index.bs
@@ -4117,9 +4117,9 @@ Relying Parties MUST choose a common [=RP ID=] to use across all ceremonies from
 
 A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
 
-    - the content type must be `application/json`
-    - JSON document MUST contain a single object named `origins`
-    - the `origins` object MUST contain an array of one or more web origins
+    - The content type must be `application/json`.
+    - JSON document MUST contain a single object named `origins`.
+    - The `origins` object MUST contain an array of one or more web origins.
 
 For example, for the RP ID `example.com`:
 

--- a/index.bs
+++ b/index.bs
@@ -4086,6 +4086,10 @@ A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) f
 
     - The content type MUST be `application/json`.
     - The top-level JSON object MUST contain a key named `origins` whose value MUST be an array of one or more strings containing web origins.
+    - Origins with the same [=origin label=] SHOULD be listed together as the first elements in the array, with unique origins as the last elements.
+
+:: Note: When adding additional origins matching an existing [=origin label=], add them after the existing elements with the same [=origin label=] instead of at the end of the array.
+   This will ensure their processing will not impact the [=origin label=] count.
 
 For example, for the RP ID `example.com`:
 
@@ -4094,8 +4098,14 @@ For example, for the RP ID `example.com`:
     "origins": [
         "https://example.co.uk",
         "https://example.de",
-        "https://example.sg"
-        "https://myexamplerewards.com"
+        "https://example.sg",
+        "https://example.net",
+        "https://exampledelivery.com",
+        "https://exampledelivery.co.uk",
+        "https://exampledelivery.de",
+        "https://exampledelivery.sg",
+        "https://myexamplerewards.com",
+        "https://examplecars.com"
     ]
 }
 </xmp>

--- a/index.bs
+++ b/index.bs
@@ -4080,8 +4080,7 @@ By default, Web Authentication requires that the [=RP ID=] be equal to the [=det
 This can make deployment challenging for large environments where multiple country-specific domains are in use (e.g. example.com vs example.co.uk vs example.sg), where alternative or brand domains are required (e.g. myexampletravel.com vs examplecruises.com), and/or where platform as a service providers are used to support mobile apps. 
 
 [=[WRPS]=] can opt in to allowing [=WebAuthn Clients=] to enable a credential to be created and used across a limited set of related [=origin|origins=].
-
-Relying Parties MUST choose a common [=RP ID=] to use across all ceremonies from related origins.
+Such [=[RPS]=] MUST choose a common [=RP ID=] to use across all ceremonies from related origins.
 
 A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
 

--- a/index.bs
+++ b/index.bs
@@ -1834,7 +1834,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>.
 
                             1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is [FALSE], throw a "{{SecurityError}}" {{DOMException}}.
-                            
+
                         :   does not support [[#sctn-related-origins|related origin requests]]
                         ::  throw a "{{SecurityError}}" {{DOMException}}.
                     </dl>
@@ -2337,13 +2337,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
                             :   supports [[#sctn-related-origins|related origin requests]]
                             ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
 
-                                1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is
-                                    <dl class="switch">
-                                        :   `false`
-                                        ::  throw a "{{SecurityError}}" {{DOMException}}.
-                                        :   `true`
-                                        ::  [=break=].
-                                    </dl>
+                                1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is [FALSE], throw a "{{SecurityError}}" {{DOMException}}.
 
                             :   does not support [[#sctn-related-origins|related origin requests]]
                             ::  throw a "{{SecurityError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -4115,7 +4115,7 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.
-1. Let |originLabelsSeen| be an empty set.
+1. Let |labelsSeen| be a new empty [=set=].
 1. [=set/For each=] string in |origins|:
     1. Let |url| be the result of parsing the string as a URL. If that fails, [=continue=].
     1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].

--- a/index.bs
+++ b/index.bs
@@ -4096,7 +4096,7 @@ Relying Parties MUST choose a common [=RP ID=] to use across all ceremonies from
 
 A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
 
-    - The content type must be `application/json`.
+    - The content type MUST be `application/json`.
     - JSON document MUST contain a single object named `origins`.
     - The `origins` object MUST contain an array of one or more web origins.
 

--- a/index.bs
+++ b/index.bs
@@ -4109,7 +4109,7 @@ To override this default policy and indicate that a cross-origin <{iframe}> is a
 
 By default, Web Authentication requires that the [=RP ID=] be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
 
-This can make deployment challenging for large environments where multiple country-specific domains are in use (e.g. example.com vs example.co.uk vs example.sg), where vanity or brand domains are required (e.g. myexampletravel.com vs examplecruises.com), and/or where platform as a service providers are used to support mobile apps. 
+This can make deployment challenging for large environments where multiple country-specific domains are in use (e.g. example.com vs example.co.uk vs example.sg), where alternative or brand domains are required (e.g. myexampletravel.com vs examplecruises.com), and/or where platform as a service providers are used to support mobile apps. 
 
 [=[WRPS]=] can opt in to allowing [=WebAuthn Clients=] to enable a credential to be created and used across a limited set of related [=origin|origins=]
 

--- a/index.bs
+++ b/index.bs
@@ -4130,9 +4130,10 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
     1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
     1. Split |domain| into |labels| and let |label| be the right-most one.
+    1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels| and |labelsSeen|does not [=contains|contain=] |label|, [=continue=].
     1. If |callerOrigin| and |url| are [=same origin=], return [TRUE].
-    1. [=set/Append=] |label| to |labelsSeen|.
-    1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels|, [=break=].
+    1. If |labelsSeen| [=contains=] |label|, [=continue=].
+    1. If the [=set/size=] of |labelsSeen| is less than |maxLabels|, [=set/Append=] |label| to |labelsSeen|.
 1. Return [FALSE].
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}

--- a/index.bs
+++ b/index.bs
@@ -4121,8 +4121,10 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
     1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
     1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
-    1. If |label| is not in |labelsSeen| and the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|. Otherwise, [=continue=]. 
+    1. If |labelsSeen| [=set/contains=] |label|, [=continue=].
     1. If |rpIdRequested| and |url| are [=same origin=], return `true`.
+    1. [=set/Append=] |label| to |labelsSeen|.
+    1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels|, [=break=].
 1. Return `false`.
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}

--- a/index.bs
+++ b/index.bs
@@ -1228,8 +1228,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Non-Discoverable Credential</dfn>
 :: This is a [=credential=] whose [=credential ID=] must be provided in {{PublicKeyCredentialRequestOptions/allowCredentials}} when calling {{CredentialsContainer/get()|navigator.credentials.get()}} because it is not [=client-side discoverable credential|client-side discoverable=]. See also [=server-side credentials=].
 
-: <dfn>Origin Label</dfn>
-:: The portion of a domain name preceding the effective top-level domain, as defined in the Public Suffix List [[PSL]]. This is often referred to as the eTLD+1. For example, the origin label for example.co.uk and example.de is `example`.
+: <dfn>Registrable Origin Label</dfn>
+:: The first [=domain label=] of the [=registrable domain=] of a [=domain=],
+    or null if the [=registrable domain=] is null.
+    For example, the [=registrable origin label=] of both `example.co.uk` and `www.example.de` is `example`
+    if both `co.uk` and `de` are [=public suffixes=].
 
 : <dfn>Public Key Credential</dfn>
 :: Generically, a *credential* is data one entity presents to another in order to *authenticate* the former to the latter
@@ -4106,7 +4109,7 @@ For example, for the RP ID `example.com`:
 }
 </xmp>
 
-[=WebAuthn Clients=] supporting this feature MUST support at least five [=origin labels=]. Client policy SHOULD define an upper limit to prevent abuse.
+[=WebAuthn Clients=] supporting this feature MUST support at least five [=registrable origin labels=]. Client policy SHOULD define an upper limit to prevent abuse.
 
 [=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOrigins}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
 
@@ -4114,21 +4117,20 @@ For example, for the RP ID `example.com`:
 
 To validate the calling origin is an authorized related origin for a given ceremony:
 
-1. Let |maxLabels| be the maximum number of [=origin labels=] allowed by client policy.
+1. Let |maxLabels| be the maximum number of [=registrable origin labels=] allowed by client policy.
 1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.
 1. Let |labelsSeen| be a new empty [=set=].
-1. [=set/For each=] string in |origins|:
-    1. Let |url| be the result of parsing the string as a URL. If that fails, [=continue=].
+1. [=set/For each=] |originItem| of |origins|:
+    1. Let |url| be the result of running the [=URL parser=] with |originItem| as the input. If that fails, [=continue=].
     1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
-    1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
-    1. Split |domain| into |labels| and let |label| be the right-most one.
-    1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels| and |labelsSeen|does not [=contains|contain=] |label|, [=continue=].
+    1. Let |label| be [=registrable origin label=] of |domain|.
+    1. If |label| is empty or null, [=continue=].
+    1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels| and |labelsSeen| does not [=set/contain=] |label|, [=continue=].
     1. If |callerOrigin| and |url| are [=same origin=], return [TRUE].
-    1. If |labelsSeen| [=contains=] |label|, [=continue=].
-    1. If the [=set/size=] of |labelsSeen| is less than |maxLabels|, [=set/Append=] |label| to |labelsSeen|.
+    1. If the [=set/size=] of |labelsSeen| is less than |maxLabels|, [=set/append=] |label| to |labelsSeen|.
 1. Return [FALSE].
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}

--- a/index.bs
+++ b/index.bs
@@ -4110,7 +4110,7 @@ For example, for the RP ID `example.com`:
 
 To validate the calling origin is an authorized related origin for a given ceremony:
 
-1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
+1. Let |maxLabels| be the maximum number of [=origin labels=] allowed by client policy.
 1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -1228,6 +1228,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 : <dfn>Non-Discoverable Credential</dfn>
 :: This is a [=credential=] whose [=credential ID=] must be provided in {{PublicKeyCredentialRequestOptions/allowCredentials}} when calling {{CredentialsContainer/get()|navigator.credentials.get()}} because it is not [=client-side discoverable credential|client-side discoverable=]. See also [=server-side credentials=].
 
+: <dfn>Origin Label</dfn>
+:: The portion of a domain name preceding the effective top-level domain, as defined in the Public Suffix List [[PSL]]. This is often referred to as the eTLD+1. For example, the origin label for example.co.uk and example.de is `example`.
+
 : <dfn>Public Key Credential</dfn>
 :: Generically, a *credential* is data one entity presents to another in order to *authenticate* the former to the latter
     [[RFC4949]]. The term [=public key credential=] refers to one of: a [=public key credential source=], the
@@ -1824,11 +1827,37 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                 :   is present
                 ::  If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> [=is not a
-                    registrable domain suffix of and is not equal to=] |effectiveDomain|, throw a "{{SecurityError}}" {{DOMException}}.
+                    registrable domain suffix of and is not equal to=] |effectiveDomain|, and if the client
+                
+                    <dl class="switch">
+                        :   supports [[#sctn-related-origins|related origin requests]]
+                        ::  1. let |rpIdRequested| be the value of |pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}
 
-                :   Is not present
-                ::  Set <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to
-                    |effectiveDomain|.
+                            1. let |maxLabels| be 
+                        
+                            1. fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn-origins</code>).
+                        
+                                1. if the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
+                                1. if the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
+                                1. if the value of the |origins| member of the JSON object is missing, or is not a list of strings, then throw a "{{SecurityError}}" {{DOMException}}.
+    
+                            1. Let |originLabelsSeen| be an empty set
+                            1. [=set/For each=] string in |origins|:
+                                1. Let |url| be the result of parsing the string as a URL. If that fails, continue with the next element in the list.
+                                1. Let |domain| be the !!effective domain of |url|. If that is null, continue with the next element of the list.
+                                1. Remove any !!public suffix from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, continue with the next element of the list.
+                                1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
+                                1. If |label| is not in |labelsSeen| then:
+                                    1. If the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|.
+                                    1. Otherwise, continue with the next element of the list.
+                                1. If |rpIdRequested| and |url| are !!same origin!!, then [=continue=].
+
+                        :   does not support [[#sctn-related-origins|related origin requests]]
+                        ::  throw a "{{SecurityError}}" {{DOMException}}.
+                    </dl>
+
+                :   is not present
+                ::  Set <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to |effectiveDomain|.
             </dl>
 
         Note: <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> represents the
@@ -4046,7 +4075,39 @@ To override this default policy and indicate that a cross-origin <{iframe}> is a
 
 [=[RPS]=] utilizing the WebAuthn API in an embedded context should review [[#sctn-seccons-visibility]] regarding [=UI redressing=] and its possible mitigations.
 
+## Using Web Authentication across related origins ## {#sctn-related-origins}
 
+By default, 
+
+[=[WRP]=] can opt in to allowing a [=WebAuthn Clients=] to select credentials created with a different, but related [=RP ID=] than the caller's [=origin=].
+
+WebAuthn credential to be used across a limited set of [=origin|origins=] to support use cases such as country code TLDs(!add reference!), vanity or brand domains, and platform as a service providers supporting mobile apps.
+
+Relying Parties MUST choose a common Relying Party ID to use across all ceremonies from related origins.
+
+A JSON document MUST be hosted at the `webauthn-origins` well-known URL ([[!RFC8615]]) for the [=RP ID=].
+
+The JSON document MUST be returned as follows:
+
+    - the content type must be `application/json`
+    - JSON document MUST contain a single object named `origins`
+    - the `origins` object MUST contain an array of one or more web origins
+
+For example, for the RP ID `example.com`:
+
+<xmp class="json" highlight="json">
+{
+    "origins": [
+        "https://example.co.uk",
+        "https://example.de",
+        "https://myexamplerewards.com"
+    ]
+}
+</xmp>
+
+[=WebAuthn Clients=] SHOULD limit the number of related origins, with a recommended maximum of 5 [=origin labels=].
+
+[=WebAuthn Clients=] supporting this feature SHOULD include `related-origin-requests` in their response to getClientCapabilities() as defined in !XYZ!.
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 

--- a/index.bs
+++ b/index.bs
@@ -4122,10 +4122,10 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
     1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
     1. If |labelsSeen| [=set/contains=] |label|, [=continue=].
-    1. If |rpIdRequested| and |url| are [=same origin=], return `true`.
+    1. If |rpIdRequested| and |url| are [=same origin=], return [TRUE].
     1. [=set/Append=] |label| to |labelsSeen|.
     1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels|, [=break=].
-1. Return `false`.
+1. Return [FALSE].
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 

--- a/index.bs
+++ b/index.bs
@@ -4086,11 +4086,6 @@ A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) f
 
     - The content type MUST be `application/json`.
     - The top-level JSON object MUST contain a key named `origins` whose value MUST be an array of one or more strings containing web origins.
-    - Origins with the same [=origin label=] SHOULD be listed together as the first elements in the array, with unique origins as the last elements.
-
-    :: Note: When adding additional origins matching an existing [=origin label=], add them after the existing elements with the same [=origin label=] instead of at the end of the array.
-        This will ensure their processing will not impact the [=origin label=] count.
-
 
 For example, for the RP ID `example.com`:
 

--- a/index.bs
+++ b/index.bs
@@ -4079,7 +4079,7 @@ By default, Web Authentication requires that the [=RP ID=] be equal to the [=det
 
 This can make deployment challenging for large environments where multiple country-specific domains are in use (e.g. example.com vs example.co.uk vs example.sg), where alternative or brand domains are required (e.g. myexampletravel.com vs examplecruises.com), and/or where platform as a service providers are used to support mobile apps. 
 
-[=[WRPS]=] can opt in to allowing [=WebAuthn Clients=] to enable a credential to be created and used across a limited set of related [=origin|origins=]
+[=[WRPS]=] can opt in to allowing [=WebAuthn Clients=] to enable a credential to be created and used across a limited set of related [=origin|origins=].
 
 Relying Parties MUST choose a common [=RP ID=] to use across all ceremonies from related origins.
 

--- a/index.bs
+++ b/index.bs
@@ -4136,7 +4136,7 @@ For example, for the RP ID `example.com`:
 }
 </xmp>
 
-To mitigate abuse, [=WebAuthn Clients=] SHOULD limit the number of related origins, with a recommended maximum of 5 [=origin labels=].
+[=WebAuthn Clients=] supporting this feature MUST support at least five [=origin labels=]. Client policy SHOULD define an upper limit to prevent abuse.
 
 [=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOriginRequests}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
 

--- a/index.bs
+++ b/index.bs
@@ -1833,27 +1833,17 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         :   supports [[#sctn-related-origins|related origin requests]]
                         ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>.
 
-                            1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
-                        
-                            1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
-                        
-                                1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
-                                1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
-                                1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.
-    
-                            1. Let |originLabelsSeen| be an empty set.
-                            1. [=set/For each=] string in |origins|:
-                                1. Let |url| be the result of parsing the string as a URL. If that fails, [=continue=].
-                                1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
-                                1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
-                                1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
-                                1. If |label| is not in |labelsSeen| and the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|. Otherwise, [=continue=].
-                                1. If |rpIdRequested| and |url| are [=same origin=], then [=continue=].
-
+                            1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is
+                                <dl class="switch">
+                                    :   `false`
+                                    ::  throw a "{{SecurityError}}" {{DOMException}}.
+                                    :   `true`
+                                    ::  [=break=].
+                                </dl>
                         :   does not support [[#sctn-related-origins|related origin requests]]
                         ::  throw a "{{SecurityError}}" {{DOMException}}.
                     </dl>
-
+                    
                 :   is not present
                 ::  Set <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> to |effectiveDomain|.
             </dl>
@@ -2352,24 +2342,13 @@ When this method is invoked, the user agent MUST execute the following algorithm
                             :   supports [[#sctn-related-origins|related origin requests]]
                             ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
 
-                                1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
-
-                                1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
-
-                                    1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
-                                    1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
-                                    1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.
-
-                                1. Let |originLabelsSeen| be an empty set.
-                                1. [=set/For each=] string in |origins|:
-                                    1. Let |url| be the result of parsing the string as a URL. If that fails, continue with the next element in the list.
-                                    1. Let |domain| be the [=effective domain=] of |url|. If that is null, continue with the next element of the list.
-                                    1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, continue with the next element of the list.
-                                    1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
-                                    1. If |label| is not in |labelsSeen| and:
-                                        1. If the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|.
-                                        1. Otherwise, continue with the next element of the list.
-                                    1. If |rpIdRequested| and |url| are [=same origin=], then [=continue=].
+                                1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is
+                                    <dl class="switch">
+                                        :   `false`
+                                        ::  throw a "{{SecurityError}}" {{DOMException}}.
+                                        :   `true`
+                                        ::  [=break=].
+                                    </dl>
 
                             :   does not support [[#sctn-related-origins|related origin requests]]
                             ::  throw a "{{SecurityError}}" {{DOMException}}.
@@ -4137,6 +4116,25 @@ For example, for the RP ID `example.com`:
 [=WebAuthn Clients=] supporting this feature MUST support at least five [=origin labels=]. Client policy SHOULD define an upper limit to prevent abuse.
 
 [=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOrigins}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
+
+### Validating Related Origins ### {#sctn-validating-relation-origin}
+
+To validate the calling origin is an authorized related origin for a given ceremony:
+
+1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
+1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
+    1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
+    1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
+    1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.
+1. Let |originLabelsSeen| be an empty set.
+1. [=set/For each=] string in |origins|:
+    1. Let |url| be the result of parsing the string as a URL. If that fails, [=continue=].
+    1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
+    1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
+    1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
+    1. If |label| is not in |labelsSeen| and the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|. Otherwise, [=continue=]. 
+    1. If |rpIdRequested| and |url| are [=same origin=], return `true`.
+1. Return `false`.
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 

--- a/index.bs
+++ b/index.bs
@@ -1843,13 +1843,13 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     
                             1. Let |originLabelsSeen| be an empty set.
                             1. [=set/For each=] string in |origins|:
-                                1. Let |url| be the result of parsing the string as a URL. If that fails, continue with the next element in the list.
-                                1. Let |domain| be the [=effective domain=] of |url|. If that is null, continue with the next element of the list.
-                                1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, continue with the next element of the list.
+                                1. Let |url| be the result of parsing the string as a URL. If that fails, [=continue=].
+                                1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
+                                1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
                                 1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
                                 1. If |label| is not in |labelsSeen| and:
                                     1. If the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|.
-                                    1. Otherwise, continue with the next element of the list.
+                                    1. Otherwise, [=continue=].
                                 1. If |rpIdRequested| and |url| are [=same origin=], then [=continue=].
 
                         :   does not support [[#sctn-related-origins|related origin requests]]

--- a/index.bs
+++ b/index.bs
@@ -1847,9 +1847,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                                 1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
                                 1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
                                 1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
-                                1. If |label| is not in |labelsSeen| and:
-                                    1. If the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|.
-                                    1. Otherwise, [=continue=].
+                                1. If |label| is not in |labelsSeen| and the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|. Otherwise, [=continue=].
                                 1. If |rpIdRequested| and |url| are [=same origin=], then [=continue=].
 
                         :   does not support [[#sctn-related-origins|related origin requests]]

--- a/index.bs
+++ b/index.bs
@@ -4018,7 +4018,7 @@ Note: The {{UserVerificationRequirement}} enumeration is deliberately not refere
         "hybridTransport",
         "passkeyPlatformAuthenticator",
         "userVerifyingPlatformAuthenticator",
-        "relatedOriginRequests"
+        "relatedOrigins"
     };
 </xmp>
 
@@ -4042,7 +4042,7 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
     :   <dfn>userVerifyingPlatformAuthenticator</dfn>
     ::  The [=WebAuthn Client=] supports usage of a [=user-verifying platform authenticator=].
 
-    :   <dfn>relatedOriginRequests</dfn>
+    :   <dfn>relatedOrigins</dfn>
     ::  The [=WebAuthn Client=] supports [[#sctn-related-origins|Related Origin Requests]].
 </div>
 
@@ -4136,7 +4136,7 @@ For example, for the RP ID `example.com`:
 
 [=WebAuthn Clients=] supporting this feature MUST support at least five [=origin labels=]. Client policy SHOULD define an upper limit to prevent abuse.
 
-[=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOriginRequests}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
+[=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOrigins}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 

--- a/index.bs
+++ b/index.bs
@@ -4120,7 +4120,7 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
     1. Split |domain| into |labels| and let |label| be the right-most one.
     1. If |labelsSeen| [=set/contains=] |label|, [=continue=].
-    1. If |rpIdRequested| and |url| are [=same origin=], return [TRUE].
+    1. If |callerOrigin| and |url| are [=same origin=], return [TRUE].
     1. [=set/Append=] |label| to |labelsSeen|.
     1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels|, [=break=].
 1. Return [FALSE].

--- a/index.bs
+++ b/index.bs
@@ -4085,8 +4085,7 @@ Such [=[RPS]=] MUST choose a common [=RP ID=] to use across all ceremonies from 
 A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
 
     - The content type MUST be `application/json`.
-    - JSON document MUST contain a single object named `origins`.
-    - The `origins` object MUST contain an array of one or more web origins.
+    - The top-level JSON object MUST contain a key named `origins` whose value MUST be an array of one or more strings containing web origins.
 
 For example, for the RP ID `example.com`:
 

--- a/index.bs
+++ b/index.bs
@@ -1833,13 +1833,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         :   supports [[#sctn-related-origins|related origin requests]]
                         ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>.
 
-                            1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is
-                                <dl class="switch">
-                                    :   `false`
-                                    ::  throw a "{{SecurityError}}" {{DOMException}}.
-                                    :   `true`
-                                    ::  [=break=].
-                                </dl>
+                            1. If the result of running the [[#sctn-validating-relation-origin|related origins validation procedure]] is [FALSE], throw a "{{SecurityError}}" {{DOMException}}.
+                            
                         :   does not support [[#sctn-related-origins|related origin requests]]
                         ::  throw a "{{SecurityError}}" {{DOMException}}.
                     </dl>

--- a/index.bs
+++ b/index.bs
@@ -1831,26 +1831,26 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                 
                     <dl class="switch">
                         :   supports [[#sctn-related-origins|related origin requests]]
-                        ::  1. let |rpIdRequested| be the value of |pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}
+                        ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>.
 
-                            1. let |maxLabels| be 
+                            1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
                         
-                            1. fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn-origins</code>).
+                            1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn-origins</code>).
                         
-                                1. if the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
-                                1. if the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
-                                1. if the value of the |origins| member of the JSON object is missing, or is not a list of strings, then throw a "{{SecurityError}}" {{DOMException}}.
+                                1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
+                                1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
+                                1. If the value of the |origins| member of the JSON object is missing, or is not a list of strings, then throw a "{{SecurityError}}" {{DOMException}}.
     
-                            1. Let |originLabelsSeen| be an empty set
+                            1. Let |originLabelsSeen| be an empty set.
                             1. [=set/For each=] string in |origins|:
                                 1. Let |url| be the result of parsing the string as a URL. If that fails, continue with the next element in the list.
-                                1. Let |domain| be the !!effective domain of |url|. If that is null, continue with the next element of the list.
-                                1. Remove any !!public suffix from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, continue with the next element of the list.
+                                1. Let |domain| be the [=effective domain=] of |url|. If that is null, continue with the next element of the list.
+                                1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, continue with the next element of the list.
                                 1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
-                                1. If |label| is not in |labelsSeen| then:
+                                1. If |label| is not in |labelsSeen| and:
                                     1. If the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|.
                                     1. Otherwise, continue with the next element of the list.
-                                1. If |rpIdRequested| and |url| are !!same origin!!, then [=continue=].
+                                1. If |rpIdRequested| and |url| are [=same origin=], then [=continue=].
 
                         :   does not support [[#sctn-related-origins|related origin requests]]
                         ::  throw a "{{SecurityError}}" {{DOMException}}.
@@ -2343,19 +2343,47 @@ When this method is invoked, the user agent MUST execute the following algorithm
         PKI-based security.
 
         <li id='GetAssn-DetermineRpId'>
-            If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> is not present, then set |rpId| to
-                |effectiveDomain|.
+            If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
+                <dl class="switch">
 
-                Otherwise:
+                    :   is present
+                    ::  If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> [=is not a
+                        registrable domain suffix of and is not equal to=] |effectiveDomain|, and if the client
 
-                1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> [=is not a registrable domain suffix of and is not
-                    equal to=] |effectiveDomain|, throw a "{{SecurityError}}" {{DOMException}}.
+                        <dl class="switch">
+                            :   supports [[#sctn-related-origins|related origin requests]]
+                            ::  1. Let |rpIdRequested| be the value of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
 
-                1. Set |rpId| to <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>.
+                                1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
 
-                    Note: |rpId| represents the caller's [=RP ID=]. The [=RP ID=] defaults to being the caller's [=environment
-                    settings object/origin=]'s [=effective domain=] unless the caller has explicitly set
-                    <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> when calling {{CredentialsContainer/get()}}.
+                                1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn-origins</code>).
+
+                                    1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
+                                    1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
+                                    1. If the value of the |origins| member of the JSON object is missing, or is not a list of strings, then throw a "{{SecurityError}}" {{DOMException}}.
+
+                                1. Let |originLabelsSeen| be an empty set.
+                                1. [=set/For each=] string in |origins|:
+                                    1. Let |url| be the result of parsing the string as a URL. If that fails, continue with the next element in the list.
+                                    1. Let |domain| be the [=effective domain=] of |url|. If that is null, continue with the next element of the list.
+                                    1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, continue with the next element of the list.
+                                    1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
+                                    1. If |label| is not in |labelsSeen| and:
+                                        1. If the number of elements in |labelsSeen| is less than |maxLabels|, then insert |label| into |labelsSeen|.
+                                        1. Otherwise, continue with the next element of the list.
+                                    1. If |rpIdRequested| and |url| are [=same origin=], then [=continue=].
+
+                            :   does not support [[#sctn-related-origins|related origin requests]]
+                            ::  throw a "{{SecurityError}}" {{DOMException}}.
+                        </dl>
+
+                    :   is not present
+                    ::  Set <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> to |effectiveDomain|.
+                </dl>
+
+            Note: |rpId| represents the caller's [=RP ID=]. The [=RP ID=] defaults to being the caller's [=environment
+            settings object/origin=]'s [=effective domain=] unless the caller has explicitly set
+            <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> when calling {{CredentialsContainer/get()}}.
         </li>
 
 1. Let |clientExtensions| be a new [=map=] and let |authenticatorExtensions| be a new [=map=].
@@ -3992,6 +4020,7 @@ Note: The {{UserVerificationRequirement}} enumeration is deliberately not refere
         "hybridTransport",
         "passkeyPlatformAuthenticator",
         "userVerifyingPlatformAuthenticator",
+        "relatedOriginRequests"
     };
 </xmp>
 
@@ -4014,6 +4043,9 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
 
     :   <dfn>userVerifyingPlatformAuthenticator</dfn>
     ::  The [=WebAuthn Client=] supports usage of a [=user-verifying platform authenticator=].
+
+    :   <dfn>relatedOriginRequests</dfn>
+    ::  The [=WebAuthn Client=] supports [[#sctn-related-origins|Related Origin Requests]].
 </div>
 
 ### User-agent Hints Enumeration (enum <dfn enum>PublicKeyCredentialHints</dfn>) ### {#enum-hints}
@@ -4077,17 +4109,15 @@ To override this default policy and indicate that a cross-origin <{iframe}> is a
 
 ## Using Web Authentication across related origins ## {#sctn-related-origins}
 
-By default, 
+By default, Web Authentication requires that the [=RP ID=] be equal to the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=], or a [=is a registrable domain suffix of or is equal to|registrable domain suffix=] of the [=determines the set of origins on which the public key credential may be exercised|origin=]'s [=effective domain=].
 
-[=[WRP]=] can opt in to allowing a [=WebAuthn Clients=] to select credentials created with a different, but related [=RP ID=] than the caller's [=origin=].
+This can make deployment challenging for large environments where multiple country-specific domains are in use (e.g. example.com vs example.co.uk vs example.sg), where vanity or brand domains are required (e.g. myexampletravel.com vs examplecruises.com), and/or where platform as a service providers are used to support mobile apps. 
 
-WebAuthn credential to be used across a limited set of [=origin|origins=] to support use cases such as country code TLDs(!add reference!), vanity or brand domains, and platform as a service providers supporting mobile apps.
+[=[WRPS]=] can opt in to allowing [=WebAuthn Clients=] to enable a credential to be created and used across a limited set of related [=origin|origins=]
 
-Relying Parties MUST choose a common Relying Party ID to use across all ceremonies from related origins.
+Relying Parties MUST choose a common [=RP ID=] to use across all ceremonies from related origins.
 
-A JSON document MUST be hosted at the `webauthn-origins` well-known URL ([[!RFC8615]]) for the [=RP ID=].
-
-The JSON document MUST be returned as follows:
+A JSON document MUST be hosted at the `webauthn-origins` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
 
     - the content type must be `application/json`
     - JSON document MUST contain a single object named `origins`
@@ -4100,14 +4130,15 @@ For example, for the RP ID `example.com`:
     "origins": [
         "https://example.co.uk",
         "https://example.de",
+        "https://example.sg"
         "https://myexamplerewards.com"
     ]
 }
 </xmp>
 
-[=WebAuthn Clients=] SHOULD limit the number of related origins, with a recommended maximum of 5 [=origin labels=].
+To mitigate abuse, [=WebAuthn Clients=] SHOULD limit the number of related origins, with a recommended maximum of 5 [=origin labels=].
 
-[=WebAuthn Clients=] supporting this feature SHOULD include `related-origin-requests` in their response to getClientCapabilities() as defined in !XYZ!.
+[=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOriginRequests}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
 
 # WebAuthn <dfn>Authenticator Model</dfn> # {#sctn-authenticator-model}
 
@@ -8676,6 +8707,11 @@ For example:
 - A web application served at a small number of domains might require
     {{CollectedClientData/origin}} to exactly equal some element of a list of allowed origins,
     for example the list <code>["https://example.org", "https://login.example.org"]</code>.
+
+- A web application leveraging [[#sctn-related-origins|related origin requests]] might also require
+    {{CollectedClientData/origin}} to exactly equal some element of a list of allowed origins,
+    for example the list <code>["https://example.co.uk", "https://example.de", "https://myexamplerewards.com"]</code>.
+    This list will typically match the origins listed in the well-known URI for the [=RP ID=]. See [[#sctn-related-origins]].
 
 - A web application served at a large set of domains that changes often might parse
     {{CollectedClientData/origin}} structurally and require that the URL scheme is <code>https</code>

--- a/index.bs
+++ b/index.bs
@@ -4130,7 +4130,6 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
     1. Split |domain| into |labels| and let |label| be the right-most one.
     1. If |callerOrigin| and |url| are [=same origin=], return [TRUE].
-    1. If |labelsSeen| [=set/contains=] |label|, [=continue=].
     1. [=set/Append=] |label| to |labelsSeen|.
     1. If the [=set/size=] of |labelsSeen| is greater than or equal to |maxLabels|, [=break=].
 1. Return [FALSE].

--- a/index.bs
+++ b/index.bs
@@ -4087,7 +4087,7 @@ This can make deployment challenging for large environments where multiple count
 [=[WRPS]=] can opt in to allowing [=WebAuthn Clients=] to enable a credential to be created and used across a limited set of related [=origin|origins=].
 Such [=[RPS]=] MUST choose a common [=RP ID=] to use across all ceremonies from related origins.
 
-A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
+A JSON document MUST be hosted at the `webauthn` well-known URL [[!RFC8615]] for the [=RP ID=]. The JSON document MUST be returned as follows:
 
     - The content type MUST be `application/json`.
     - The top-level JSON object MUST contain a key named `origins` whose value MUST be an array of one or more strings containing web origins.
@@ -4120,7 +4120,7 @@ For example, for the RP ID `example.com`:
 The <dfn abstract-op>related origins validation procedure</dfn>, given arguments |callerOrigin| and |rpIdRequested|, is as follows:
 
 1. Let |maxLabels| be the maximum number of [=registrable origin labels=] allowed by client policy.
-1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
+1. Fetch the `webauthn` well-known URL [[!RFC8615]] for the RP ID |rpIdRequested| (i.e., <code>https://|rpIdRequested|/.well-known/webauthn</code>).
     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -1835,7 +1835,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                             1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
                         
-                            1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn-origins</code>).
+                            1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
                         
                                 1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
                                 1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
@@ -2356,7 +2356,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                                 1. Let |maxLabels| be the number of maximum [=origin labels=] allowed by client policy.
 
-                                1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn-origins</code>).
+                                1. Fetch the well-known URL for the RP ID (<code>https://|rpIdRequested|/.well-known/webauthn</code>).
 
                                     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
                                     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
@@ -4117,7 +4117,7 @@ This can make deployment challenging for large environments where multiple count
 
 Relying Parties MUST choose a common [=RP ID=] to use across all ceremonies from related origins.
 
-A JSON document MUST be hosted at the `webauthn-origins` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
+A JSON document MUST be hosted at the `webauthn` well-known URL ([[!RFC8615]]) for the [=RP ID=]. The JSON document MUST be returned as follows:
 
     - the content type must be `application/json`
     - JSON document MUST contain a single object named `origins`

--- a/index.bs
+++ b/index.bs
@@ -4118,7 +4118,7 @@ To validate the calling origin is an authorized related origin for a given cerem
     1. Let |url| be the result of parsing the string as a URL. If that fails, [=continue=].
     1. Let |domain| be the [=effective domain=] of |url|. If that is null, [=continue=].
     1. Remove any [=public suffix=] from the end of |domain|, including private registries and unknown registries. If |domain| is now empty, [=continue=].
-    1. Split |domain| into [=origin labels|labels=] and let |label| be the right-most one.
+    1. Split |domain| into |labels| and let |label| be the right-most one.
     1. If |labelsSeen| [=set/contains=] |label|, [=continue=].
     1. If |rpIdRequested| and |url| are [=same origin=], return [TRUE].
     1. [=set/Append=] |label| to |labelsSeen|.


### PR DESCRIPTION
Adds the Related Origin Requests feature ([explainer](https://github.com/w3c/webauthn/wiki/Explainer:-Related-origin-requests))

- Updates "Create a New Credential"
- Updates "Use an Existing Credential"
- Adds a new subsection: "Using Web Authentication across related origins"
- Adds a new definition for "Origin Label"
- Updates "Validating the origin of a credential"
- Updates "enum ClientCapability"


Resolves #1372


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2040.html" title="Last updated on Jul 17, 2024, 6:35 PM UTC (017a5e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2040/c75b69e...017a5e3.html" title="Last updated on Jul 17, 2024, 6:35 PM UTC (017a5e3)">Diff</a>