### PR TITLE
Remove bikeshed workaround

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6427,7 +6427,7 @@ The firmware of a particular authenticator model MAY be differentiated using the
 For example, the following is an attestation certificate containing the above extension OIDs as well as required fields:
 
 ~~~ pem
------BEGIN CERTIFICATE----- <!-- bikeshed emdash workaround -->
+-----BEGIN CERTIFICATE-----
 MIIBzTCCAXOgAwIBAgIUYHS3FJEL/JTfFqafuAHvlAS+hDYwCgYIKoZIzj0EAwIw
 QTELMAkGA1UEBhMCVVMxFDASBgNVBAoMC1dlYkF1dGhuIFdHMRwwGgYDVQQDDBNF
 eGFtcGxlIEF0dGVzdGF0aW9uMCAXDTI0MDEwMzE3NDUyMVoYDzIwNTAwMTA2MTc0
@@ -6438,7 +6438,7 @@ YH9yMOOcci3nr+Q/jOBaWVERo0cwRTAhBgsrBgEEAYLlHAEBBAQSBBDNjDlcJu3u
 3mU7AHl9A8o8MBIGCysGAQQBguUcAQEFBAMCASowDAYDVR0TAQH/BAIwADAKBggq
 hkjOPQQDAgNIADBFAiA3k3aAUVtLhDHLXOgY2kRnK2hrbRgf2EKdTDLJ1Ds/RAIh
 AOmIblhI3ALCHOaO0IO7YlMpw/lSTvFYv3qwO3m7H8Dc
------END CERTIFICATE----- <!-- bikeshed emdash workaround -->
+-----END CERTIFICATE-----
 ~~~
 
 The attributes above are structured within this certificate as such:


### PR DESCRIPTION
This removes a workaround to `bikeshed` processing/rendering behavior that was added as part of #1953.

The underlying issue has been fixed in the version of `bikeshed` being used to CI-render the current spec. The changed behavior also appears to have caused the workaround to currently appear in the rendered spec text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dwaite/webauthn/pull/2149.html" title="Last updated on Sep 18, 2024, 8:03 PM UTC (176ea81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2149/caefa8a...dwaite:176ea81.html" title="Last updated on Sep 18, 2024, 8:03 PM UTC (176ea81)">Diff</a>