### PR TITLE
Add warning about sending PRF outputs to server

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7510,6 +7510,15 @@ Note: this extension may be implemented for [=authenticators=] that do not use [
 
         :   <dfn>results</dfn>
         ::  The results of evaluating the PRF for the inputs given in {{AuthenticationExtensionsPRFInputs/eval}} or {{AuthenticationExtensionsPRFInputs/evalByCredential}}. Outputs may not be available during [=registration=]; see comments in {{AuthenticationExtensionsPRFInputs/eval}}.
+
+            Advisement:
+            For some use cases, for example if PRF outputs are used to derive encryption keys to use only on the client side,
+            it may be necessary to omit this {{AuthenticationExtensionsPRFOutputs/results}} output
+            if the {{PublicKeyCredential}} is sent to a remote server,
+            for example to perform the procedures in [[#sctn-rp-operations]].
+            Note in particular that the {{RegistrationResponseJSON}} and {{AuthenticationResponseJSON}}
+            returned by <code>{{PublicKeyCredential}}.{{PublicKeyCredential/toJSON()}}</code>
+            will include this {{AuthenticationExtensionsPRFOutputs/results}} output if present.
     </div>
 
 ### Large blob storage extension (<dfn>largeBlob</dfn>) ### {#sctn-large-blob-extension}


### PR DESCRIPTION
Fixes #2177 as described in https://github.com/w3c/webauthn/pull/2174#issuecomment-2389695303.

This conflicts with #2178.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2183.html" title="Last updated on Oct 7, 2024, 2:18 PM UTC (8c6827e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2183/386ad79...8c6827e.html" title="Last updated on Oct 7, 2024, 2:18 PM UTC (8c6827e)">Diff</a>