### PR TITLE
Various improvements to conditionalCreate/Mediation discoverability and uniformity

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1594,6 +1594,11 @@ that are returned to the caller when a new credential is created, or a new asser
         Note: If this method is not present, {{CredentialMediationRequirement/conditional}} [=user mediation=] is not available for
         {{CredentialsContainer/get()|navigator.credentials.get()}}.
 
+        Note: This method does _not_ indicate
+        whether or not {{CredentialMediationRequirement/conditional}} [=user mediation=] is available
+        in {{CredentialsContainer/create()|navigator.credentials.create()}}.
+        For that, see the {{ClientCapability/conditionalCreate}} capability in {{PublicKeyCredential/getClientCapabilities()}}.
+
     :   {{PublicKeyCredential/toJSON()}}
     ::  This operation returns {{RegistrationResponseJSON}} or {{AuthenticationResponseJSON}},
         which are [=JSON type=] representations mirroring {{PublicKeyCredential}}, suitable for submission to a

--- a/index.bs
+++ b/index.bs
@@ -4027,7 +4027,7 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
     :   <dfn>conditionalGet</dfn>
     ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation for [=authentication ceremonies=].
 
-        This capability is equivalent to {{PublicKeyCredential/isConditionalMediationAvailable()}} returning [TRUE].
+        This capability is equivalent to {{PublicKeyCredential/isConditionalMediationAvailable()}} resolving to [TRUE].
 
         See [[#sctn-getAssertion]] for more details.
 

--- a/index.bs
+++ b/index.bs
@@ -1745,7 +1745,7 @@ options, sameOriginWithAncestors)</dfn> [=internal method=] [[!CREDENTIAL-MANAGE
 [=public key credential source=], [=bound credential|bound=] to an [=authenticator=].
 
 By setting <code>|options|.{{CredentialCreationOptions/mediation}}</code> to {{CredentialMediationRequirement/conditional}},
-[=[RPS]=] can indicate that they would like to register a credential without prominent modal UI if user has already consented to create a credential.
+[=[RPS]=] can indicate that they would like to register a credential without prominent modal UI if the user has already consented to create a credential.
 The [=[RP]=] SHOULD first use {{PublicKeyCredential/getClientCapabilities()}}
 to check that the [=client=] supports the {{ClientCapability/conditionalCreate}} capability
 in order to prevent a user-visible error in case this feature is not available.

--- a/index.bs
+++ b/index.bs
@@ -4003,12 +4003,14 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
 
 <div dfn-type="enum-value" dfn-for="ClientCapability">
     :   <dfn>conditionalCreate</dfn>
-    ::  The [=WebAuthn Client=] is capable of a {{CredentialMediationRequirement/conditional}} credential creation operation.
+    ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation
+        in {{CredentialsContainer/create()|navigator.credentials.create()}}.
 
         See [[#sctn-createCredential]] for more details.
 
     :   <dfn>conditionalMediation</dfn>
-    ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation.
+    ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation
+        in {{CredentialsContainer/get()|navigator.credentials.get()}}.
 
         See [[#sctn-getAssertion]] for more details.
 

--- a/index.bs
+++ b/index.bs
@@ -1591,6 +1591,8 @@ that are returned to the caller when a new credential is created, or a new asser
 
         This method has no arguments and returns a promise to a Boolean value.
 
+        The {{ClientCapability/conditionalMediation}} capability is equivalent to this promise resolving to [TRUE].
+
         Note: If this method is not present, {{CredentialMediationRequirement/conditional}} [=user mediation=] is not available for
         {{CredentialsContainer/get()|navigator.credentials.get()}}.
 
@@ -4011,6 +4013,8 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
     :   <dfn>conditionalMediation</dfn>
     ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation
         in {{CredentialsContainer/get()|navigator.credentials.get()}}.
+
+        This capability is equivalent to {{PublicKeyCredential/isConditionalMediationAvailable()}} returning [TRUE].
 
         See [[#sctn-getAssertion]] for more details.
 

--- a/index.bs
+++ b/index.bs
@@ -1742,7 +1742,7 @@ options, sameOriginWithAncestors)</dfn> [=internal method=] [[!CREDENTIAL-MANAGE
 
 By setting <code>|options|.{{CredentialCreationOptions/mediation}}</code> to {{CredentialMediationRequirement/conditional}},
 [=[RPS]=] can indicate that they would like to register a credential without prominent modal UI if user has already consented to create a credential. The [=[RP]=] SHOULD first check that {{ClientCapability/conditionalCreate}} is present
-in the result of {{PublicKeyCredential/getClientCapabilities()}} in order to avoid the possibility of causing a user-visible error to be returned if the user agent does
+in the result of {{PublicKeyCredential/getClientCapabilities()}} in order to prevent a user-visible error if the user agent does
 not support {{CredentialMediationRequirement/conditional}} [=user mediation=] for {{CredentialsContainer/create()|navigator.credentials.create()}}.
 
 Any {{CredentialsContainer/create()|navigator.credentials.create()}} operation can be aborted by leveraging the {{AbortController}};

--- a/index.bs
+++ b/index.bs
@@ -1746,9 +1746,10 @@ options, sameOriginWithAncestors)</dfn> [=internal method=] [[!CREDENTIAL-MANAGE
 [=public key credential source=], [=bound credential|bound=] to an [=authenticator=].
 
 By setting <code>|options|.{{CredentialCreationOptions/mediation}}</code> to {{CredentialMediationRequirement/conditional}},
-[=[RPS]=] can indicate that they would like to register a credential without prominent modal UI if user has already consented to create a credential. The [=[RP]=] SHOULD first check that {{ClientCapability/conditionalCreate}} is present
-in the result of {{PublicKeyCredential/getClientCapabilities()}} in order to prevent a user-visible error if the user agent does
-not support {{CredentialMediationRequirement/conditional}} [=user mediation=] for {{CredentialsContainer/create()|navigator.credentials.create()}}.
+[=[RPS]=] can indicate that they would like to register a credential without prominent modal UI if user has already consented to create a credential.
+The [=[RP]=] SHOULD first use {{PublicKeyCredential/getClientCapabilities()}}
+to check that the [=client=] supports the {{ClientCapability/conditionalCreate}} capability
+in order to prevent a user-visible error in case this feature is not available.
 
 Any {{CredentialsContainer/create()|navigator.credentials.create()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
@@ -2253,10 +2254,11 @@ for="PublicKeyCredential" method>\[[CollectFromCredentialStore]](origin, options
 {{Credential/[[CollectFromCredentialStore]]()|Credential.[[CollectFromCredentialStore]]()}}, of returning an empty set.
 
 In general, the user agent SHOULD show some UI to the user to guide them in selecting and authorizing an authenticator with which
-to complete the operation. By setting <code>|options|.{{CredentialRequestOptions/mediation}}</code> to {{CredentialMediationRequirement/conditional}}, [=[RPS]=] can indicate that a prominent modal UI should <i>not</i> be shown <i>unless</i> credentials are discovered. [=[RP]=]
-script SHOULD first check that {{PublicKeyCredential/isConditionalMediationAvailable()}} returns [TRUE] in order to avoid
-the possibility of causing a user-visible error to be returned if the user agent does not support
-{{CredentialMediationRequirement/conditional}} [=user mediation=].
+to complete the operation. By setting <code>|options|.{{CredentialRequestOptions/mediation}}</code> to {{CredentialMediationRequirement/conditional}}, [=[RPS]=] can indicate that a prominent modal UI should <i>not</i> be shown <i>unless</i> credentials are discovered.
+The [=[RP]=] SHOULD first use {{PublicKeyCredential/isConditionalMediationAvailable()}}
+or {{PublicKeyCredential/getClientCapabilities()}}
+to check that the [=client=] supports the {{ClientCapability/conditionalMediation}} capability
+in order to prevent a user-visible error in case this feature is not available.
 
 Any
 {{CredentialsContainer/get()|navigator.credentials.get()}} operation can be aborted by leveraging the {{AbortController}};

--- a/index.bs
+++ b/index.bs
@@ -4001,6 +4001,9 @@ Note: The {{UserVerificationRequirement}} enumeration is deliberately not refere
 
 This enumeration defines a limited set of client capabilities which a [=[WRP]=] may evaluate to offer certain workflows and experiences to users.
 
+[=[RPS]=] may use the {{PublicKeyCredential/getClientCapabilities()}} method of {{PublicKeyCredential}}
+to obtain a description of available capabilities.
+
 Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
 
 <div dfn-type="enum-value" dfn-for="ClientCapability">

--- a/index.bs
+++ b/index.bs
@@ -2253,7 +2253,7 @@ script SHOULD first check that {{PublicKeyCredential/isConditionalMediationAvail
 the possibility of causing a user-visible error to be returned if the user agent does not support
 {{CredentialMediationRequirement/conditional}} [=user mediation=].
 
-This
+Any
 {{CredentialsContainer/get()|navigator.credentials.get()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
 

--- a/index.bs
+++ b/index.bs
@@ -4005,8 +4005,12 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
     :   <dfn>conditionalCreate</dfn>
     ::  The [=WebAuthn Client=] is capable of a {{CredentialMediationRequirement/conditional}} credential creation operation.
 
+        See [[#sctn-createCredential]] for more details.
+
     :   <dfn>conditionalMediation</dfn>
     ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation.
+
+        See [[#sctn-getAssertion]] for more details.
 
     :   <dfn>hybridTransport</dfn>
     ::  The [=WebAuthn Client=] supports usage of the {{AuthenticatorTransport/hybrid}} transport.


### PR DESCRIPTION
Various opportunities for improvement I noticed while reviewing PR #1951, but some of this is beyond the scope of that PR. We should merge #1951 first, then this PR scope will be much smaller as most of these commits will have been merged already with #1951.

- Reword "This operation" to "Any operation" in `get()` too, for uniformity with the new language in `create()`.
- Rephrase and shorten recommendation to check `isConditionalMediationAvailable()` or `getClientCapabilities()`
- Add cross-links between `conditionalCreate` and ~~`conditionalMediation`~~ `conditionalGet` client capabilities and where they are used
- Point out that ~~`conditionalMediation`~~ `conditionalGet` and `isConditionalMediationAvailable()` are equivalent


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2046.html" title="Last updated on Jul 17, 2024, 11:06 AM UTC (bf60b7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2046/fabbc09...bf60b7a.html" title="Last updated on Jul 17, 2024, 11:06 AM UTC (bf60b7a)">Diff</a>