### PR TITLE
Align RP ID string types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2906,7 +2906,7 @@ value and terminate the operation.
     dictionary PublicKeyCredentialRequestOptionsJSON {
         required Base64URLString                                challenge;
         unsigned long                                           timeout;
-        DOMString                                               rpId;
+        USVString                                               rpId;
         sequence<PublicKeyCredentialDescriptorJSON>             allowCredentials = [];
         DOMString                                               userVerification = "preferred";
         sequence<DOMString>                                     hints = [];
@@ -3235,7 +3235,7 @@ The {{PublicKeyCredentialRpEntity}} dictionary is used to supply additional [=[R
 
 <xmp class="idl">
     dictionary PublicKeyCredentialRpEntity : PublicKeyCredentialEntity {
-        DOMString      id;
+        USVString      id;
     };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -2844,7 +2844,7 @@ value and terminate the operation.
     };
 
     dictionary PublicKeyCredentialCreationOptionsJSON {
-        required PublicKeyCredentialRpEntity                    rp;
+        required PublicKeyCredentialRpEntityJSON                rp;
         required PublicKeyCredentialUserEntityJSON              user;
         required Base64URLString                                challenge;
         required sequence<PublicKeyCredentialParameters>        pubKeyCredParams;
@@ -2855,6 +2855,11 @@ value and terminate the operation.
         DOMString                                               attestation = "none";
         sequence<DOMString>                                     attestationFormats = [];
         AuthenticationExtensionsClientInputsJSON                extensions;
+    };
+
+    dictionary PublicKeyCredentialRpEntityJSON {
+        required DOMString              name;
+        DOMString                       id;
     };
 
     dictionary PublicKeyCredentialUserEntityJSON {
@@ -2873,6 +2878,11 @@ value and terminate the operation.
     };
 </xmp>
 
+Note: <code>{{PublicKeyCredentialRpEntityJSON}}.{{PublicKeyCredentialRpEntityJSON/id}}</code> uses the {{DOMString}} type,
+unlike <code>{{PublicKeyCredentialRpEntity}}.{{PublicKeyCredentialRpEntity/id}}</code> which uses the {{USVString}} type.
+When a {{PublicKeyCredentialRpEntityJSON}} value is parsed from JSON,
+its {{PublicKeyCredentialRpEntityJSON/name}} member will always satisfy the additional requirements of {{USVString}}
+since JSON is always encoded in UTF-8 which does not include [=surrogate=] code points.
 </div>
 
 ### Deserialize Authentication ceremony options - PublicKeyCredential's `parseRequestOptionsFromJSON()` Methods ### {#sctn-parseRequestOptionsFromJSON}
@@ -2906,7 +2916,7 @@ value and terminate the operation.
     dictionary PublicKeyCredentialRequestOptionsJSON {
         required Base64URLString                                challenge;
         unsigned long                                           timeout;
-        USVString                                               rpId;
+        DOMString                                               rpId;
         sequence<PublicKeyCredentialDescriptorJSON>             allowCredentials = [];
         DOMString                                               userVerification = "preferred";
         sequence<DOMString>                                     hints = [];


### PR DESCRIPTION
`rp.id` in `PublicKeyCredentialCreationOptions` and `rpId` in `PublicKeyCredentialRequestOptions` represent the same thing, but with different types. The WG agreed on the 2024-05-15 call that both should be `USVString`. Strictly speaking this is a breaking change (changing a type bound in input (contravariant) position to be more restrictive), but in practice this shouldn't be able to break any applications since then those credentials wouldn't have worked in `get()` anyway.

Fixes #2066.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2074.html" title="Last updated on Jul 17, 2024, 12:25 PM UTC (3618093)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2074/62b069e...3618093.html" title="Last updated on Jul 17, 2024, 12:25 PM UTC (3618093)">Diff</a>