### PR TITLE
Reorder PublicKeyCredentialDescriptorJSON values to match PublicKeyCredentialDescriptor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2901,8 +2901,8 @@ value and terminate the operation.
     };
 
     dictionary PublicKeyCredentialDescriptorJSON {
-        required Base64URLString        id;
         required DOMString              type;
+        required Base64URLString        id;
         sequence<DOMString>             transports;
     };
 


### PR DESCRIPTION
This PR rearranges the properties in the `PublicKeyCredentialDescriptorJSON` dictionary to match the ordering of its non-JSON representation `PublicKeyCredentialDescriptor` dictionary.

## `PublicKeyCredentialDescriptorJSON`

![Screenshot 2024-08-06 at 11 04 48 AM](https://github.com/user-attachments/assets/29e6c459-11ad-45f9-9c06-669849858f34)

## `PublicKeyCredentialDescriptor`

![Screenshot 2024-08-06 at 11 05 39 AM](https://github.com/user-attachments/assets/7f914f7c-b5a2-4a7c-b734-93ec669150fa)


Fixes #2082.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2110.html" title="Last updated on Aug 6, 2024, 6:06 PM UTC (a5a12f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2110/30061db...a5a12f6.html" title="Last updated on Aug 6, 2024, 6:06 PM UTC (a5a12f6)">Diff</a>