### PR TITLE
Adds timeSinceUv extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7611,6 +7611,59 @@ To <dfn abstract-op>Create a new supplemental public key record</dfn>, perform t
         In [step 22](#authn-ceremony-update-credential-record) of [[#sctn-verifying-assertion]],
         [=set/append=] this [=supplemental public key record=] to |credentialRecord|.[$credential record/supplementalPubKeys$].
 
+### Time Since User Verification Extension (timeSinceUv) ### {#sctn-time-since-uv-extension}
+
+This extension enables an authenticator to disclose the time since the last user verification was peformed.
+
+:   Extension identifier
+::  `timeSinceUv`
+
+:   Operation applicability
+::  [=registration extension|Registration=] and [=authentication extension|Authentication=] when {{AuthenticatorSelectionCriteria/userVerification}} is set to {{UserVerificationRequirement/preferred}}.
+
+:   Client extension input
+::  The Boolean value [TRUE] to indicate that this extension is requested by the [=[RP]=].
+        <xmp class="idl">
+        partial dictionary AuthenticationExtensionsClientInputs {
+          boolean timeSinceUv;
+        };
+        </xmp>
+
+:   Client extension processing
+::  None, except creating the authenticator extension input from the client extension input.
+
+:   Client extension output
+::  <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientOutputs {
+        AuthenticationExtensionsTimeSinceUvOutputs timeSinceUv;
+    };
+
+    dictionary AuthenticationExtensionsTimeSinceUvOutputs {
+        unsigned long timeSinceUv;
+    };
+    </xmp>
+
+:   Authenticator extension input
+::  The Boolean value [TRUE], encoded in CBOR (major type 7, value 21).
+
+        ```
+        $$extensionInput //= (
+          timeSinceUv: true,
+        )
+        ```
+
+:   Authenticator extension processing
+::  The [=authenticator=] sets the [=authenticator extension output=] to be the time in milliseconds since [=user verification=] was performed.
+    This extension can be added to attestation objects and assertions.
+
+:   Authenticator extension output
+::  Authenticators can report a single value which MUST be between 1000 (1 second) and 86400000 (1 day), and MUST be rounded up to the next power of two. 
+
+    ```
+    $$extensionOutput //= (
+      timeSinceUv: timeSinceUvValue,
+    )
+    ```
 
 # User Agent Automation # {#sctn-automation}
 


### PR DESCRIPTION
Adds the `timeSinceUv` authenticator extension as defined in #2034 

Open questions for WG discussion:

1. Technically an out of band vault unlock for passkey provider doesn't satisfy user verification as it was not part of a WebAuthn ceremony. How do we want to handle that?
2. If the time since UV value is out of range (<1000 or >86400000), what should happen?

Resolves #2034


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2052.html" title="Last updated on Mar 27, 2024, 3:35 PM UTC (a71faec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2052/89f204f...a71faec.html" title="Last updated on Mar 27, 2024, 3:35 PM UTC (a71faec)">Diff</a>