### PR TITLE
Fix typo in reference to variable |effectiveDomain|

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3098,7 +3098,7 @@ The [$Asynchronous RP ID validation algorithm$] lets [=signal methods=] validate
 and returns a promise that rejects if the validation fails. The steps are:
 
 1. Let |effectiveDomain| be the [=relevant settings object=]'s [=environment
-    settings object/origin=]'s [=effective domain=]. If |effective domain| is
+    settings object/origin=]'s [=effective domain=]. If |effectiveDomain| is
     not a [=valid domain=], then return [=a promise rejected with=]
     "{{SecurityError}}" {{DOMException}}.
 1. If |rpId| [=is a registrable domain suffix of or is equal to=]


### PR DESCRIPTION
Fixes this Bikeshed lint:

```
LINE ~3100: The var 'effective domain' (in global scope) is only used once.
If this is not a typo, please add an ignore='' attribute to the <var>.
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2182.html" title="Last updated on Oct 7, 2024, 1:57 PM UTC (1fcb7aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2182/386ad79...1fcb7aa.html" title="Last updated on Oct 7, 2024, 1:57 PM UTC (1fcb7aa)">Diff</a>