### PR TITLE
Exclude all platform authenticators that use self attesation from hav…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2175,7 +2175,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                             :   {{AttestationConveyancePreference/none}}
                             ::  Replace potentially uniquely identifying information with non-identifying versions of the
                                 same:
-                                  1. If the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] is 16 zero bytes, <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> is "packed", and "x5c" is absent from <code>|credentialCreationData|.[=attestationObjectResult=]</code>, then [=self attestation=] is being used and no further action is needed.
+                                  1. If the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] is 16 zero bytes or |authenticator| is a [=platform authenticator=], <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> is "packed", and "x5c" is absent from <code>|credentialCreationData|.[=attestationObjectResult=]</code>, then [=self attestation=] is being used and no further action is needed.
                                   1. Otherwise:
                                       1. Set the value of <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> to "none", and set the value of <code>|credentialCreationData|.[=attestationObjectResult=].attStmt</code> to be an empty [=CBOR=] map. (See [[#sctn-none-attestation]] and [[#sctn-generating-an-attestation-object]]).
                                       1. If |authenticator| is not a [=platform authenticator=] then replace the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] with 16 zero bytes.


### PR DESCRIPTION
…ing to use none attestation

Closes #2146
Related #1962

#2146 raises the possibility of leaving attestation for _all_ platform authenticators based on the argument that much of the information related to attestation could be re-generated once AAGUID is known (which all platform authenticators keep); however this PR more conservatively only excludes platform authenticators that use self attestation since self attestation does not contain any new information and self attestation is already excluded from being replaced with none when the AAGUID is already all zero (i.e., RPs, even ones that only intend to support none attestations, have to be prepared to handle via error the possibility of receiving self attestation despite requesting none).

The following tasks have been completed:

- [ ] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/))

Implementation commitment:

- [ ] WebKit ([link to issue](https://bugs.webkit.org/))
- [ ] Chromium ([link to issue](https://issues.chromium.org/issues/new?component=1456855&template=0))
- [ ] Gecko ([link to issue](https://bugzilla.mozilla.org/home))

Documentation and checks

~~- [ ] Affects privacy~~ This PR only affects self attestation which doesn't contain any data not already known by the RP.
~~- [ ] Affects security~~
~~- [ ] Updated explainer ([link](https://github.com/w3c/webauthn/wiki)~~


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zacknewman/webauthn/pull/2150.html" title="Last updated on Sep 27, 2024, 6:50 PM UTC (d7e238e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2150/caefa8a...zacknewman:d7e238e.html" title="Last updated on Sep 27, 2024, 6:50 PM UTC (d7e238e)">Diff</a>