### PR TITLE
Clarify meaning of "unless" in UP flag validation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5635,9 +5635,8 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Verify that the <code>[=rpIdHash=]</code> in |authData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
 
-1. Verify that the [=UP=] bit of the <code>[=flags=]</code> in |authData| is set.
-    If <code>|options|.{{CredentialCreationOptions/mediation}}</code> is set to {{CredentialMediationRequirement/conditional}},
-    ignore this verification step.
+1. If <code>|options|.{{CredentialCreationOptions/mediation}}</code> is not set to {{CredentialMediationRequirement/conditional}},
+    verify that the [=UP=] bit of the <code>[=flags=]</code> in |authData| is set.
 
 1. If the [=[RP]=] requires [=user verification=] for this registration,
     verify that the [=authData/flags/UV=] bit of the <code>[=flags=]</code> in |authData| is set.

--- a/index.bs
+++ b/index.bs
@@ -5635,7 +5635,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
 1. Verify that the <code>[=rpIdHash=]</code> in |authData| is the SHA-256 hash of the [=RP ID=] expected by the [=[RP]=].
 
-1. Verify that the [=UP=] bit of the <code>[=flags=]</code> in |authData| is set, unless <code>|options|.{{CredentialCreationOptions/mediation}}</code> is set to {{CredentialMediationRequirement/conditional}}.
+1. Verify that the [=UP=] bit of the <code>[=flags=]</code> in |authData| is set.
+    If <code>|options|.{{CredentialCreationOptions/mediation}}</code> is set to {{CredentialMediationRequirement/conditional}},
+    ignore this verification step.
 
 1. If the [=[RP]=] requires [=user verification=] for this registration,
     verify that the [=authData/flags/UV=] bit of the <code>[=flags=]</code> in |authData| is set.


### PR DESCRIPTION
Fixes #2122.

I'm not entirely convinced about the "ignore this" part being a completely separated sentence, but I chose to formulate it this way to emphasize that by default the `UP` flag should be verified, and only in exceptional circumstances should this verification be ignored.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2126.html" title="Last updated on Sep 24, 2024, 10:06 AM UTC (6cae8a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2126/1558106...6cae8a5.html" title="Last updated on Sep 24, 2024, 10:06 AM UTC (6cae8a5)">Diff</a>