### PR TITLE
Fix type of AuthenticatorAttestationResponseJSON.publicKeyAlgorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1644,7 +1644,7 @@ that are returned to the caller when a new credential is created, or a new asser
         // algorithm then the public key must be parsed directly from
         // attestationObject or authenticatorData.
         Base64URLString publicKey;
-        required long long publicKeyAlgorithm;
+        required COSEAlgorithmIdentifier publicKeyAlgorithm;
         // This value contains copies of some of the fields above. See
         // section “Easily accessing credential data”.
         required Base64URLString attestationObject;


### PR DESCRIPTION
Fixes https://github.com/w3c/webauthn/issues/2065.

`AuthenticatorAttestationResponseJSON` was added in the L3 drafts, so we can easily change
`AuthenticatorAttestationResponseJSON.publicKeyAlgorithm` to type `long` (or `COSEAlgorithmIdentifier`) since L3 isn't formally released yet. `AuthenticatorAttestationResponseJSON.publicKeyAlgorithm` is also in output (covariant) position, so changing its type to be more restrictive is even backwards compatible.

I misspoke on the 2024-05-15 call: I said the range of [CBOR integers](https://datatracker.ietf.org/doc/html/rfc7049#section-2.1) is any value whose size in bits can be represented by uint64_t. This was incorrect - uint64_t (2^64-1) is the max value range, not a value size range.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2071.html" title="Last updated on May 15, 2024, 8:26 PM UTC (c8eeef5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2071/62b069e...c8eeef5.html" title="Last updated on May 15, 2024, 8:26 PM UTC (c8eeef5)">Diff</a>