### PR TITLE
Remove apparent reference to non-existent [[Get]] internal method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2321,6 +2321,7 @@ the user select a [=public key credential source=].
 Since this specification requires an [=authorization gesture=] to create any [=assertions=],
 {{PublicKeyCredential}} inherits the default behavior of
 {{Credential/[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)}}, of returning an empty set.
+{{PublicKeyCredential}}'s implementation of {{PublicKeyCredential/[DISCOVER-METHOD]}} is specified in the next section.
 
 In general, the user agent SHOULD show some UI to the user to guide them in selecting and authorizing an authenticator with which
 to complete the operation. By setting <code>|options|.{{CredentialRequestOptions/mediation}}</code> to {{CredentialMediationRequirement/conditional}}, [=[RPS]=] can indicate that a prominent modal UI should <i>not</i> be shown <i>unless</i> credentials are discovered.

--- a/index.bs
+++ b/index.bs
@@ -2318,9 +2318,9 @@ should be available without [=user mediation=] (roughly, this specification's [=
 exactly one of those, it then calls <code>PublicKeyCredential.{{PublicKeyCredential/[DISCOVER-METHOD]}}</code> to have
 the user select a [=public key credential source=].
 
-Since this specification requires an [=authorization gesture=] to create any [=assertions=], the <code>PublicKeyCredential.<dfn
-for="PublicKeyCredential" method>\[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)</dfn></code> [=internal method=] inherits the default behavior of
-{{Credential/[[CollectFromCredentialStore]]()|Credential.[[CollectFromCredentialStore]]()}}, of returning an empty set.
+Since this specification requires an [=authorization gesture=] to create any [=assertions=],
+{{PublicKeyCredential}} inherits the default behavior of
+{{Credential/[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)}}, of returning an empty set.
 
 In general, the user agent SHOULD show some UI to the user to guide them in selecting and authorizing an authenticator with which
 to complete the operation. By setting <code>|options|.{{CredentialRequestOptions/mediation}}</code> to {{CredentialMediationRequirement/conditional}}, [=[RPS]=] can indicate that a prominent modal UI should <i>not</i> be shown <i>unless</i> credentials are discovered.

--- a/index.bs
+++ b/index.bs
@@ -2301,7 +2301,7 @@ The following [=simple exceptions=] can be raised:
 
 </dl>
 
-### Use an Existing Credential to Make an Assertion - PublicKeyCredential's `[[Get]](options)` Method ### {#sctn-getAssertion}
+### Use an Existing Credential to Make an Assertion ### {#sctn-getAssertion}
 
 [=[WRPS]=] call <code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code> to
 discover and use an existing [=public key credential=], with the [=user consent|user's consent=]. [=[RP]=] script optionally specifies some criteria

--- a/index.bs
+++ b/index.bs
@@ -1739,7 +1739,7 @@ To support obtaining assertions via {{CredentialsContainer/get()|navigator.crede
 </xmp>
 
 
-### Create a New Credential - PublicKeyCredential's <dfn for="PublicKeyCredential" method>[CREATE-METHOD-DEF]</dfn> Method ### {#sctn-createCredential}
+### Create a New Credential - PublicKeyCredential's <dfn for="PublicKeyCredential" method>[CREATE-METHOD-DEF]</dfn> Internal Method ### {#sctn-createCredential}
 
 <div link-for-hint="PublicKeyCredential/[CREATE-METHOD]">
 {{PublicKeyCredential}}'s [=interface object=]'s implementation of the {{Credential/[CREATE-METHOD]}} [=internal method=] [[!CREDENTIAL-MANAGEMENT-1]] allows
@@ -2333,7 +2333,7 @@ Any
 {{CredentialsContainer/get()|navigator.credentials.get()}} operation can be aborted by leveraging the {{AbortController}};
 see [[dom#abortcontroller-api-integration]] for detailed instructions.
 
-#### PublicKeyCredential's <code><dfn for="PublicKeyCredential" method>[DISCOVER-METHOD-DEF]</dfn></code> Method #### {#sctn-discover-from-external-source}
+#### PublicKeyCredential's <code><dfn for="PublicKeyCredential" method>[DISCOVER-METHOD-DEF]</dfn></code> Internal Method #### {#sctn-discover-from-external-source}
 
 <div link-for-hint="PublicKeyCredential/[DISCOVER-METHOD]">
 
@@ -2855,7 +2855,7 @@ The following [=simple exceptions=] can be raised:
 
 </dl>
 
-### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Method ### {#sctn-storeCredential}
+### Store an Existing Credential - PublicKeyCredential's `[[Store]](credential, sameOriginWithAncestors)` Internal Method ### {#sctn-storeCredential}
 
 <div link-for-hint="PublicKeyCredential/[[Store]](credential, sameOriginWithAncestors)">
 


### PR DESCRIPTION
Closes #2169.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2180.html" title="Last updated on Oct 7, 2024, 3:34 PM UTC (068d7f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2180/6744192...068d7f5.html" title="Last updated on Oct 7, 2024, 3:34 PM UTC (068d7f5)">Diff</a>