### PR TITLE
Fix Credential*Options/PublicKeyCredential*Options confusion in RP ops

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5577,10 +5577,10 @@ structures.
 
 In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as follows:
 
-1. Let |options| be a new {{PublicKeyCredentialCreationOptions}} structure configured to the [=[RP]=]'s needs for the ceremony.
+1. Let |options| be a new {{CredentialCreationOptions}} structure configured to the [=[RP]=]'s needs for the ceremony.
+    Let |pkOptions| be <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
-1. Call {{CredentialsContainer/create()|navigator.credentials.create()}} and pass |options|
-    as the <code>{{CredentialCreationOptions/publicKey}}</code> option.
+1. Call {{CredentialsContainer/create()|navigator.credentials.create()}} and pass |options| as the argument.
     Let |credential| be the result of the successfully resolved promise.
     If the promise is rejected, abort the ceremony with a user-visible error, or otherwise guide the user experience as
     might be determinable from the context available in the rejected promise. For example if the promise is rejected with
@@ -5608,7 +5608,7 @@ In order to perform a [=registration ceremony=], the [=[RP]=] MUST proceed as fo
 1. Verify that the value of <code>|C|.{{CollectedClientData/type}}</code> is `webauthn.create`.
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/challenge}}</code> equals
-    the base64url encoding of <code>|options|.{{PublicKeyCredentialCreationOptions/challenge}}</code>.
+    the base64url encoding of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/challenge}}</code>.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
@@ -5650,20 +5650,20 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Verify that the "alg" parameter in the [=credentialPublicKey|credential public key=] in |authData|
     matches the {{PublicKeyCredentialParameters/alg}} attribute of one of the [=list/items=] in
-    <code>|options|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>.
+    <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/pubKeyCredParams}}</code>.
 
     <li id='reg-ceremony-verify-extension-outputs'>
         Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
         outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
-        extension input=] values that were given in <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
+        extension input=] values that were given in <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/extensions}}</code>
         and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
-        <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
+        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/extensions}}</code>.
         In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
         Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
         [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
         [=client extension outputs=] that were not originally specified as part of
-        <code>|options|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
+        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
         situations, whether it be to ignore the unsolicited extensions or reject the attestation. The [=[RP]=] can make this
         decision based on local policy and the extensions in use.
 
@@ -5716,7 +5716,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     <li id="reg-ceremony-store-credential-record">
         If the attestation statement |attStmt| verified successfully and is found to be trustworthy,
         then create and store a new [=credential record=] in the [=user account=]
-        that was denoted in <code>|options|.{{PublicKeyCredentialCreationOptions/user}}</code>,
+        that was denoted in <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
         with the following contents:
 
         <dl>
@@ -5776,10 +5776,10 @@ provide this chain in the attestation information.
 
 In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as follows:
 
-1. Let |options| be a new {{PublicKeyCredentialRequestOptions}} structure configured to the [=[RP]=]'s needs for the ceremony.
+1. Let |options| be a new {{CredentialRequestOptions}} structure configured to the [=[RP]=]'s needs for the ceremony.
+    Let |pkOptions| be <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
-1. Call {{CredentialsContainer/get()|navigator.credentials.get()}} and pass |options|
-    as the <code>{{CredentialRequestOptions/publicKey}}</code> option.
+1. Call {{CredentialsContainer/get()|navigator.credentials.get()}} and pass |options| as the argument.
     Let |credential| be the result of the successfully resolved promise.
     If the promise is rejected, abort the ceremony with a user-visible error, or otherwise guide the user experience as might
     be determinable from the context available in the rejected promise. For information on different error contexts and the
@@ -5790,9 +5790,9 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
 
 1. Let |clientExtensionResults| be the result of calling <code>|credential|.{{PublicKeyCredential/getClientExtensionResults()}}</code>.
 
-1. If <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> [=list/is not empty=],
+1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> [=list/is not empty=],
     verify that <code>|credential|.{{Credential/id}}</code> identifies one of the [=public key credentials=]
-    listed in <code>|options|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>.
+    listed in <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code>.
 
 1. Identify the user being authenticated and let |credentialRecord|
     be the [=credential record=] for the [=credential=]:
@@ -5830,7 +5830,7 @@ In order to perform an [=authentication ceremony=], the [=[RP]=] MUST proceed as
 1. Verify that the value of <code>|C|.{{CollectedClientData/type}}</code> is the string `webauthn.get`.
 
 1. Verify that the value of <code>|C|.{{CollectedClientData/challenge}}</code> equals
-    the base64url encoding of <code>|options|.{{PublicKeyCredentialRequestOptions/challenge}}</code>.
+    the base64url encoding of <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/challenge}}</code>.
 
 <!-- Note: this next step is actually a top-level step, but bikeshed wanted it indented this much in order to render it as
 a numbered step. If outdented, it (today) is rendered as a bullet in the midst of a numbered list :-/
@@ -5861,7 +5861,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Determine whether [=user verification=] is required for this assertion.
     [=User verification=] SHOULD be required if, and only if,
-    <code>|options|.{{PublicKeyCredentialRequestOptions/userVerification}}</code> is set to {{UserVerificationRequirement/required}}.
+    <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/userVerification}}</code> is set to {{UserVerificationRequirement/required}}.
 
     If [=user verification=] was determined to be required,
     verify that the [=authData/flags/UV=] bit of the <code>[=flags=]</code> in |authData| is set.
@@ -5886,15 +5886,15 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     <li id='authn-ceremony-verify-extension-outputs'>
         Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
         outputs=] in the <code>[=authData/extensions=]</code> in |authData| are as expected, considering the [=client
-        extension input=] values that were given in <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
+        extension input=] values that were given in <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/extensions}}</code>
         and any specific policy of the [=[RP]=] regarding unsolicited extensions, i.e., those that were not specified as part of
-        <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
+        <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/extensions}}</code>.
         In the general case, the meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in use.
 
         Note:  [=Client platforms=] MAY enact local policy that sets additional [=authenticator extensions=] or
         [=client extensions=] and thus cause values to appear in the [=authenticator extension outputs=] or
         [=client extension outputs=] that were not originally specified as part of
-        <code>|options|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
+        <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/extensions}}</code>. [=[RPS]=] MUST be prepared to handle such
         situations, whether it be to ignore the unsolicited extensions or reject the assertion. The [=[RP]=] can make this
         decision based on local policy and the extensions in use.
 


### PR DESCRIPTION
Analogue of 4800133de6cf06cb926106f35203fe5beb651598 (PR #1948) for the RP operations.

Fixes #2122.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2125.html" title="Last updated on Aug 19, 2024, 11:34 AM UTC (1558106)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2125/93193a1...1558106.html" title="Last updated on Aug 19, 2024, 11:34 AM UTC (1558106)">Diff</a>