### PR TITLE
Apply RFC 8264 enforcement only to non-empty strings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3278,8 +3278,8 @@ credential.
     :   <dfn>displayName</dfn>
     ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for
         display. The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice
-        more than necessary. If no suitable or [=human palatability|human-palatable=] name is
-        available, the [=[RP]=] SHOULD set this value to an empty string.
+        more than necessary.
+        Its value MUST NOT be the empty string.
 
         Examples of suitable values for this identifier include, "Alex Müller", "Alex Müller (ACME Co.)" or "田中倫".
 

--- a/index.bs
+++ b/index.bs
@@ -3278,21 +3278,22 @@ credential.
     :   <dfn>displayName</dfn>
     ::  A [=human palatability|human-palatable=] name for the [=user account=], intended only for
         display. The [=[RP]=] SHOULD let the user choose this, and SHOULD NOT restrict the choice
-        more than necessary.
-        Its value MUST NOT be the empty string.
+        more than necessary. If no suitable or [=human palatability|human-palatable=] name is
+        available, the [=[RP]=] SHOULD set this value to an empty string.
 
         Examples of suitable values for this identifier include, "Alex Müller", "Alex Müller (ACME Co.)" or "田中倫".
 
         - [=[RPS]=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
-            when setting {{PublicKeyCredentialUserEntity/displayName}}'s value, or displaying the value to the user.
+            when setting {{PublicKeyCredentialUserEntity/displayName}}'s value to a non-empty string,
+            or displaying a non-empty value to the user.
 
         - This string MAY contain language and direction metadata. [=[RPS]=] SHOULD consider providing this information. See [[#sctn-strings-langdir]] about how this metadata is encoded.
 
         - [=Clients=] SHOULD perform enforcement, as prescribed in Section 2.3 of
             [[!RFC8266]] for the Nickname Profile of the PRECIS FreeformClass [[!RFC8264]],
-            on {{PublicKeyCredentialUserEntity/displayName}}'s value prior to displaying the value to the user or
-            including the value as a parameter of the [=authenticatorMakeCredential=] operation.
+            on {{PublicKeyCredentialUserEntity/displayName}}'s value prior to displaying a non-empty value to the user or
+            including a non-empty value as a parameter of the [=authenticatorMakeCredential=] operation.
 
         When [=clients=], [=client platforms=], or [=authenticators=] display a {{PublicKeyCredentialUserEntity/displayName}}'s value, they should always use UI elements to provide a clear boundary around the displayed value, and not allow overflow into other elements [[css-overflow-3]].
 


### PR DESCRIPTION
Fixes #2068 

Cc @zacknewman


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/webauthn/pull/2073.html" title="Last updated on Jul 17, 2024, 5:25 PM UTC (787585f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2073/62b069e...selfissued:787585f.html" title="Last updated on Jul 17, 2024, 5:25 PM UTC (787585f)">Diff</a>