### PR TITLE
Upgrade Matthew Miller to Editor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,6 +21,7 @@ Include MDN Panels: maybe
 Editor: Michael B. Jones, w3cid 38745, Self-Issued Consulting, michael_b_jones@hotmail.com
 Editor: Akshay Kumar, w3cid 99318, Microsoft, akshayku@microsoft.com
 Editor: Emil Lundberg, w3cid 102508, Yubico, emil@yubico.com
+Editor: Matthew Miller, w3cid 129314, Cisco, mattmil3@cisco.com
 Former Editor: Dirk Balfanz, w3cid 47648, Google, balfanz@google.com
 Former Editor: Vijay Bharadwaj, w3cid 55440, Microsoft, vijay.bharadwaj@microsoft.com
 Former Editor: Arnar Birgisson, w3cid 87332, Google, arnarb@google.com
@@ -35,7 +36,6 @@ Former Editor: Rolf Lindemann, w3cid 84447, Nok Nok Labs, rolf@noknok.com
 !Contributors: <a href="mailto:tim.cappalli@okta.com">Tim Cappalli</a> (Okta)
 !Contributors: <a href="mailto:agl@google.com">Adam Langley</a> (Google)
 !Contributors: <a href="mailto:mandyam@qti.qualcomm.com">Giridhar Mandyam</a> (Qualcomm)
-!Contributors: <a href="mailto:mattmil3@cisco.com">Matthew Miller</a> (Cisco)
 !Contributors: <a href="mailto:nsatragno@google.com">Nina Satragno</a> (Google)
 !Contributors: <a href="mailto:kieun.shin@sk.com">Ki-Eun Shin</a> (SK Telecom)
 !Contributors: <a href="mailto:nick.steele@agilebits.com">Nick Steele</a> (1Password)


### PR DESCRIPTION
Inspired by discussion at the last Working Group meeting I'm proposing a change to my role from Contributor to Editor. I've championed the addition of headliner features to L3 like JSON serialization and client capabilities querying (alongside Tim for the latter, of course), but also have numerous PR's to my name that removed ambiguities from other parts of the spec. I am also remaining committed to my participation in editorial review of current and future PR's.

#MillerTime 🍌


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2043.html" title="Last updated on Mar 14, 2024, 4:59 PM UTC (21015ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2043/354a717...21015ce.html" title="Last updated on Mar 14, 2024, 4:59 PM UTC (21015ce)">Diff</a>