### PR TITLE
Add userName and userDisplayName to webdriver

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8013,6 +8013,22 @@ The <dfn>Credential Parameters</dfn> is a JSON [=Object=] passed to the [=remote
                 </td>
                 <td>boolean</td>
             </tr>
+            <tr>
+                <td>|userName|</td>
+                <td>
+                    The {{PublicKeyCredentialUserEntity|user}}'s {{PublicKeyCredentialEntity/name}} associated to the credential.
+                    If unset, the value will default to the empty string.
+                </td>
+                <td>string</td>
+            </tr>
+            <tr>
+                <td>|userDisplayName|</td>
+                <td>
+                    The {{PublicKeyCredentialUserEntity|user}}'s {{PublicKeyCredentialUserEntity/displayName}} associated to the credential.
+                    If unset, the value will default to the empty string.
+                </td>
+                <td>string</td>
+            </tr>
         </tbody>
     </table>
 </figure>
@@ -8053,6 +8069,10 @@ The [=remote end steps=] are:
  1. If |backupEligibility| is not defined, set |backupEligibility| to the value of the |authenticator|'s |defaultBackupEligibility|.
  1. Let |backupState| be the |parameters|' |backupState| property.
  1. If |backupState| is not defined, set |backupState| to the value of the |authenticator|'s |defaultBackupState|.
+ 1. Let |userName| be the |parameters|' |userName| property.
+ 1. If |userName| is not defined, set |userName| to the empty string.
+ 1. Let |userDisplayName| be the |parameters|' |userDisplayName| property.
+ 1. If |userDisplayName| is not defined, set |userDisplayName| to the empty string.
  1. Let |credential| be a new [=Client-side discoverable Public Key Credential Source=] if |isResidentCredential| is [TRUE]
      or a [=Server-side Public Key Credential Source=] otherwise whose items are:
     : [=public key credential source/type=]
@@ -8065,6 +8085,8 @@ The [=remote end steps=] are:
     :: |rpId|
     : [=public key credential source/userHandle=]
     :: |userHandle|
+    : [=public key credential source/otherUI=]
+    :: Construct from |userName| and |userDisplayName|.
  1. Set the |credential|'s [=backup eligibility=] [=credential property=] to |backupEligibility|.
  1. Set the |credential|'s [=backup state=] [=credential property=] to |backupState|.
  1. Associate a [=signature counter=] |counter| to the |credential| with a starting value equal to the |parameters|'


### PR DESCRIPTION
This PR adds the userName and userDisplayName properties to the webdriver's credential parameters. These properties are useful to test the new signalCurrentUserDetails method, both on WPTs and for web developers.

Closes #2143

The following tasks have been completed:

- [ ] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/))
 -- This will be done as a follow-up

Implementation commitment:
- [ ] WebKit ([link to issue](https://bugs.webkit.org/))
- [ X ] Chromium ([link to issue](https://crbug.com/367915823))
- [ ] Gecko ([link to issue](https://bugzilla.mozilla.org/home))


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nsatragno/webauthn/pull/2148.html" title="Last updated on Oct 1, 2024, 3:14 PM UTC (146a63e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2148/efdf948...nsatragno:146a63e.html" title="Last updated on Oct 1, 2024, 3:14 PM UTC (146a63e)">Diff</a>