### PR TITLE
Help RP's understand actionable exceptions from `create()` and `get()`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2253,7 +2253,7 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not a registrable domain suffix of nor was equal to the [=effective domain=].
 
     :   {{TypeError}}
-    ::  The <code>|options|</code> argument was not a valid {{CredentialCreationOptions}} value,
+    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialcreationoptions-extension|CredentialCreationOptions]] value,
         or the value of <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> was empty or was longer than 64 bytes.
 
     :   {{UnknownError}}

--- a/index.bs
+++ b/index.bs
@@ -2229,6 +2229,8 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
 
 #### Create Request Exceptions #### {#sctn-create-request-exceptions}
 
+[INFORMATIVE]
+
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}. Some errors can have multiple reasons for why they happened, requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn:
 
 <dl>
@@ -2770,6 +2772,8 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
     1. Return [TRUE].
 
 #### Get Request Exceptions #### {#sctn-get-request-exceptions}
+
+[INFORMATIVE]
 
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
 

--- a/index.bs
+++ b/index.bs
@@ -2745,20 +2745,26 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
 #### Authentication API Exceptions
 
-[=[RP]=]'s should prepare to encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
+[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
 
 <dl dfn-type="argument" dfn-for="Authentication API Exceptions">
     :   <dfn>AbortError</dfn>
-    ::  Definition here
-
-    :   <dfn>NotAllowedError</dfn>
-    ::  Definition here
+    ::  The ceremony was cancelled via an {{AbortController}}
+        (see [[#sctn-abortoperation]] and [[#sctn-sample-aborting]] for more information.)
 
     :   <dfn>SecurityError</dfn>
-    ::  Definition here
+    ::  The [=effective domain=] was not a [=valid domain=],
+        or {{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}} was not a registrable domain suffix of nor was equal to the [=effective domain=].
 
     :   <dfn>UnknownError</dfn>
-    ::  Definition here
+    ::  The [=authenticator=] could not process the supplied options,
+        or encountered an error while generating an [=assertion signature=].
+
+    :   <dfn>NotAllowedError</dfn>
+    ::  A catch-all error covering a wide range of possible reasons,
+        including common ones like the user canceling out of the ceremony.
+        Some of these causes are documented throughout this spec,
+        while others are client-specific.
 </dl>
 
 ### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Method ### {#sctn-storeCredential}
@@ -5919,7 +5925,7 @@ The attributes above are structured within this certificate as such:
   04 12                                  -- OCTET STRING
     04  10                               -- OCTET STRING
       CD 8C 39 5C 26 ED EE DE            -- AAGUID cd8c395c-26ed-eede-653b-00797d03ca3c
-      65 3B 00 79 7D 03 CA 3C 
+      65 3B 00 79 7D 03 CA 3C
 
 30 12                                    -- SEQUENCE
   06 0B 2B 06 01 04 01 82 E5 1C 01 01 05 -- OID 1.3.6.1.4.1.45724.1.1.5

--- a/index.bs
+++ b/index.bs
@@ -2285,6 +2285,9 @@ The following {{DOMException}} exceptions can be raised:
     :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
+        In the case of [[#sctn-related-origins|related origin requests]],
+        the [=authenticator=] does not support it
+        or there were issues when [[#sctn-validating-relation-origin|validating related origins]].
 
     :   {{TimeoutError}}
     ::  The ceremony was cancelled by the user agent after exceeding the time limit permitted for the ceremony.
@@ -2848,6 +2851,9 @@ The following {{DOMException}} exceptions can be raised:
     :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
+        In the case of [[#sctn-related-origins|related origin requests]],
+        the [=authenticator=] does not support it
+        or there were issues when [[#sctn-validating-relation-origin|validating related origins]].
 
     :   {{TimeoutError}}
     ::  The ceremony was cancelled by the user agent after exceeding the time limit permitted for the ceremony.

--- a/index.bs
+++ b/index.bs
@@ -2204,32 +2204,42 @@ authorizing an authenticator.
 
 #### Registration API Exceptions
 
-[=[RP]=]'s should prepare to encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}:
+[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}. Some errors can have multiple reasons for why they happened, requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn:
 
 <dl dfn-type="argument" dfn-for="Registration API Exceptions">
     :   <dfn>AbortError</dfn>
-    ::  Definition here
+    ::  The ceremony was cancelled via an {{AbortController}}
+        (see [[#sctn-abortoperation]] and [[#sctn-sample-aborting]] for more information.)
 
     :   <dfn>ConstraintError</dfn>
-    ::  Definition here
+    ::  Either {{residentKey}} was set to "{{ResidentKeyRequirement/required}}" and no available authenticator supported resident keys,
+        or {{userVerification}} was set to "{{UserVerificationRequirement/required}}" and no available authenticator could perform [=user verification=].
 
     :   <dfn>InvalidStateError</dfn>
-    ::  Definition here
-
-    :   <dfn>{{NotAllowedError}}</dfn>
-    ::  Definition here
+    ::  The authenticator used in the ceremony recognized an entry in {{excludeCredentials}}
+        after the user [=user consent|consented=] to registering a credential.
 
     :   <dfn>NotSupportedError</dfn>
-    ::  Definition here
+    ::  No entry in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}} had a `type` property of "{{PublicKeyCredentialType/public-key}}",
+        or the [=authenticator=] did not support any of the specified cryptographic parameters in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}}.
 
     :   <dfn>SecurityError</dfn>
-    ::  Definition here
+    ::  The [=effective domain=] was not a [=valid domain=],
+        or {{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}} was not a registrable domain suffix of nor was equal to the [=effective domain=].
 
     :   <dfn>TypeError</dfn>
-    ::  Definition here
+    ::  The value of {{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}} was not between 1 and 64 bytes (inclusive.)
 
     :   <dfn>UnknownError</dfn>
-    ::  Definition here
+    ::  The [=authenticator=] could not process the supplied options,
+        or encountered an error while creating the new credential object.
+
+    :   <dfn>{{NotAllowedError}}</dfn>
+    ::  A catch-all error covering a wide range of possible reasons,
+        including common ones like the user canceling out of the ceremony.
+        Some of these causes are documented throughout this spec,
+        while others are client-specific.
+
 </dl>
 
 ### Use an Existing Credential to Make an Assertion - PublicKeyCredential's `[[Get]](options)` Method ### {#sctn-getAssertion}

--- a/index.bs
+++ b/index.bs
@@ -2289,10 +2289,6 @@ The following {{DOMException}} exceptions can be raised:
         the [=authenticator=] does not support it
         or there were issues when [[#sctn-validating-relation-origin|validating related origins]].
 
-    :   {{TimeoutError}}
-    ::  The ceremony was cancelled by the user agent after exceeding the time limit permitted for the ceremony.
-        See [[#sctn-timeout-recommended-range]] for more information.
-
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,
         or encountered an error while creating the new credential.
@@ -2854,10 +2850,6 @@ The following {{DOMException}} exceptions can be raised:
         In the case of [[#sctn-related-origins|related origin requests]],
         the [=authenticator=] does not support it
         or there were issues when [[#sctn-validating-relation-origin|validating related origins]].
-
-    :   {{TimeoutError}}
-    ::  The ceremony was cancelled by the user agent after exceeding the time limit permitted for the ceremony.
-        See [[#sctn-timeout-recommended-range]] for more information.
 
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,

--- a/index.bs
+++ b/index.bs
@@ -2256,7 +2256,7 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
 [INFORMATIVE]
 
 [=[WRPS]=] can encounter a number of exceptions from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}.
-Some errors can have multiple reasons for why they happened,
+Some exceptions can have multiple reasons for why they happened,
 requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
 Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
 defined outside of this specification may not be listed here.
@@ -2829,7 +2829,7 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 [INFORMATIVE]
 
 [=[WRPS]=] can encounter a number of exceptions from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}.
-Some errors can have multiple reasons for why they happened,
+Some exceptions can have multiple reasons for why they happened,
 requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
 Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
 defined outside of this specification may not be listed here.

--- a/index.bs
+++ b/index.bs
@@ -2285,9 +2285,9 @@ The following {{DOMException}} exceptions can be raised:
     :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
-        In the case of [[#sctn-related-origins|related origin requests]],
-        the [=authenticator=] does not support it
-        or there were issues when [[#sctn-validating-relation-origin|validating related origins]].
+        In the latter case,
+        the [=client=] does not support [[#sctn-related-origins|related origin requests]]
+        or the [$related origins validation procedure$] failed.
 
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,
@@ -2847,9 +2847,9 @@ The following {{DOMException}} exceptions can be raised:
     :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
-        In the case of [[#sctn-related-origins|related origin requests]],
-        the [=authenticator=] does not support it
-        or there were issues when [[#sctn-validating-relation-origin|validating related origins]].
+        In the latter case,
+        the [=client=] does not support [[#sctn-related-origins|related origin requests]]
+        or the [$related origins validation procedure$] failed.
 
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,

--- a/index.bs
+++ b/index.bs
@@ -264,7 +264,6 @@ spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
 spec: webidl; urlPrefix: https://webidl.spec.whatwg.org
     type: dfn;
         text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-copy
-        text: Exceptions; url: idl-exceptions
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
@@ -2303,7 +2302,7 @@ The following {{DOMException}} exceptions can be raised:
 
 </dl>
 
-The following <code>[=Exceptions|Exception=]</code> exceptions can be raised:
+The following [=simple exceptions=] can be raised:
 
 <dl>
 
@@ -2865,7 +2864,7 @@ The following {{DOMException}} exceptions can be raised:
         while others are client-specific.
 </dl>
 
-The following <code>[=Exceptions|Exception=]</code> exceptions can be raised:
+The following [=simple exceptions=] can be raised:
 
 <dl>
 

--- a/index.bs
+++ b/index.bs
@@ -2253,7 +2253,8 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not a registrable domain suffix of nor was equal to the [=effective domain=].
 
     :   {{TypeError}}
-    ::  The value of <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> was empty or was longer than 64 bytes.
+    ::  The <code>|options|</code> argument was not a valid {{CredentialCreationOptions}} value,
+        or the value of <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> was empty or was longer than 64 bytes.
 
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,

--- a/index.bs
+++ b/index.bs
@@ -2227,7 +2227,7 @@ During the above process, the user agent SHOULD show some UI to the user to guid
 authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/mediation}}</code> is set to {{CredentialMediationRequirement/conditional}}, prominent modal UI should <i>not</i> be shown <i>unless</i> credential creation was previously consented to via means determined by the user agent.
 </div>
 
-#### Registration API Exceptions #### {#sctn-registration-api-exceptions}
+#### Create Request Exceptions #### {#sctn-create-request-exceptions}
 
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}. Some errors can have multiple reasons for why they happened, requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn:
 
@@ -2769,7 +2769,7 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
     1. Return [TRUE].
 
-#### Authentication API Exceptions #### {#sctn-authentication-api-exceptions}
+#### Get Request Exceptions #### {#sctn-get-request-exceptions}
 
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
 

--- a/index.bs
+++ b/index.bs
@@ -2787,6 +2787,9 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
     ::  The [=effective domain=] was not a [=valid domain=],
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
 
+    :   {{TypeError}}
+    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialrequestoptions-extension|CredentialRequestOptions]] value.
+
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,
         or encountered an error while generating an [=assertion signature=].

--- a/index.bs
+++ b/index.bs
@@ -2227,7 +2227,7 @@ During the above process, the user agent SHOULD show some UI to the user to guid
 authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/mediation}}</code> is set to {{CredentialMediationRequirement/conditional}}, prominent modal UI should <i>not</i> be shown <i>unless</i> credential creation was previously consented to via means determined by the user agent.
 </div>
 
-#### Registration API Exceptions ### {#sctn-registration-api-exceptions}
+#### Registration API Exceptions #### {#sctn-registration-api-exceptions}
 
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}. Some errors can have multiple reasons for why they happened, requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn:
 
@@ -2768,7 +2768,7 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
     1. Return [TRUE].
 
-#### Authentication API Exceptions ### {#sctn-authentication-api-exceptions}
+#### Authentication API Exceptions #### {#sctn-authentication-api-exceptions}
 
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
 

--- a/index.bs
+++ b/index.bs
@@ -5999,7 +5999,7 @@ The attributes above are structured within this certificate as such:
   04 12                                  -- OCTET STRING
     04  10                               -- OCTET STRING
       CD 8C 39 5C 26 ED EE DE            -- AAGUID cd8c395c-26ed-eede-653b-00797d03ca3c
-      65 3B 00 79 7D 03 CA 3C
+      65 3B 00 79 7D 03 CA 3C 
 
 30 12                                    -- SEQUENCE
   06 0B 2B 06 01 04 01 82 E5 1C 01 01 05 -- OID 1.3.6.1.4.1.45724.1.1.5

--- a/index.bs
+++ b/index.bs
@@ -2259,8 +2259,10 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
 [=[WRPS]=] can encounter a number of exceptions from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}.
 Some exceptions can have multiple reasons for why they happened,
 requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
-Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
-defined outside of this specification may not be listed here.
+
+Note: Exceptions that can be raised during processing of any [=WebAuthn Extensions=],
+including ones defined outside of this specification,
+are not listed here.
 
 The following {{DOMException}} exceptions can be raised:
 
@@ -2832,8 +2834,10 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 [=[WRPS]=] can encounter a number of exceptions from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}.
 Some exceptions can have multiple reasons for why they happened,
 requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
-Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
-defined outside of this specification may not be listed here.
+
+Note: Exceptions that can be raised during processing of any [=WebAuthn Extensions=],
+including ones defined outside of this specification,
+are not listed here.
 
 The following {{DOMException}} exceptions can be raised:
 

--- a/index.bs
+++ b/index.bs
@@ -2280,7 +2280,7 @@ The following {{DOMException}} exceptions can be raised:
 
     :   {{NotSupportedError}}
     ::  No entry in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}} had a {{PublicKeyCredentialDescriptor/type}} property of {{PublicKeyCredentialType/public-key}},
-        or the [=authenticator=] did not support any of the specified cryptographic parameters in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}}.
+        or the [=authenticator=] did not support any of the signature algorithms specified in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}}.
 
     :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],

--- a/index.bs
+++ b/index.bs
@@ -2231,7 +2231,11 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
 
 [INFORMATIVE]
 
-[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}. Some errors can have multiple reasons for why they happened, requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn:
+[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}.
+Some errors can have multiple reasons for why they happened,
+requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
+Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
+defined outside of this specification may not be listed here.
 
 <dl>
     :   {{AbortError}}
@@ -2266,8 +2270,7 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
     ::  A catch-all error covering a wide range of possible reasons,
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,
-        while others are client-specific
-        or caused by issues that may occur during processing of [=WebAuthn Extensions=] defined outside of this specification.
+        while others are client-specific.
 
 </dl>
 
@@ -2776,7 +2779,11 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
 [INFORMATIVE]
 
-[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
+[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}.
+Some errors can have multiple reasons for why they happened,
+requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
+Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
+defined outside of this specification may not be listed here.
 
 <dl>
     :   {{AbortError}}
@@ -2798,8 +2805,7 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
     ::  A catch-all error covering a wide range of possible reasons,
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,
-        while others are client-specific
-        or caused by issues that may occur during processing of [=WebAuthn Extensions=] defined outside of this specification.
+        while others are client-specific.
 </dl>
 
 ### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Method ### {#sctn-storeCredential}

--- a/index.bs
+++ b/index.bs
@@ -2255,11 +2255,13 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
 
 [INFORMATIVE]
 
-[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}.
+[=[WRPS]=] can encounter a number of exceptions from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}.
 Some errors can have multiple reasons for why they happened,
 requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
 Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
 defined outside of this specification may not be listed here.
+
+The following {{DOMException}} exceptions can be raised:
 
 <dl>
     :   {{AbortError}}
@@ -2282,9 +2284,9 @@ defined outside of this specification may not be listed here.
     ::  The [=effective domain=] was not a [=valid domain=],
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
 
-    :   {{TypeError}}
-    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialcreationoptions-extension|CredentialCreationOptions]] value,
-        or the value of <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> was empty or was longer than 64 bytes.
+    :   {{TimeoutError}}
+    ::  The ceremony was cancelled by the user agent after exceeding the time limit permitted for the ceremony.
+        See [[#sctn-timeout-recommended-range]] for more information.
 
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,
@@ -2295,6 +2297,16 @@ defined outside of this specification may not be listed here.
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,
         while others are client-specific.
+
+</dl>
+
+The following {{Error}} exceptions can be raised:
+
+<dl>
+
+    :   {{TypeError}}
+    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialcreationoptions-extension|CredentialCreationOptions]] value,
+        or the value of <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> was empty or was longer than 64 bytes.
 
 </dl>
 
@@ -2816,11 +2828,13 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
 [INFORMATIVE]
 
-[=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}.
+[=[WRPS]=] can encounter a number of exceptions from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}.
 Some errors can have multiple reasons for why they happened,
 requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn.
 Some exceptions that can be raised during processing of [=WebAuthn Extensions=]
 defined outside of this specification may not be listed here.
+
+The following {{DOMException}} exceptions can be raised:
 
 <dl>
     :   {{AbortError}}
@@ -2831,8 +2845,9 @@ defined outside of this specification may not be listed here.
     ::  The [=effective domain=] was not a [=valid domain=],
         or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
 
-    :   {{TypeError}}
-    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialrequestoptions-extension|CredentialRequestOptions]] value.
+    :   {{TimeoutError}}
+    ::  The ceremony was cancelled by the user agent after exceeding the time limit permitted for the ceremony.
+        See [[#sctn-timeout-recommended-range]] for more information.
 
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,
@@ -2843,6 +2858,15 @@ defined outside of this specification may not be listed here.
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,
         while others are client-specific.
+</dl>
+
+The following {{Error}} exceptions can be raised:
+
+<dl>
+
+    :   {{TypeError}}
+    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialrequestoptions-extension|CredentialRequestOptions]] value.
+
 </dl>
 
 ### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Method ### {#sctn-storeCredential}

--- a/index.bs
+++ b/index.bs
@@ -261,10 +261,6 @@ spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
         text: something you have; url: af
         text: something you are; url: af
 
-spec: webidl; urlPrefix: https://webidl.spec.whatwg.org
-    type: dfn;
-        text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-copy
-
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
         text: WebDriver error; url: dfn-error

--- a/index.bs
+++ b/index.bs
@@ -261,9 +261,10 @@ spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
         text: something you have; url: af
         text: something you are; url: af
 
-spec: webidl; urlPrefix: https://heycam.github.io/webidl
+spec: webidl; urlPrefix: https://webidl.spec.whatwg.org
     type: dfn;
         text: get a copy of the bytes held by the buffer source; url: dfn-get-buffer-source-copy
+        text: Exceptions; url: idl-exceptions
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
@@ -2300,7 +2301,7 @@ The following {{DOMException}} exceptions can be raised:
 
 </dl>
 
-The following {{Error}} exceptions can be raised:
+The following <code>[=Exceptions|Exception=]</code> exceptions can be raised:
 
 <dl>
 
@@ -2860,7 +2861,7 @@ The following {{DOMException}} exceptions can be raised:
         while others are client-specific.
 </dl>
 
-The following {{Error}} exceptions can be raised:
+The following <code>[=Exceptions|Exception=]</code> exceptions can be raised:
 
 <dl>
 

--- a/index.bs
+++ b/index.bs
@@ -2252,7 +2252,7 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
 
     :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
-        or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not a registrable domain suffix of nor was equal to the [=effective domain=].
+        or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
 
     :   {{TypeError}}
     ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialcreationoptions-extension|CredentialCreationOptions]] value,
@@ -2784,7 +2784,7 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
     :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
-        or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not a registrable domain suffix of nor was equal to the [=effective domain=].
+        or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not equal to or a registrable domain suffix of the [=effective domain=].
 
     :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,

--- a/index.bs
+++ b/index.bs
@@ -2266,7 +2266,8 @@ authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/m
     ::  A catch-all error covering a wide range of possible reasons,
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,
-        while others are client-specific.
+        while others are client-specific
+        or caused by issues that may occur during processing of [=WebAuthn Extensions=] defined outside of this specification.
 
 </dl>
 
@@ -2794,7 +2795,8 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
     ::  A catch-all error covering a wide range of possible reasons,
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,
-        while others are client-specific.
+        while others are client-specific
+        or caused by issues that may occur during processing of [=WebAuthn Extensions=] defined outside of this specification.
 </dl>
 
 ### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Method ### {#sctn-storeCredential}

--- a/index.bs
+++ b/index.bs
@@ -2298,7 +2298,7 @@ The following [=simple exceptions=] can be raised:
 <dl>
 
     :   {{TypeError}}
-    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialcreationoptions-extension|CredentialCreationOptions]] value,
+    ::  The <code>|options|</code> argument was not a valid <code>[[#sctn-credentialcreationoptions-extension|CredentialCreationOptions]]</code> value,
         or the value of <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> was empty or was longer than 64 bytes.
 
 </dl>
@@ -2855,7 +2855,7 @@ The following [=simple exceptions=] can be raised:
 <dl>
 
     :   {{TypeError}}
-    ::  The <code>|options|</code> argument was not a valid [[#sctn-credentialrequestoptions-extension|CredentialRequestOptions]] value.
+    ::  The <code>|options|</code> argument was not a valid <code>[[#sctn-credentialrequestoptions-extension|CredentialRequestOptions]]</code> value.
 
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -2202,6 +2202,35 @@ During the above process, the user agent SHOULD show some UI to the user to guid
 authorizing an authenticator.
 </div>
 
+#### Registration API Exceptions
+
+[=[RP]=]'s should prepare to encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}:
+
+<dl dfn-type="argument" dfn-for="Registration API Exceptions">
+    :   <dfn>AbortError</dfn>
+    ::  Definition here
+
+    :   <dfn>ConstraintError</dfn>
+    ::  Definition here
+
+    :   <dfn>InvalidStateError</dfn>
+    ::  Definition here
+
+    :   <dfn>{{NotAllowedError}}</dfn>
+    ::  Definition here
+
+    :   <dfn>NotSupportedError</dfn>
+    ::  Definition here
+
+    :   <dfn>SecurityError</dfn>
+    ::  Definition here
+
+    :   <dfn>TypeError</dfn>
+    ::  Definition here
+
+    :   <dfn>UnknownError</dfn>
+    ::  Definition here
+</dl>
 
 ### Use an Existing Credential to Make an Assertion - PublicKeyCredential's `[[Get]](options)` Method ### {#sctn-getAssertion}
 
@@ -2704,6 +2733,23 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
     1. Return [TRUE].
 
+#### Authentication API Exceptions
+
+[=[RP]=]'s should prepare to encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
+
+<dl dfn-type="argument" dfn-for="Authentication API Exceptions">
+    :   <dfn>AbortError</dfn>
+    ::  Definition here
+
+    :   <dfn>NotAllowedError</dfn>
+    ::  Definition here
+
+    :   <dfn>SecurityError</dfn>
+    ::  Definition here
+
+    :   <dfn>UnknownError</dfn>
+    ::  Definition here
+</dl>
 
 ### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Method ### {#sctn-storeCredential}
 

--- a/index.bs
+++ b/index.bs
@@ -2285,10 +2285,6 @@ The following {{DOMException}} exceptions can be raised:
         the [=client=] does not support [[#sctn-related-origins|related origin requests]]
         or the [$related origins validation procedure$] failed.
 
-    :   {{UnknownError}}
-    ::  The [=authenticator=] could not process the supplied options,
-        or encountered an error while creating the new credential.
-
     :   {{NotAllowedError}}
     ::  A catch-all error covering a wide range of possible reasons,
         including common ones like the user canceling out of the ceremony.
@@ -2846,10 +2842,6 @@ The following {{DOMException}} exceptions can be raised:
         In the latter case,
         the [=client=] does not support [[#sctn-related-origins|related origin requests]]
         or the [$related origins validation procedure$] failed.
-
-    :   {{UnknownError}}
-    ::  The [=authenticator=] could not process the supplied options,
-        or encountered an error while generating an [=assertion signature=].
 
     :   {{NotAllowedError}}
     ::  A catch-all error covering a wide range of possible reasons,

--- a/index.bs
+++ b/index.bs
@@ -2227,39 +2227,39 @@ During the above process, the user agent SHOULD show some UI to the user to guid
 authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/mediation}}</code> is set to {{CredentialMediationRequirement/conditional}}, prominent modal UI should <i>not</i> be shown <i>unless</i> credential creation was previously consented to via means determined by the user agent.
 </div>
 
-#### Registration API Exceptions
+#### Registration API Exceptions ### {#sctn-registration-api-exceptions}
 
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/create()|navigator.credentials.create()}}. Some errors can have multiple reasons for why they happened, requiring the [=[WRPS]=] to infer the actual reason based on their use of WebAuthn:
 
-<dl dfn-type="argument" dfn-for="Registration API Exceptions">
-    :   <dfn>AbortError</dfn>
-    ::  The ceremony was cancelled via an {{AbortController}}
-        (see [[#sctn-abortoperation]] and [[#sctn-sample-aborting]] for more information.)
+<dl>
+    :   {{AbortError}}
+    ::  The ceremony was cancelled by an {{AbortController}}.
+        See [[#sctn-abortoperation]] and [[#sctn-sample-aborting]].
 
-    :   <dfn>ConstraintError</dfn>
-    ::  Either {{residentKey}} was set to "{{ResidentKeyRequirement/required}}" and no available authenticator supported resident keys,
-        or {{userVerification}} was set to "{{UserVerificationRequirement/required}}" and no available authenticator could perform [=user verification=].
+    :   {{ConstraintError}}
+    ::  Either {{residentKey}} was set to {{ResidentKeyRequirement/required}} and no available authenticator supported resident keys,
+        or {{AuthenticatorSelectionCriteria/userVerification}} was set to {{UserVerificationRequirement/required}} and no available authenticator could perform [=user verification=].
 
-    :   <dfn>InvalidStateError</dfn>
-    ::  The authenticator used in the ceremony recognized an entry in {{excludeCredentials}}
+    :   {{InvalidStateError}}
+    ::  The authenticator used in the ceremony recognized an entry in {{PublicKeyCredentialCreationOptions/excludeCredentials}}
         after the user [=user consent|consented=] to registering a credential.
 
-    :   <dfn>NotSupportedError</dfn>
-    ::  No entry in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}} had a `type` property of "{{PublicKeyCredentialType/public-key}}",
+    :   {{NotSupportedError}}
+    ::  No entry in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}} had a {{PublicKeyCredentialDescriptor/type}} property of {{PublicKeyCredentialType/public-key}},
         or the [=authenticator=] did not support any of the specified cryptographic parameters in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}}.
 
-    :   <dfn>SecurityError</dfn>
+    :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
-        or {{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}} was not a registrable domain suffix of nor was equal to the [=effective domain=].
+        or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not a registrable domain suffix of nor was equal to the [=effective domain=].
 
-    :   <dfn>TypeError</dfn>
-    ::  The value of {{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}} was not between 1 and 64 bytes (inclusive.)
+    :   {{TypeError}}
+    ::  The value of <code>{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> was empty or was longer than 64 bytes.
 
-    :   <dfn>UnknownError</dfn>
+    :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,
-        or encountered an error while creating the new credential object.
+        or encountered an error while creating the new credential.
 
-    :   <dfn>{{NotAllowedError}}</dfn>
+    :   {{NotAllowedError}}
     ::  A catch-all error covering a wide range of possible reasons,
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,
@@ -2768,24 +2768,24 @@ The steps for [=issuing a credential request to an authenticator=] are as follow
 
     1. Return [TRUE].
 
-#### Authentication API Exceptions
+#### Authentication API Exceptions ### {#sctn-authentication-api-exceptions}
 
 [=[WRPS]=] can encounter the following {{DOMException|DOMExceptions}} from a call to {{CredentialsContainer/get()|navigator.credentials.get()}}:
 
-<dl dfn-type="argument" dfn-for="Authentication API Exceptions">
-    :   <dfn>AbortError</dfn>
-    ::  The ceremony was cancelled via an {{AbortController}}
-        (see [[#sctn-abortoperation]] and [[#sctn-sample-aborting]] for more information.)
+<dl>
+    :   {{AbortError}}
+    ::  The ceremony was cancelled by an {{AbortController}}.
+        See [[#sctn-abortoperation]] and [[#sctn-sample-aborting]].
 
-    :   <dfn>SecurityError</dfn>
+    :   {{SecurityError}}
     ::  The [=effective domain=] was not a [=valid domain=],
-        or {{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}} was not a registrable domain suffix of nor was equal to the [=effective domain=].
+        or <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> was not a registrable domain suffix of nor was equal to the [=effective domain=].
 
-    :   <dfn>UnknownError</dfn>
+    :   {{UnknownError}}
     ::  The [=authenticator=] could not process the supplied options,
         or encountered an error while generating an [=assertion signature=].
 
-    :   <dfn>NotAllowedError</dfn>
+    :   {{NotAllowedError}}
     ::  A catch-all error covering a wide range of possible reasons,
         including common ones like the user canceling out of the ceremony.
         Some of these causes are documented throughout this spec,


### PR DESCRIPTION
This PR attempts to pull together any exceptions raised by `create()` and `get()` to help RP's understand what exceptions may be encountered when using WebAuthn. The intention here is to help RP's understand which errors might be surfaced to the user, and which should not.

Addresses #1859.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2047.html" title="Last updated on Jul 31, 2024, 4:56 PM UTC (2b692fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2047/2b8e368...2b692fa.html" title="Last updated on Jul 31, 2024, 4:56 PM UTC (2b692fa)">Diff</a>