### PR TITLE
Mark Android SafetyNet attestation as deprecated.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6659,6 +6659,8 @@ data</dfn> is identified by the OID `1.3.6.1.4.1.11129.2.1.17`, and its schema i
 
 ## Android SafetyNet Attestation Statement Format ## {#sctn-android-safetynet-attestation}
 
+Note: This format is deprecated and is expected to be removed in a future revision of this document.
+
 When the [=authenticator=] is a [=platform authenticator=] on certain Android platforms, the attestation
 statement may be based on the [SafetyNet API](https://developer.android.com/training/safetynet/attestation#compat-check-response). In
 this case the [=authenticator data=] is completely controlled by the caller of the SafetyNet API (typically an application


### PR DESCRIPTION
Google have
[announced](https://developer.android.com/privacy-and-security/safetynet/deprecation-timeline) the deprecation of SafetyNet in general, and [specifically for](https://android-developers.googleblog.com/2024/09/attestation-format-change-for-android-fido2-api.html) WebAuthn.

This change adds a note in the SafetyNet section that it may be removed in a future revision of the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2155.html" title="Last updated on Sep 25, 2024, 5:07 PM UTC (bcd428d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2155/efdf948...bcd428d.html" title="Last updated on Sep 25, 2024, 5:07 PM UTC (bcd428d)">Diff</a>