### PR TITLE
Don't zero platform-authenticator AAGUIDs.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2136,9 +2136,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                             ::  Replace potentially uniquely identifying information with non-identifying versions of the
                                 same:
                                   1. If the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] is 16 zero bytes, <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> is "packed", and "x5c" is absent from <code>|credentialCreationData|.[=attestationObjectResult=]</code>, then [=self attestation=] is being used and no further action is needed.
-                                  1. Otherwise
-                                      1. Replace the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] with 16 zero bytes.
+                                  1. Otherwise:
                                       1. Set the value of <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> to "none", and set the value of <code>|credentialCreationData|.[=attestationObjectResult=].attStmt</code> to be an empty [=CBOR=] map. (See [[#sctn-none-attestation]] and [[#sctn-generating-an-attestation-object]]).
+                                      1. If |authenticator| is not a [=platform authenticator=] then replace the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] with 16 zero bytes.
 
                             :   {{AttestationConveyancePreference/indirect}}
                             ::  The client MAY replace the [=authData/attestedCredentialData/aaguid=] and [=attestation statement=] with a more privacy-friendly


### PR DESCRIPTION
As discussed at the face-to-face, this reflects current practice where the AAGUID of platform authenticators are passed through even when attestation is not requested.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2058.html" title="Last updated on Apr 20, 2024, 10:56 PM UTC (8f87400)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2058/3ad0eda...8f87400.html" title="Last updated on Apr 20, 2024, 10:56 PM UTC (8f87400)">Diff</a>