### PR TITLE
Don't return an algorithm from [[DiscoverFromExternalSource]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2636,49 +2636,46 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
             1. If |credentialIdFilter| [=list/is empty=] and [=userHandleResult=] is null, [=continue=].
 
-            1.  Let |constructAssertionAlg| be an algorithm that takes a [=global object=]
-                |global|, and whose steps are:
+            1. Let |settings| be the [=current settings object=]. Let |global| be |settings|’ [=global object=].
 
-                1.  Let |pubKeyCred| be a new {{PublicKeyCredential}} object associated with |global| whose fields are:
+            1.  Let |pubKeyCred| be a new {{PublicKeyCredential}} object associated with |global| whose fields are:
 
-                    :   {{PublicKeyCredential/[[identifier]]}}
+                :   {{PublicKeyCredential/[[identifier]]}}
+                ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
+                    <code>|assertionCreationData|.[=credentialIdResult=]</code>.
+
+                :   {{PublicKeyCredential/authenticatorAttachment}}
+                ::  The {{AuthenticatorAttachment}} value matching the current [=authenticator attachment modality=] of |authenticator|.
+
+                :   {{PublicKeyCredential/response}}
+                ::  A new {{AuthenticatorAssertionResponse}} object associated with |global| whose fields are:
+
+                    :   {{AuthenticatorResponse/clientDataJSON}}
                     ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
-                        <code>|assertionCreationData|.[=credentialIdResult=]</code>.
+                        <code>|assertionCreationData|.[=assertionCreationData/clientDataJSONResult=]</code>.
 
-                    :   {{PublicKeyCredential/authenticatorAttachment}}
-                    ::  The {{AuthenticatorAttachment}} value matching the current [=authenticator attachment modality=] of |authenticator|.
-
-                    :   {{PublicKeyCredential/response}}
-                    ::  A new {{AuthenticatorAssertionResponse}} object associated with |global| whose fields are:
-
-                        :   {{AuthenticatorResponse/clientDataJSON}}
-                        ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
-                            <code>|assertionCreationData|.[=assertionCreationData/clientDataJSONResult=]</code>.
-
-                        :   {{AuthenticatorAssertionResponse/authenticatorData}}
-                        ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
-                            <code>|assertionCreationData|.[=assertionCreationData/authenticatorDataResult=]</code>.
-
-                        :   {{AuthenticatorAssertionResponse/signature}}
-                        ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
-                            <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
-
-                        :   {{AuthenticatorAssertionResponse/userHandle}}
-                        ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this
-                            field to null. Otherwise, set this field to a new {{ArrayBuffer}}, created using |global|'s
-                            [=%ArrayBuffer%=], containing the bytes of
-                            <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code>.
-
-                    :   {{PublicKeyCredential/[[clientExtensionsResults]]}}
+                    :   {{AuthenticatorAssertionResponse/authenticatorData}}
                     ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
-                        <code>|assertionCreationData|.[=assertionCreationData/clientExtensionResults=]</code>.
+                        <code>|assertionCreationData|.[=assertionCreationData/authenticatorDataResult=]</code>.
 
-                1.  Return |pubKeyCred|.
+                    :   {{AuthenticatorAssertionResponse/signature}}
+                    ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
+                        <code>|assertionCreationData|.[=assertionCreationData/signatureResult=]</code>.
+
+                    :   {{AuthenticatorAssertionResponse/userHandle}}
+                    ::  If <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code> is null, set this
+                        field to null. Otherwise, set this field to a new {{ArrayBuffer}}, created using |global|'s
+                        [=%ArrayBuffer%=], containing the bytes of
+                        <code>|assertionCreationData|.[=assertionCreationData/userHandleResult=]</code>.
+
+                :   {{PublicKeyCredential/[[clientExtensionsResults]]}}
+                ::  A new {{ArrayBuffer}}, created using |global|'s [=%ArrayBuffer%=], containing the bytes of
+                    <code>|assertionCreationData|.[=assertionCreationData/clientExtensionResults=]</code>.
 
             1.  [=set/For each=] remaining |authenticator| in |issuedRequests| invoke the [=authenticatorCancel=] operation
                 on |authenticator| and [=set/remove=] it from |issuedRequests|.
 
-            1.  Return |constructAssertionAlg| and terminate this algorithm.
+            1.  Return |pubKeyCred| and terminate this algorithm.
     </dl>
 
 1. Throw a "{{NotAllowedError}}" {{DOMException}}.


### PR DESCRIPTION
Fixes #1984.

This initialization of |settings| and |global| is copied from the equivalent steps of [§2.5.4. Create a Credential][1] in CredMan, which sets the arguments used to invoke the |constructCredentialAlg| in WebAuthn's [[Create]]:

>Let |settings| be the [current settings object][2].
>
>Assert: |settings| is a [secure context][3].
>
>Let |global| be |settings|’ [global object][4].

[1]: https://w3c.github.io/webappsec-credential-management/#algorithm-create
[2]: https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object
[3]: https://html.spec.whatwg.org/multipage/webappapis.html#secure-context
[4]: https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2168.html" title="Last updated on Oct 1, 2024, 2:28 PM UTC (bdcb938)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2168/efdf948...bdcb938.html" title="Last updated on Oct 1, 2024, 2:28 PM UTC (bdcb938)">Diff</a>