### PR TITLE
Update obsolete privacy concerns about throwing errors early

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2234,9 +2234,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         </dl>
     </li>
 
-1. Throw a "{{NotAllowedError}}" {{DOMException}}. In order to prevent information leak that could identify the
-    user without [=user consent|consent=], this step MUST NOT be executed before |lifetimeTimer| has expired. See
-    [[#sctn-make-credential-privacy]] for details.
+1. Throw a "{{NotAllowedError}}" {{DOMException}}.
 
 During the above process, the user agent SHOULD show some UI to the user to guide them in the process of selecting and
 authorizing an authenticator. When <code>|options|.{{CredentialCreationOptions/mediation}}</code> is set to {{CredentialMediationRequirement/conditional}}, prominent modal UI should <i>not</i> be shown <i>unless</i> credential creation was previously consented to via means determined by the user agent.
@@ -2683,9 +2681,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1.  Return |constructAssertionAlg| and terminate this algorithm.
     </dl>
 
-1. Throw a "{{NotAllowedError}}" {{DOMException}}. In order to prevent information leak that could identify the
-    user without [=user consent|consent=], this step MUST NOT be executed before |lifetimeTimer| has expired. See
-    [[#sctn-assertion-privacy]] for details.
+1. Throw a "{{NotAllowedError}}" {{DOMException}}.
 
 </div>
 
@@ -8806,8 +8802,8 @@ credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreation
 If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing for
 which [=public key credential|credentials=] are available. For example, one such information leak is if the client returns a
 failure response as soon as an excluded [=authenticator=] becomes available. In this case - especially if the excluded
-[=authenticator=] is a [=platform authenticator=] - the [=[RP]=] could detect that the [=ceremony=] was canceled before the
-timeout and before the user could feasibly have canceled it manually, and thus conclude that at least one of the [=public key
+[=authenticator=] is a [=platform authenticator=] - the [=[RP]=] could detect that the [=ceremony=] was canceled
+before the user could feasibly have canceled it manually, and thus conclude that at least one of the [=public key
 credential|credentials=] listed in the {{PublicKeyCredentialCreationOptions/excludeCredentials}} parameter is available to the user.
 
 The above is not a concern, however, if the user has [=user consent|consented=] to create a new credential before a
@@ -8826,11 +8822,17 @@ key credential|credential=] is listed by the [=[RP]=] in {{PublicKeyCredentialRe
 - A named [=public key credential|credential=] is available, but the user does not [=user consent|consent=] to use it.
 
 If the above cases are distinguishable, information is leaked by which a malicious [=[RP]=] could identify the user by probing
-for which [=public key credential|credentials=] are available. For example, one such information leak is if the client returns a
-failure response as soon as the user denies [=user consent|consent=] to proceed with an [=authentication ceremony=]. In this
-case the [=[RP]=] could detect that the [=ceremony=] was canceled by the user and not the timeout, and thus conclude that at least
+for which [=public key credential|credentials=] are available.
+For example, one such information leak may happen if the client displays instructions and controls
+for canceling or proceeding with the [=authentication ceremony=]
+only after discovering an [=authenticator=] that [=contains=] a named [=credential=].
+In this case, if the [=[RP]=] is aware of this [=client=] behavior,
+the [=[RP]=] could detect that the [=ceremony=] was canceled by the user and not the timeout, and thus conclude that at least
 one of the [=public key credential|credentials=] listed in the {{PublicKeyCredentialRequestOptions/allowCredentials}} parameter is
 available to the user.
+
+This concern may be addressed by displaying controls allowing the user to cancel an [=authentication ceremony=] at any time,
+regardless of whether any named [=credentials=] are available.
 
 
 ### Privacy Between Operating System Accounts ### {#sctn-os-account-privacy}


### PR DESCRIPTION
Given the conclusions in https://github.com/w3c/webauthn/issues/2132#issuecomment-2328586778 and https://github.com/w3c/webauthn/issues/2132#issuecomment-2328645419, update the respective privacy concerns and remove the obsolete restrictions against returning "NotAllowedError" before the timeout expires. This simplifies some aspects of #2095 and #2096 (see: https://github.com/w3c/webauthn/pull/2095#discussion_r1697291190).

Closes #2132.

<!-- Remove the following for non-normative changes -->

The following tasks have been completed:

- ~~[ ] Modified Web platform tests~~ (No applicable tests)

Implementation commitment:

- (This change only removes restrictions, but does not require action from implementers.)

Documentation and checks

- [x] Affects privacy: see analysis in https://github.com/w3c/webauthn/issues/2132#issuecomment-2328586778
- ~~[ ] Affects security~~
- ~~[ ] Updated explainer~~


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2134.html" title="Last updated on Sep 4, 2024, 12:08 PM UTC (e0fb9b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2134/a871f79...e0fb9b2.html" title="Last updated on Sep 4, 2024, 12:08 PM UTC (e0fb9b2)">Diff</a>