### PR TITLE
Change `*ResponseJSON.id` to `DOMString`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1629,7 +1629,7 @@ that are returned to the caller when a new credential is created, or a new asser
     typedef object PublicKeyCredentialJSON;
 
     dictionary RegistrationResponseJSON {
-        required Base64URLString id;
+        required DOMString id;
         required Base64URLString rawId;
         required AuthenticatorAttestationResponseJSON response;
         DOMString authenticatorAttachment;
@@ -1655,7 +1655,7 @@ that are returned to the caller when a new credential is created, or a new asser
     };
 
     dictionary AuthenticationResponseJSON {
-        required Base64URLString id;
+        required DOMString id;
         required Base64URLString rawId;
         required AuthenticatorAssertionResponseJSON response;
         DOMString authenticatorAttachment;


### PR DESCRIPTION
This PR refines typing in `RegistrationResponseJSON` and `AuthenticationResponseJSON` to remove confusion around the shape of the value of JSON-serialized `Credential.id`.

Fixes #2119.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2120.html" title="Last updated on Aug 14, 2024, 3:58 PM UTC (769610e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2120/b308a66...769610e.html" title="Last updated on Aug 14, 2024, 3:58 PM UTC (769610e)">Diff</a>