### PR TITLE
Change type of credProps.authenticatorDisplayName to DOMString

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6943,7 +6943,7 @@ This [=client extension|client=] [=registration extension=] and [=authentication
 ::  <xmp class="idl">
     dictionary CredentialPropertiesOutput {
         boolean rk;
-        USVString authenticatorDisplayName;
+        DOMString authenticatorDisplayName;
     };
 
     partial dictionary AuthenticationExtensionsClientOutputs {


### PR DESCRIPTION
As recommended by the [Web IDL spec][1]:

>Specifications should only use `USVString` for APIs that perform text processing and need a string of scalar values to operate on. Most APIs that use strings should instead be using `DOMString`, which does not make any interpretations of the code units in the string. When in doubt, use `DOMString`.

[1]: https://webidl.spec.whatwg.org/#idl-USVString

---

Implementation commitment:

- [x] WebKit ([link to issue](https://bugs.webkit.org/show_bug.cgi?id=278787))
- [x] Chromium ([link to issue](https://issues.chromium.org/issues/362676943))
- [x] Gecko ([link to issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1915385))

Documentation and checks

- ~~[ ] Pinged MDN~~
  - `credProps.authenticatorDisplayName` not yet documented on MDN: [WebAuthn Extensions](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#available_extensions)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2115.html" title="Last updated on Aug 28, 2024, 12:43 PM UTC (34d8b60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2115/30061db...34d8b60.html" title="Last updated on Aug 28, 2024, 12:43 PM UTC (34d8b60)">Diff</a>