### PR TITLE
Mozilla feedback: Related Origins

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4563,6 +4563,8 @@ For example, for the RP ID `example.com`:
 
 [=WebAuthn Clients=] supporting this feature MUST support at least five [=registrable origin labels=]. Client policy SHOULD define an upper limit to prevent abuse.
 
+Requests to this well-known endpoint by [=WebAuthn Clients=] MUST be made without [=request/credentials mode|credentials=] and without a [=request/referrer policy|referrer=].
+
 [=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOrigins}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
 
 ### Validating Related Origins ### {#sctn-validating-relation-origin}
@@ -4570,7 +4572,7 @@ For example, for the RP ID `example.com`:
 The <dfn abstract-op>related origins validation procedure</dfn>, given arguments |callerOrigin| and |rpIdRequested|, is as follows:
 
 1. Let |maxLabels| be the maximum number of [=registrable origin labels=] allowed by client policy.
-1. Fetch the `webauthn` well-known URL [[!RFC8615]] for the RP ID |rpIdRequested| (i.e., <code>https://|rpIdRequested|/.well-known/webauthn</code>).
+1. Fetch the `webauthn` well-known URL [[!RFC8615]] for the RP ID |rpIdRequested| (i.e., <code>https://|rpIdRequested|/.well-known/webauthn</code>) without [=request/credentials mode|credentials=] and without a [=request/referrer policy|referrer=].
     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -4537,7 +4537,7 @@ This can make deployment challenging for large environments where multiple count
 [=[WRPS]=] can opt in to allowing [=WebAuthn Clients=] to enable a credential to be created and used across a limited set of related [=origin|origins=].
 Such [=[RPS]=] MUST choose a common [=RP ID=] to use across all ceremonies from related origins.
 
-A JSON document MUST be hosted at the `webauthn` well-known URL [[!RFC8615]] for the [=RP ID=]. The JSON document MUST be returned as follows:
+A JSON document MUST be hosted at the `webauthn` well-known URL [[!RFC8615]] for the [=RP ID=], and MUST be served using HTTPS. The JSON document MUST be returned as follows:
 
     - The content type MUST be `application/json`.
     - The top-level JSON object MUST contain a key named `origins` whose value MUST be an array of one or more strings containing web origins.
@@ -4563,7 +4563,8 @@ For example, for the RP ID `example.com`:
 
 [=WebAuthn Clients=] supporting this feature MUST support at least five [=registrable origin labels=]. Client policy SHOULD define an upper limit to prevent abuse.
 
-Requests to this well-known endpoint by [=WebAuthn Clients=] MUST be made without [=request/credentials mode|credentials=] and without a [=request/referrer policy|referrer=].
+Requests to this well-known endpoint by [=WebAuthn Clients=] MUST be made without [=request/credentials mode|credentials=], without a [=request/referrer policy|referrer=],
+and using the `https:` [=scheme=]. When following redirects, [=WebAuthn Clients=] MUST explicitly require all redirects to also use the `https:` [=scheme=].
 
 [=WebAuthn Clients=] supporting this feature SHOULD include {{ClientCapability/relatedOrigins}} in their response to [[#sctn-getClientCapabilities|getClientCapabilities()]].
 
@@ -4572,7 +4573,7 @@ Requests to this well-known endpoint by [=WebAuthn Clients=] MUST be made withou
 The <dfn abstract-op>related origins validation procedure</dfn>, given arguments |callerOrigin| and |rpIdRequested|, is as follows:
 
 1. Let |maxLabels| be the maximum number of [=registrable origin labels=] allowed by client policy.
-1. Fetch the `webauthn` well-known URL [[!RFC8615]] for the RP ID |rpIdRequested| (i.e., <code>https://|rpIdRequested|/.well-known/webauthn</code>) without [=request/credentials mode|credentials=] and without a [=request/referrer policy|referrer=].
+1. Fetch the `webauthn` well-known URL [[!RFC8615]] for the RP ID |rpIdRequested| (i.e., <code>https://|rpIdRequested|/.well-known/webauthn</code>) without [=request/credentials mode|credentials=], without a [=request/referrer policy|referrer=] and using the `https:` [=scheme=].
     1. If the fetch fails, the response does not have a content type of `application/json`, or does not have a status code (after following redirects) of 200, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the body of the resource is not a valid JSON object, then throw a "{{SecurityError}}" {{DOMException}}.
     1. If the value of the |origins| property of the JSON object is missing, or is not an array of strings, then throw a "{{SecurityError}}" {{DOMException}}.


### PR DESCRIPTION
https://github.com/mozilla/standards-positions/issues/1052#issuecomment-2412388864

Addresses Mozilla's feedback around Related Origins.

- Requires well-known to be served via HTTPS by the RP
- Requires `https:` scheme for all well-known calls by the client
- Requires `https:` for all redirects
- Requires calls by client to well-known endpoint to not be credentialed and not include referrer

/ghcc @dveditz 

<!-- Remove the following for non-normative changes -->

The following tasks have been completed:

- [ ] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/))

Implementation commitment:

- [ ] WebKit ([link to issue](https://bugs.webkit.org/))
- [ ] Chromium ([link to issue](https://issues.chromium.org/issues/new?component=1456855&template=0))
- [ ] Gecko ([link to issue](https://bugzilla.mozilla.org/home))

Documentation and checks

- [x] Affects privacy
- [x] Affects security
- [x] Updated explainer ([link](https://github.com/w3c/webauthn/wiki/Explainer:-Related-origin-requests))


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2186.html" title="Last updated on Oct 23, 2024, 5:47 PM UTC (241833d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2186/efdf948...241833d.html" title="Last updated on Oct 23, 2024, 5:47 PM UTC (241833d)">Diff</a>