### PR TITLE
Move topOrigin definition after crossOrigin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1923,14 +1923,14 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialCreationOptions/challenge}}.
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
-    : {{CollectedClientData/topOrigin}}
-    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
-        the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
-        argument passed to this [=internal method=] is [FALSE], else `undefined`.
     : {{CollectedClientData/crossOrigin}}
     :: The inverse of the value of the
         {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
+    : {{CollectedClientData/topOrigin}}
+    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
+        the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
+        argument passed to this [=internal method=] is [FALSE], else `undefined`.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -2414,14 +2414,14 @@ When this method is invoked, the user agent MUST execute the following algorithm
     :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialRequestOptions/challenge}}
     : {{CollectedClientData/origin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
-    : {{CollectedClientData/topOrigin}}
-    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
-        the {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
-        argument passed to this [=internal method=] is [FALSE], else `undefined`.
     : {{CollectedClientData/crossOrigin}}
     :: The inverse of the value of the
         {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
+    : {{CollectedClientData/topOrigin}}
+    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
+        the {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
+        argument passed to this [=internal method=] is [FALSE], else `undefined`.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
 
@@ -3696,8 +3696,8 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
         required DOMString           type;
         required DOMString           challenge;
         required DOMString           origin;
-        DOMString                    topOrigin;
         boolean                      crossOrigin;
+        DOMString                    topOrigin;
     };
 
     dictionary TokenBinding {
@@ -3722,14 +3722,14 @@ Note: The {{CollectedClientData}} may be extended in the future. Therefore it's 
     ::  This member contains the fully qualified [=origin=] of the requester, as provided to the authenticator by the client, in
         the syntax defined by [[!RFC6454]].
 
+    :   <dfn>crossOrigin</dfn>
+    ::  This OPTIONAL member contains the inverse of the `sameOriginWithAncestors` argument value
+        that was passed into the [=internal method=].
+
     :   <dfn>topOrigin</dfn>
     ::  This OPTIONAL member contains the fully qualified [=top-level origin=] of the requester, in the syntax defined
         by [[!RFC6454]]. It is set only if the call was made from context that is not [=same-origin with its
         ancestors=], i.e. if {{CollectedClientData/crossOrigin}} is [TRUE].
-
-    :   <dfn>crossOrigin</dfn>
-    ::  This OPTIONAL member contains the inverse of the `sameOriginWithAncestors` argument value
-        that was passed into the [=internal method=].
 
         <!-- Setting explicit dfn ID (this becomes the fragment part of the anchor URL) for backwards compatibility;
              without this Bikeshed generates the ID "collectedclientdata-tokenbinding". -->


### PR DESCRIPTION
Fixes #2101. Web IDL dictionaries are [insensitive to source definition order](https://github.com/w3c/webauthn/issues/2082#issuecomment-2163824960), so this does not change the semantic meaning of the Web IDL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2114.html" title="Last updated on Aug 7, 2024, 2:17 PM UTC (998b863)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2114/30061db...998b863.html" title="Last updated on Aug 7, 2024, 2:17 PM UTC (998b863)">Diff</a>