### PR TITLE
Include supported extensions in getClientCapabilities.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2775,12 +2775,16 @@ This method has no arguments and returns a record of capability keys to Boolean 
 </xmp>
 
 [=map/Keys=] in {{PublicKeyCredentialClientCapabilities}} MUST be sorted in ascending lexicographical order.
-The set of [=map/keys=] SHOULD equal the set of [=enumeration values=] of {{ClientCapability}},
+The set of [=map/keys=] SHOULD contain the set of [=enumeration values=] of {{ClientCapability}},
 but the client MAY omit keys as it deems necessary; see [[#sctn-disclosing-client-capabilities]].
 
 When the value for a given capability is [TRUE], the feature is known to be currently supported by the client.
 When the value for a given capability is [FALSE], the feature is known to be not currently supported by the client.
 When a capability does not [=map/exist=] as a key, the availability of the client feature is not known.
+
+The set of [=map/keys=] SHOULD also contain a key for each [extension](#sctn-extensions) implemented by the client, where the key is formed by prefixing the string `extension:` to the [=extension identifier=]. The associated value for each implemented extension SHOULD be [TRUE]. If `getClientCapabilities()` is supported by a client, but an extension is not mapped to the value [TRUE], then a [=[RP]=] MAY assume that client processing steps for that extension will not be carried out by this client and that the extension MAY not be forwarded to the authenticator.
+
+Note: Even if an extension is mapped to [TRUE], the authenticator used for any given operation may not support that extension, so [=[RPS]=] MUST NOT assume that the authenticator processing steps for that extension will be performed on that basis.
 
 Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=permissions policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-permissions-policy]].
 


### PR DESCRIPTION
It is of somewhat limited value because getClientCapabilities can't know what extensions the user's authenticator will support, but it can be meaningful to know that an extension isn't supported. Absent this, sites are guessing based on browser names and versions, but that is fragile.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2041.html" title="Last updated on Mar 13, 2024, 11:12 PM UTC (1bf960f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2041/354a717...1bf960f.html" title="Last updated on Mar 13, 2024, 11:12 PM UTC (1bf960f)">Diff</a>