### PR TITLE
Make `AuthenticatorAttestationResponseJSON.publicKeyAlgorithm` optional.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1657,7 +1657,7 @@ that are returned to the caller when a new credential is created, or a new asser
         // algorithm then the public key must be parsed directly from
         // attestationObject or authenticatorData.
         Base64URLString publicKey;
-        required COSEAlgorithmIdentifier publicKeyAlgorithm;
+        COSEAlgorithmIdentifier publicKeyAlgorithm;
         // This value contains copies of some of the fields above. See
         // section “Easily accessing credential data”.
         required Base64URLString attestationObject;


### PR DESCRIPTION
`AuthenticatorAttestationResponseJSON.publicKeyAlgorithm` serves no purpose without `AuthenticatorAttestationResponseJSON.publicKey` also existing. The latter is wisely optional, so this should be too.
Fixes #2106.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zacknewman/webauthn/pull/2107.html" title="Last updated on Jul 27, 2024, 1:53 AM UTC (68a3709)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2107/2b8e368...zacknewman:68a3709.html" title="Last updated on Jul 27, 2024, 1:53 AM UTC (68a3709)">Diff</a>