### PR TITLE
Include enterpriseAttestation in getClientClientCapabilities

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3431,6 +3431,8 @@ Note: The {{AttestationConveyancePreference}} enumeration is deliberately not re
     ::  The [=[RP]=] wants to receive an [=attestation statement=] that may include uniquely identifying information. This is intended for controlled deployments within an enterprise where the organization wishes to tie registrations to specific authenticators. User agents MUST NOT provide such an attestation unless the user agent or authenticator configuration permits it for the requested [=RP ID=].
 
         If permitted, the user agent SHOULD signal to the authenticator (at [invocation time](#CreateCred-InvokeAuthnrMakeCred)) that enterprise attestation is requested, and convey the resulting [=/AAGUID=] and [=attestation statement=], unaltered, to the [=[RP]=].
+
+        [=WebAuthn Clients=] supporting enterprise attestation SHOULD include {{ClientCapability/enterpriseAttestation}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
 </div>
 
 
@@ -3961,6 +3963,7 @@ Note: The {{UserVerificationRequirement}} enumeration is deliberately not refere
     enum ClientCapability {
         "conditionalCreate",
         "conditionalMediation",
+        "enterpriseAttestation",
         "hybridTransport",
         "passkeyPlatformAuthenticator",
         "userVerifyingPlatformAuthenticator",
@@ -3977,6 +3980,9 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
 
     :   <dfn>conditionalMediation</dfn>
     ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation.
+
+    :   <dfn>enterpriseAttestation</dfn>
+    ::  The [=WebAuthn Client=] supports {{AttestationConveyancePreference/enterprise}} attestation.
 
     :   <dfn>hybridTransport</dfn>
     ::  The [=WebAuthn Client=] supports usage of the {{AuthenticatorTransport/hybrid}} transport.

--- a/index.bs
+++ b/index.bs
@@ -3982,7 +3982,8 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
     ::  The [=WebAuthn Client=] is capable of {{CredentialMediationRequirement/conditional}} mediation.
 
     :   <dfn>enterpriseAttestation</dfn>
-    ::  The [=WebAuthn Client=] supports {{AttestationConveyancePreference/enterprise}} attestation.
+    ::  The [=WebAuthn Client=] supports {{AttestationConveyancePreference/enterprise}} attestation. 
+        The presence of this capability does not guarantee that the [=WebAuthn Client|client=] and/or [=authenticator=] policy allows enterprise attestation for the calling [=[RP]=].
 
     :   <dfn>hybridTransport</dfn>
     ::  The [=WebAuthn Client=] supports usage of the {{AuthenticatorTransport/hybrid}} transport.


### PR DESCRIPTION
- Adds `enterpriseAttestation` to getClientClientCapabilities enum
- Adds blurb to "enterprise" definition that clients should include it

Resolves #1742


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2051.html" title="Last updated on Apr 2, 2024, 10:01 PM UTC (51b4b40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2051/89f204f...51b4b40.html" title="Last updated on Apr 2, 2024, 10:01 PM UTC (51b4b40)">Diff</a>