### PR TITLE
Add BE/BS steps to authData generation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4758,6 +4758,14 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
     possibly combined in a single [=authorization gesture=],
     then the authenticator will set both the [=UP=] [=flag=] and the [=authData/flags/UV=] [=flag=].
 
+- The [=BE=] [=flag=] SHALL be set if and only if a credential is a [=multi-device credential=]. 
+    This value MUST not change after a [=registration ceremony=] as defined in [[#sctn-credential-backup]].
+
+- The [=BS=] [=flag=] SHALL be set if and only if the credential is a [=multi-device credential=] and is currently [=backed up=].
+
+    If the backup status of a credential is uncertain or the authenticator suspects a problem with the backed up credential,
+        the [=BS=] [=flag=] SHOULD NOT be set.
+
 - For [=attestation signatures=], the authenticator MUST set the [=AT=] [=flag=] and include the <code>[=attestedCredentialData=]</code>.
     For [=assertion signatures=], the [=AT=] [=flag=] MUST NOT be set and the <code>[=attestedCredentialData=]</code> MUST NOT be included.
 

--- a/index.bs
+++ b/index.bs
@@ -4759,7 +4759,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
     then the authenticator will set both the [=UP=] [=flag=] and the [=authData/flags/UV=] [=flag=].
 
 - The [=BE=] [=flag=] SHALL be set if and only if a credential is a [=multi-device credential=]. 
-    This value MUST not change after a [=registration ceremony=] as defined in [[#sctn-credential-backup]].
+    This value MUST NOT change after a [=registration ceremony=] as defined in [[#sctn-credential-backup]].
 
 - The [=BS=] [=flag=] SHALL be set if and only if the credential is a [=multi-device credential=] and is currently [=backed up=].
 

--- a/index.bs
+++ b/index.bs
@@ -4758,7 +4758,7 @@ the requested [=public key credential|credential=] is [=scoped=] to exactly matc
     possibly combined in a single [=authorization gesture=],
     then the authenticator will set both the [=UP=] [=flag=] and the [=authData/flags/UV=] [=flag=].
 
-- The [=BE=] [=flag=] SHALL be set if and only if a credential is a [=multi-device credential=]. 
+- The [=BE=] [=flag=] SHALL be set if and only if the credential is a [=multi-device credential=]. 
     This value MUST NOT change after a [=registration ceremony=] as defined in [[#sctn-credential-backup]].
 
 - The [=BS=] [=flag=] SHALL be set if and only if the credential is a [=multi-device credential=] and is currently [=backed up=].


### PR DESCRIPTION
Closes #2064

Adds `BE` and `BS` steps to the authData generation sequence.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2141.html" title="Last updated on Sep 11, 2024, 9:16 AM UTC (caf217a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2141/a871f79...caf217a.html" title="Last updated on Sep 11, 2024, 9:16 AM UTC (caf217a)">Diff</a>