### PR TITLE
Relax PublicKeyCredentialRequestOptions.rpId to DOMString

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3472,7 +3472,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
     dictionary PublicKeyCredentialRequestOptions {
         required BufferSource                challenge;
         unsigned long                        timeout;
-        USVString                            rpId;
+        DOMString                            rpId;
         sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
         DOMString                            userVerification = "preferred";
         sequence<DOMString>                  hints = [];


### PR DESCRIPTION
Alternative resolution to issue #2066 and PR #2074.

Fixes #2066.

This is a backwards-compatible change (changing a type bound in input (contravariant) position to be more permissive). This could have risked that WebAuthn calls in new implementations fail if run in clients that were built to the older spec and still enforce the `USVString` type in `get()`, but WebAuthn already defines that an RP ID must be a _valid domain string_:

- A [valid domain string][1] must pass the _domain to ASCII_ procedure without error.
- [Domain to ASCII][2] invokes the _processing steps in section 4_ of the same document.
- Those processing steps begin with looking up each code point in the _IDNA mapping table_ and then returning an error if any code point was mapped to **disallowed**.
- The [IDNA mapping table][3] notes that "Each table for a version of the Unicode Standard will always be backward compatible with previous versions of the table: only characters with the Status value **disallowed** may change in Status or Mapping value, [...]".
- [Version 15.1.0 of the mapping table][4] maps the range U+D800..U+DFFF to **disallowed**. This is the range of surrogate code units.
- Since this range is **disallowed** in version 15.1.0, it must also be **disallowed** in all previous versions.

Conclusion: WebAuthn RP IDs are already always scalar value strings, because valid domain strings MUST NOT contain surrogate code units. Therefore this type relaxation is backwards compatible with WebAuthn clients that still enforce `USVString` type in `get()`.

[1]: https://url.spec.whatwg.org/#valid-domain-string
[2]: https://www.unicode.org/reports/tr46/#ToASCII
[3]: https://www.unicode.org/Public/idna/
[4]: https://www.unicode.org/Public/idna/15.1.0/IdnaMappingTable.txt


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2098.html" title="Last updated on Jul 17, 2024, 12:24 PM UTC (e3603f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2098/62b069e...e3603f3.html" title="Last updated on Jul 17, 2024, 12:24 PM UTC (e3603f3)">Diff</a>