### PR TITLE
Extract macros for referring to [[Create]] and [[DiscoverFromExternalSource]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1733,11 +1733,10 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 </xmp>
 
 
-### Create a New Credential - PublicKeyCredential's `[[Create]](origin, options, sameOriginWithAncestors)` Method ### {#sctn-createCredential}
+### Create a New Credential - PublicKeyCredential's <dfn for="PublicKeyCredential" method>\[[Create]](origin, options, sameOriginWithAncestors)</dfn> Method ### {#sctn-createCredential}
 
 <div link-for-hint="PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)">
-{{PublicKeyCredential}}'s [=interface object=]'s implementation of the <dfn for="PublicKeyCredential" method>\[[Create]](origin,
-options, sameOriginWithAncestors)</dfn> [=internal method=] [[!CREDENTIAL-MANAGEMENT-1]] allows
+{{PublicKeyCredential}}'s [=interface object=]'s implementation of the {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}} [=internal method=] [[!CREDENTIAL-MANAGEMENT-1]] allows
 [=[WRP]=] scripts to call {{CredentialsContainer/create()|navigator.credentials.create()}} to request the creation of a new
 [=public key credential source=], [=bound credential|bound=] to an [=authenticator=].
 

--- a/index.bs
+++ b/index.bs
@@ -58,6 +58,12 @@ Text Macro: WAA WebAuthn Authenticator
 Text Macro: WAC WebAuthn Client
 Text Macro: WRP WebAuthn Relying Party
 Text Macro: WRPS WebAuthn Relying Parties
+Text Macro: CREATE-METHOD-ARGS (origin, options, sameOriginWithAncestors)
+Text Macro: CREATE-METHOD [[Create]][CREATE-METHOD-ARGS]
+Text Macro: CREATE-METHOD-DEF \[[Create]][CREATE-METHOD-ARGS]
+Text Macro: DISCOVER-METHOD-ARGS (origin, options, sameOriginWithAncestors)
+Text Macro: DISCOVER-METHOD [[DiscoverFromExternalSource]][DISCOVER-METHOD-ARGS]
+Text Macro: DISCOVER-METHOD-DEF \[[DiscoverFromExternalSource]][DISCOVER-METHOD-ARGS]
 Ignored Vars: op, alg, type, algorithm
 Abstract: This specification defines an API enabling the creation and use of strong, attested, [=scoped=], public key-based
  credentials by [=web applications=], for the purpose of strongly authenticating users. Conceptually, one or more [=public key
@@ -1009,7 +1015,7 @@ BCP 14 [[!RFC2119]] [[!RFC8174]] when, and only when, they appear in all capital
 
 : <dfn>Client</dfn>
 : <dfn>[WAC]</dfn>
-:: Also referred to herein as simply a [=client=]. See also [=Conforming User Agent=]. A [=[WAC]=] is an intermediary entity typically implemented in the user agent (in whole, or in part). Conceptually, it underlies the [=Web Authentication API=] and embodies the implementation of the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=]. It is responsible for both marshalling the inputs for the underlying [=authenticator operations=], and for returning the results of the latter operations to the [=Web Authentication API=]'s callers.
+:: Also referred to herein as simply a [=client=]. See also [=Conforming User Agent=]. A [=[WAC]=] is an intermediary entity typically implemented in the user agent (in whole, or in part). Conceptually, it underlies the [=Web Authentication API=] and embodies the implementation of the {{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} [=internal methods=]. It is responsible for both marshalling the inputs for the underlying [=authenticator operations=], and for returning the results of the latter operations to the [=Web Authentication API=]'s callers.
 
     The [=[WAC]=] runs on, and is distinct from, a [=[WAC] Device=].
 
@@ -1703,7 +1709,7 @@ that are returned to the caller when a new credential is created, or a new asser
 
 {{PublicKeyCredential}}'s [=interface object=] inherits {{Credential}}'s implementation of
 {{Credential/[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)}}, and defines its own
-implementation of each of {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}}, {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}, and
+implementation of each of {{PublicKeyCredential/[CREATE-METHOD]}}, {{PublicKeyCredential/[DISCOVER-METHOD]}}, and
 {{PublicKeyCredential/[[Store]](credential, sameOriginWithAncestors)}}.
 
 Calling {{CredentialsContainer}}'s {{CredentialsContainer/preventSilentAccess()}} method
@@ -1733,10 +1739,10 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 </xmp>
 
 
-### Create a New Credential - PublicKeyCredential's <dfn for="PublicKeyCredential" method>\[[Create]](origin, options, sameOriginWithAncestors)</dfn> Method ### {#sctn-createCredential}
+### Create a New Credential - PublicKeyCredential's <dfn for="PublicKeyCredential" method>[CREATE-METHOD-DEF]</dfn> Method ### {#sctn-createCredential}
 
-<div link-for-hint="PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)">
-{{PublicKeyCredential}}'s [=interface object=]'s implementation of the {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}} [=internal method=] [[!CREDENTIAL-MANAGEMENT-1]] allows
+<div link-for-hint="PublicKeyCredential/[CREATE-METHOD]">
+{{PublicKeyCredential}}'s [=interface object=]'s implementation of the {{Credential/[CREATE-METHOD]}} [=internal method=] [[!CREDENTIAL-MANAGEMENT-1]] allows
 [=[WRP]=] scripts to call {{CredentialsContainer/create()|navigator.credentials.create()}} to request the creation of a new
 [=public key credential source=], [=bound credential|bound=] to an [=authenticator=].
 
@@ -1754,7 +1760,7 @@ see [[dom#abortcontroller-api-integration]] for detailed instructions.
 
 This [=internal method=] accepts three arguments:
 
-<dl dfn-type="argument" dfn-for="PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)">
+<dl dfn-type="argument" dfn-for="PublicKeyCredential/[CREATE-METHOD]">
 
     :   <dfn>origin</dfn>
     ::  This argument is the [=relevant settings object=]'s [=environment settings object/origin=], as determined by the
@@ -1819,7 +1825,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. If the length of <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/id}}</code> is not between 1 and 64 bytes (inclusive) then throw a {{TypeError}}.
 
-1. Let |callerOrigin| be {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/origin}}. If |callerOrigin| is an [=opaque origin=], throw a "{{NotAllowedError}}" {{DOMException}}.
+1. Let |callerOrigin| be {{PublicKeyCredential/[CREATE-METHOD]/origin}}. If |callerOrigin| is an [=opaque origin=], throw a "{{NotAllowedError}}" {{DOMException}}.
 
 1. Let |effectiveDomain| be the |callerOrigin|'s [=effective domain=].
     If [=effective domain=] is not a [=valid domain=], then throw a
@@ -1915,11 +1921,11 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/crossOrigin}}
     :: The inverse of the value of the
-        {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
+        {{PublicKeyCredential/[CREATE-METHOD]/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
     : {{CollectedClientData/topOrigin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
-        the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
+        the {{PublicKeyCredential/[CREATE-METHOD]/sameOriginWithAncestors}}
         argument passed to this [=internal method=] is [FALSE], else `undefined`.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
@@ -2309,7 +2315,7 @@ decline the entire interaction even if a [=public key credential source=] is pre
 The {{CredentialsContainer/get()|navigator.credentials.get()}} implementation [[!CREDENTIAL-MANAGEMENT-1]] calls
 <code>PublicKeyCredential.{{PublicKeyCredential/[[CollectFromCredentialStore]]()}}</code> to collect any [=credentials=] that
 should be available without [=user mediation=] (roughly, this specification's [=authorization gesture=]), and if it does not find
-exactly one of those, it then calls <code>PublicKeyCredential.{{PublicKeyCredential/[[DiscoverFromExternalSource]]()}}</code> to have
+exactly one of those, it then calls <code>PublicKeyCredential.{{PublicKeyCredential/[DISCOVER-METHOD]}}</code> to have
 the user select a [=public key credential source=].
 
 Since this specification requires an [=authorization gesture=] to create any [=assertions=], the <code>PublicKeyCredential.<dfn
@@ -2327,13 +2333,13 @@ Any
 {{CredentialsContainer/get()|navigator.credentials.get()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
 
-#### PublicKeyCredential's <code><dfn for="PublicKeyCredential" method>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn></code> Method #### {#sctn-discover-from-external-source}
+#### PublicKeyCredential's <code><dfn for="PublicKeyCredential" method>[DISCOVER-METHOD-DEF]</dfn></code> Method #### {#sctn-discover-from-external-source}
 
-<div link-for-hint="PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)">
+<div link-for-hint="PublicKeyCredential/[DISCOVER-METHOD]">
 
 This [=internal method=] accepts three arguments:
 
-<dl dfn-type="argument" dfn-for="PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)">
+<dl dfn-type="argument" dfn-for="PublicKeyCredential/[DISCOVER-METHOD]">
 
     :   <dfn>origin</dfn>
     ::  This argument is the [=relevant settings object=]'s [=environment settings object/origin=], as determined by the
@@ -2394,7 +2400,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
             Note: The user agent should take cognitive guidelines into considerations regarding timeout for users with special needs.
 
-1. Let |callerOrigin| be {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/origin}}. If |callerOrigin| is
+1. Let |callerOrigin| be {{PublicKeyCredential/[DISCOVER-METHOD]/origin}}. If |callerOrigin| is
     an [=opaque origin=], throw a "{{NotAllowedError}}" {{DOMException}}.
 
 1. Let |effectiveDomain| be the |callerOrigin|'s [=effective domain=].
@@ -2459,11 +2465,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
     : {{CollectedClientData/crossOrigin}}
     :: The inverse of the value of the
-        {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
+        {{PublicKeyCredential/[DISCOVER-METHOD]/sameOriginWithAncestors}}
         argument passed to this [=internal method=].
     : {{CollectedClientData/topOrigin}}
     :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
-        the {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/sameOriginWithAncestors}}
+        the {{PublicKeyCredential/[DISCOVER-METHOD]/sameOriginWithAncestors}}
         argument passed to this [=internal method=] is [FALSE], else `undefined`.
 
 1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
@@ -2686,9 +2692,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 #### <dfn for="PublicKeyCredential" algorithm="Issuing a credential request to an authenticator">Issuing a Credential Request to an Authenticator</dfn> #### {#sctn-issuing-cred-request-to-authenticator}
 
-This sub-algorithm of {{PublicKeyCredential/[[DiscoverFromExternalSource]]()}} encompasses the specific UI context-independent
+This sub-algorithm of {{PublicKeyCredential/[DISCOVER-METHOD]}} encompasses the specific UI context-independent
 steps necessary for requesting a [=credential=] from a given [=authenticator=], using given {{PublicKeyCredentialRequestOptions}}.
-It is called by {{PublicKeyCredential/[[DiscoverFromExternalSource]]()}} from various points depending on which [=user mediation=]
+It is called by {{PublicKeyCredential/[DISCOVER-METHOD]}} from various points depending on which [=user mediation=]
 the present [=authentication ceremony=] is subject to (e.g.: {{CredentialMediationRequirement/conditional}} mediation).
 
 This algorithm accepts the following arguments:
@@ -3391,7 +3397,7 @@ during registration.
 
 #### Easily accessing credential data #### {#sctn-public-key-easy}
 
-Every user of the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method will need to parse and store the returned [=credential public key=] in order to verify future [=authentication assertions=]. However, the [=credential public key=] is in COSE format [[!RFC9052]], inside the [=credentialPublicKey=] member of the [=attestedCredentialData=], inside the [=authenticator data=], inside the [=attestation object=] conveyed by {{AuthenticatorAttestationResponse}}.{{AuthenticatorAttestationResponse/attestationObject}}. [=[RPS]=] wishing to use [=attestation=] are obliged to do the work of parsing the {{AuthenticatorAttestationResponse/attestationObject}} and obtaining the [=credential public key=] because that public key copy is the one the [=authenticator=] [signed](#signing-procedure). However, many valid WebAuthn use cases do not require [=attestation=]. For those uses, user agents can do the work of parsing, expose the [=authenticator data=] directly, and translate the [=credential public key=] into a more convenient format.
+Every user of the {{PublicKeyCredential/[CREATE-METHOD]}} method will need to parse and store the returned [=credential public key=] in order to verify future [=authentication assertions=]. However, the [=credential public key=] is in COSE format [[!RFC9052]], inside the [=credentialPublicKey=] member of the [=attestedCredentialData=], inside the [=authenticator data=], inside the [=attestation object=] conveyed by {{AuthenticatorAttestationResponse}}.{{AuthenticatorAttestationResponse/attestationObject}}. [=[RPS]=] wishing to use [=attestation=] are obliged to do the work of parsing the {{AuthenticatorAttestationResponse/attestationObject}} and obtaining the [=credential public key=] because that public key copy is the one the [=authenticator=] [signed](#signing-procedure). However, many valid WebAuthn use cases do not require [=attestation=]. For those uses, user agents can do the work of parsing, expose the [=authenticator data=] directly, and translate the [=credential public key=] into a more convenient format.
 
 The {{AuthenticatorAttestationResponse/getPublicKey()}} operation thus returns the [=credential public key=] as a [=SubjectPublicKeyInfo=]. This {{ArrayBuffer}} can, for example, be passed to Java's `java.security.spec.X509EncodedKeySpec`, .NET's `System.Security.Cryptography.ECDsa.ImportSubjectPublicKeyInfo`, or Go's `crypto/x509.ParsePKIXPublicKey`.
 
@@ -3784,10 +3790,9 @@ Note: The {{AuthenticatorAttachment}} enumeration is deliberately not referenced
     ::  This value indicates [=cross-platform attachment=].
 </div>
 
-Note: An [=authenticator attachment modality=] selection option is available only in the {{PublicKeyCredential/[[Create]](origin, options,
-sameOriginWithAncestors)}} operation. The [=[RP]=] may use it to, for example, ensure the user has a [=roaming credential=] for
+Note: An [=authenticator attachment modality=] selection option is available only in the {{PublicKeyCredential/[CREATE-METHOD]}} operation. The [=[RP]=] may use it to, for example, ensure the user has a [=roaming credential=] for
 authenticating on another [=client device=]; or to specifically register a [=platform credential=] for easier reauthentication using a
-particular [=client device=]. The {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
+particular [=client device=]. The {{PublicKeyCredential/[DISCOVER-METHOD]}}
 operation has no [=authenticator attachment modality=] selection option, so the [=[RP]=] SHOULD accept any of the user's registered [=public key
 credential|credentials=]. The [=client=] and user will then use whichever is available and convenient at the time.
 
@@ -3969,24 +3974,24 @@ an assertion. Its {{PublicKeyCredentialRequestOptions/challenge}} member MUST be
 ## Abort Operations with `AbortSignal` ## {#sctn-abortoperation}
 
 Developers are encouraged to leverage the {{AbortController}} to manage the
-{{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} operations.
+{{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} operations.
 See [[dom#abortcontroller-api-integration]] section for detailed instructions.
 
     Note: [[dom#abortcontroller-api-integration]] section specifies that web platform APIs integrating with the
     {{AbortController}} must reject the promise immediately once the {{AbortSignal}} is [=AbortSignal/aborted=].
-    Given the complex inheritance and parallelization structure of the {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}}
-    and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} methods, the algorithms for the two APIs fulfills this
+    Given the complex inheritance and parallelization structure of the {{PublicKeyCredential/[CREATE-METHOD]}}
+    and {{PublicKeyCredential/[DISCOVER-METHOD]}} methods, the algorithms for the two APIs fulfills this
     requirement by checking the [=AbortSignal/aborted=] property in three places. In the case of
-    {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}}, the [=AbortSignal/aborted=] property is checked first in
-    [[credential-management-1#algorithm-create]] immediately before calling {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}},
+    {{PublicKeyCredential/[CREATE-METHOD]}}, the [=AbortSignal/aborted=] property is checked first in
+    [[credential-management-1#algorithm-create]] immediately before calling {{Credential/[CREATE-METHOD]}},
     then in [[#sctn-createCredential]] right before [=authenticator sessions=] start, and finally
     during [=authenticator sessions=]. The same goes for
-    {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}.
+    {{PublicKeyCredential/[DISCOVER-METHOD]}}.
 
 The [=visibility states|visibility=] and [=focus=] state of the {{Window}} object determines whether the
-{{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} operations
+{{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} operations
 should continue. When the {{Window}} object associated with the [=Document=] loses focus,
-{{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} operations
+{{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} operations
 SHOULD be aborted.
 
     Issue: The WHATWG HTML WG is discussing whether to provide a hook when a browsing context gains or
@@ -4522,14 +4527,14 @@ A {{Document}}'s [=Document/permissions policy=] determines whether any content 
 If disabled in any document, no content in the document will be [=allowed to use=]
 the foregoing methods: attempting to do so will [return an error](https://www.w3.org/2001/tag/doc/promises-guide#errors).
 
-Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual permissions policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=] does not have such access since they are invoked [=in parallel=] by {{CredentialsContainer}}'s <a abstract-op>Create a `Credential`</a> and <a abstract-op>Request a `Credential`</a> abstract operations [[!CREDENTIAL-MANAGEMENT-1]].
+Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual permissions policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} [=internal methods=] does not have such access since they are invoked [=in parallel=] by {{CredentialsContainer}}'s <a abstract-op>Create a `Credential`</a> and <a abstract-op>Request a `Credential`</a> abstract operations [[!CREDENTIAL-MANAGEMENT-1]].
 
 
 
 ## Using Web Authentication within <code>iframe</code> elements ## {#sctn-iframe-guidance}
 
 The [=Web Authentication API=] is disabled by default in cross-origin <{iframe}>s.
-To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=]'s {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method, specify the <{iframe/allow}> attribute on the <{iframe}> element and include the <code>[=publickey-credentials-get-feature|publickey-credentials-get=]</code> feature-identifier token in the <{iframe/allow}> attribute's value.
+To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=]'s {{PublicKeyCredential/[DISCOVER-METHOD]}} method, specify the <{iframe/allow}> attribute on the <{iframe}> element and include the <code>[=publickey-credentials-get-feature|publickey-credentials-get=]</code> feature-identifier token in the <{iframe/allow}> attribute's value.
 
 [=[RPS]=] utilizing the WebAuthn API in an embedded context should review [[#sctn-seccons-visibility]] regarding [=UI redressing=] and its possible mitigations.
 
@@ -7572,10 +7577,10 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
            1. Set {{AuthenticationExtensionsLargeBlobOutputs/supported}} to [TRUE].
 
                Note: This is in anticipation of an authenticator capable of storing large blobs becoming available.
-               It occurs during extension processing in [step 12](#CreateCred-process-extensions) of {{PublicKeyCredential/[[Create]]()}}.
+               It occurs during extension processing in [step 12](#CreateCred-process-extensions) of {{PublicKeyCredential/[CREATE-METHOD]}}.
                The {{AuthenticationExtensionsLargeBlobOutputs}} will be abandoned if no satisfactory authenticator becomes available.
 
-           1. If a [=create/candidate authenticator=] becomes available ([step 21](#CreateCred-async-loop) of {{PublicKeyCredential/[[Create]]()}}) then,
+           1. If a [=create/candidate authenticator=] becomes available ([step 21](#CreateCred-async-loop) of {{PublicKeyCredential/[CREATE-METHOD]}}) then,
               before evaluating any <code>|options|</code>, [=iteration/continue=] (i.e. ignore the [=create/candidate authenticator=])
               if the [=create/candidate authenticator=] is not capable of storing large blobs.
        1. Otherwise (i.e. {{AuthenticationExtensionsLargeBlobInputs/support}} is absent or has the value {{LargeBlobSupport/preferred}}):
@@ -7589,7 +7594,7 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
            1. Return a {{DOMException}} whose name is “{{NotSupportedError}}”.
        1. If {{AuthenticationExtensionsLargeBlobInputs/read}} is present and has the value [TRUE]:
            1. Initialize the [=client extension output=], {{AuthenticationExtensionsClientOutputs/largeBlob}}.
-           1. If any authenticator indicates success (in {{PublicKeyCredential/[[DiscoverFromExternalSource]]()}}), attempt to read any largeBlob data associated with the asserted credential.
+           1. If any authenticator indicates success (in {{PublicKeyCredential/[DISCOVER-METHOD]}}), attempt to read any largeBlob data associated with the asserted credential.
            1. If successful, set {{AuthenticationExtensionsLargeBlobOutputs/blob}} to the result.
 
               Note: if the read is not successful, {{AuthenticationExtensionsClientOutputs/largeBlob}} will be present in {{AuthenticationExtensionsClientOutputs}} but the {{AuthenticationExtensionsLargeBlobOutputs/blob}} member will not be present.
@@ -8852,7 +8857,7 @@ These recommendations serve to prevent an adversary with physical access to an [
 ### Registration Ceremony Privacy ### {#sctn-make-credential-privacy}
 
 In order to protect users from being identified without [=user consent|consent=], implementations of the
-{{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} method need to take care to not leak information that
+{{PublicKeyCredential/[CREATE-METHOD]}} method need to take care to not leak information that
 could enable a malicious [=[WRP]=] to distinguish between these cases, where "excluded" means that at least one of the [=public key
 credential|credentials=] listed by the [=[RP]=] in {{PublicKeyCredentialCreationOptions/excludeCredentials}} is [=bound credential|bound=] to the
 [=authenticator=]:
@@ -8875,7 +8880,7 @@ leaked.
 ### Authentication Ceremony Privacy ### {#sctn-assertion-privacy}
 
 In order to protect users from being identified without [=user consent|consent=], implementations of the
-{{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} method need to take care to not
+{{PublicKeyCredential/[DISCOVER-METHOD]}} method need to take care to not
 leak information that could enable a malicious [=[WRP]=] to distinguish between these cases, where "named" means that the [=public
 key credential|credential=] is listed by the [=[RP]=] in {{PublicKeyCredentialRequestOptions/allowCredentials}}:
 


### PR DESCRIPTION
It's really cumbersome to have to list out the parameter list in every reference, but [omitting the parameters](https://speced.github.io/bikeshed/#:~:text=For%20convenience%2C%20however%2C%20Bikeshed%20will%20allow%20autolinks%20with%20empty%20argument%20lists%20to%20work%2C%20as%20long%20as%20it%20can%20resolve%20the%20link%20unambiguously) also omits them from the rendered link, so that doesn't seem right either.

This also fixes some inconsistencies in parameter lists between references to
these methods.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2179.html" title="Last updated on Oct 9, 2024, 6:08 PM UTC (9942c9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2179/1e2256d...9942c9c.html" title="Last updated on Oct 9, 2024, 6:08 PM UTC (9942c9c)">Diff</a>