### PR TITLE
Adds dfn for passkey in passkey platform authenticator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1036,7 +1036,7 @@ BCP 14 [[!RFC2119]] [[!RFC8174]] when, and only when, they appear in all capital
 : <dfn>Client-side discoverable Public Key Credential Source</dfn>
 : <dfn>Client-side discoverable Credential</dfn>
 : <dfn>Discoverable Credential</dfn>
-: <dfn>Passkey</dfn>
+: <dfn export>Passkey</dfn>
 : \[DEPRECATED] <dfn>Resident Credential</dfn>
 : \[DEPRECATED] <dfn>Resident Key</dfn>
 :: Note: Historically, [=client-side discoverable credentials=] have  been known as [=resident credentials=] or [=resident keys=].
@@ -4671,7 +4671,7 @@ lists and names some [=authenticator types=] of particular interest.
                 <td> [=Multi-factor capable=] </td>
             </tr>
             <tr>
-                <th> <dfn>Passkey platform authenticator</dfn> </th>
+                <th> <dfn>[=Passkey=] platform authenticator</dfn> </th>
                 <td> [=platform attachment|platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/internal}}) or [=cross-platform attachment|cross-platform=] ({{AuthenticatorTransport|transport}} = {{AuthenticatorTransport/hybrid}})</td>
                 <td> [=client-side credential storage modality|Client-side storage=] </td>
                 <td> [=Multi-factor capable=] </td>

--- a/index.bs
+++ b/index.bs
@@ -3269,7 +3269,7 @@ optionally evidence of [=user consent=] to a specific transaction.
         See [[#dictionary-authenticatorSelection]].
 
     :   <dfn>hints</dfn>
-    ::  This OPTIONAL member contains zero or more elements from {{PublicKeyCredentialHints}} to guide the user agent in interacting with the user. Note that the elements have type `DOMString` despite being taken from that enumeration. See [[#sct-domstring-backwards-compatibility]].
+    ::  This OPTIONAL member contains zero or more elements from {{PublicKeyCredentialHint}} to guide the user agent in interacting with the user. Note that the elements have type `DOMString` despite being taken from that enumeration. See [[#sct-domstring-backwards-compatibility]].
 
     :   <dfn>attestation</dfn>
     ::  The [=[RP]=] MAY use this OPTIONAL member to specify a preference regarding [=attestation conveyance=].
@@ -3666,7 +3666,7 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
         See {{UserVerificationRequirement}} for the description of {{AuthenticatorSelectionCriteria/userVerification}}'s values and semantics.
 
     :   <dfn>hints</dfn>
-    ::  This OPTIONAL member contains zero or more elements from {{PublicKeyCredentialHints}} to guide the user agent in interacting with the user. Note that the elements have type `DOMString` despite being taken from that enumeration. See [[#sct-domstring-backwards-compatibility]].
+    ::  This OPTIONAL member contains zero or more elements from {{PublicKeyCredentialHint}} to guide the user agent in interacting with the user. Note that the elements have type `DOMString` despite being taken from that enumeration. See [[#sct-domstring-backwards-compatibility]].
 
     :   <dfn>extensions</dfn>
     ::  The [=[RP]=] MAY use this OPTIONAL member to provide [=client extension inputs=]
@@ -4161,19 +4161,19 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
     ::  The [=WebAuthn Client=] supports [[#sctn-related-origins|Related Origin Requests]].
 </div>
 
-### User-agent Hints Enumeration (enum <dfn enum>PublicKeyCredentialHints</dfn>) ### {#enum-hints}
+### User-agent Hints Enumeration (enum <dfn enum>PublicKeyCredentialHint</dfn>) ### {#enum-hints}
 
 <xmp class="idl">
-    enum PublicKeyCredentialHints {
+    enum PublicKeyCredentialHint {
         "security-key",
         "client-device",
         "hybrid",
     };
 </xmp>
 
-Note: The {{PublicKeyCredentialHints}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+Note: The {{PublicKeyCredentialHint}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
 
-<div dfn-type="enum-value" dfn-for="PublicKeyCredentialHints">
+<div dfn-type="enum-value" dfn-for="PublicKeyCredentialHint">
     [=[WRPS]=] may use this enumeration to communicate hints to the user-agent about how a request may be best completed. These hints are not requirements, and do not bind the user-agent, but may guide it in providing the best experience by using contextual information that the [=[RP]=] has about the request. Hints are provided in order of decreasing preference so, if two hints are contradictory, the first one controls. Hints may also overlap: if a more-specific hint is defined a [=[RP]=] may still wish to send less specific ones for user-agents that may not recognise the more specific one. In this case the most specific hint should be sent before the less-specific ones.
 
     Hints MAY contradict information contained in credential {{PublicKeyCredentialDescriptor/transports}} and {{AuthenticatorSelectionCriteria/authenticatorAttachment}}. When this occurs, the hints take precedence. (Note that {{PublicKeyCredentialDescriptor/transports}} values are not provided when using [=discoverable credentials=], leaving hints as the only avenue for expressing some aspects of such a request.)


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2137.html" title="Last updated on Sep 6, 2024, 2:49 PM UTC (e8934e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2137/93193a1...e8934e6.html" title="Last updated on Sep 6, 2024, 2:49 PM UTC (e8934e6)">Diff</a>