### PR TITLE
Clarify use creating and verifying TPM attestation statements.  

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6594,7 +6594,7 @@ TPM [=attestation certificate=] MUST have the following fields/extensions:
         Note: Previous versions of [[!TPMv2-EK-Profile]] allowed the inclusion of an optional attribute,
         called HardwareModuleName, that contains the TPM serial number in the EK certificate.
         HardwareModuleName SHOULD NOT be placed in in the [=attestation certificate=]
-        Subject Alternatieve Name.
+        Subject Alternative Name.
 
 - The Extended Key Usage extension MUST contain the OID `2.23.133.8.3`
     ("joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8) tcg-kp-AIKCertificate(3)").

--- a/index.bs
+++ b/index.bs
@@ -6590,8 +6590,8 @@ engine.
     - Verify that `attested` contains a `TPMS_CERTIFY_INFO` structure as specified in [[!TPMv2-Part2]] section 10.12.3,
         whose `name` field contains a valid Name for |pubArea|, as computed using the procedure specified in [[!TPMv2-Part1]] section 16 using the nameAlg in the |pubArea|.
 
-        Note: The hash algorithm is also included within the attested `name`
-        field of the TPMS_CERTIFY_INFO structure and will also match nameAlg in |pubArea| when returned by the TPM.
+        Note: The TPM will always return TPMS_CERTIFY_INFO structure with the same nameAlg in the `name` as the nameAlg
+        in |pubArea|.
 
         Note: The remaining fields in the "Standard Attestation Structure" [[!TPMv2-Part1]]
         section 31.2, i.e., `qualifiedSigner`, `clockInfo` and `firmwareVersion` are ignored.

--- a/index.bs
+++ b/index.bs
@@ -6536,8 +6536,11 @@ engine.
     setting the `extraData` parameter to the digest of |attToBeSigned| using the hash algorithm corresponding to the "alg" signature algorithm.
     (For the "RS256" algorithm, this would be a SHA-256 digest.)
 
-    Set the |pubArea| field to the public area of the credential public key, the |certInfo| field to the output parameter of the
-    same name, and the |sig| field to the signature obtained from the above procedure.
+    Set the |pubArea| field to the public area of the credential public key (the TPMT_PUBLIC structure), the |certInfo| field (the TPMS_ATTEST structure)
+    to the output parameter of the same name, and the |sig| field to the signature obtained from the above procedure.
+
+    Note: If the |pubArea| is read from the TPM using the TPM2_ReadPublic command, that command returns a TPM2B_PUBLIC structure. TPM2B_PUBLIC
+    is two bytes of length followed by the TPMT_PUBLIC structure. The two bytes of length must be removed prior to putting this into the |pubArea|.
 
 : Verification procedure
 :: Given the [=verification procedure inputs=] |attStmt|, |authenticatorData| and |clientDataHash|, the [=verification procedure=] is
@@ -6552,13 +6555,15 @@ engine.
     Concatenate |authenticatorData| and |clientDataHash| to form |attToBeSigned|.
 
     Validate that |certInfo| is valid:
+    Note: |certInfo| is a TPMS_ATTEST structure.
     - Verify that `magic` is set to `TPM_GENERATED_VALUE`.
     - Verify that `type` is set to `TPM_ST_ATTEST_CERTIFY`.
     - Verify that `extraData` is set to the hash of |attToBeSigned| using the hash algorithm employed in "alg".
     - Verify that `attested` contains a `TPMS_CERTIFY_INFO` structure as specified in [[!TPMv2-Part2]] section 10.12.3,
         whose `name` field contains a valid Name for |pubArea|,
         as computed using the procedure specified in [[!TPMv2-Part1]]
-        section 16. Note that the hash algorithm is included within the attested `name` field of the TPMS_CERTIFY_INFO structure.
+        section 16 using the nameAlg in the |pubArea|. Note that the hash algorithm is also included within the attested `name`
+	field of the TPMS_CERTIFY_INFO structure and will also match nameAlg in |pubArea| when returned by the TPM.
     - Verify that |x5c| is present.
     - Note that the remaining fields in the "Standard Attestation Structure" [[!TPMv2-Part1]]
         section 31.2, i.e., `qualifiedSigner`, `clockInfo` and `firmwareVersion` are ignored.

--- a/index.bs
+++ b/index.bs
@@ -6568,9 +6568,7 @@ engine.
     - Verify that `type` is set to `TPM_ST_ATTEST_CERTIFY`.
     - Verify that `extraData` is set to the hash of |attToBeSigned| using the hash algorithm employed in "alg".
     - Verify that `attested` contains a `TPMS_CERTIFY_INFO` structure as specified in [[!TPMv2-Part2]] section 10.12.3,
-        whose `name` field contains a valid Name for |pubArea|,
-        as computed using the procedure specified in [[!TPMv2-Part1]]
-        section 16 using the nameAlg in the |pubArea|.
+        whose `name` field contains a valid Name for |pubArea|, as computed using the procedure specified in [[!TPMv2-Part1]] section 16 using the nameAlg in the |pubArea|.
 
         Note: The hash algorithm is also included within the attested `name`
         field of the TPMS_CERTIFY_INFO structure and will also match nameAlg in |pubArea| when returned by the TPM.
@@ -6592,6 +6590,11 @@ TPM [=attestation certificate=] MUST have the following fields/extensions:
 - Subject field MUST be set to empty.
 
 - The Subject Alternative Name extension MUST be set as defined in [[!TPMv2-EK-Profile]] section 3.2.9.
+
+        Note: Previous versions of [[!TPMv2-EK-Profile]] allowed the inclusion of an optional attribute,
+        called HardwareModuleName, that contains the TPM serial number in the EK certificate.
+        HardwareModuleName SHOULD NOT be placed in in the [=attestation certificate=]
+        Subject Alternatieve Name.
 
 - The Extended Key Usage extension MUST contain the OID `2.23.133.8.3`
     ("joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8) tcg-kp-AIKCertificate(3)").
@@ -9417,7 +9420,7 @@ for their contributions as our W3C Team Contacts.
   "TPMv2-EK-Profile": {
     "title": "TCG EK Credential Profile for TPM Family 2.0",
     "publisher": "Trusted Computing Group",
-    "href": "https://www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf"
+    "href": "https://trustedcomputinggroup.org/wp-content/uploads/TCG-EK-Credential-Profile-V-2.5-R2_published.pdf"
   },
 
   "FIDOAuthnrSecReqs": {

--- a/index.bs
+++ b/index.bs
@@ -6562,10 +6562,13 @@ engine.
     - Verify that `attested` contains a `TPMS_CERTIFY_INFO` structure as specified in [[!TPMv2-Part2]] section 10.12.3,
         whose `name` field contains a valid Name for |pubArea|,
         as computed using the procedure specified in [[!TPMv2-Part1]]
-        section 16 using the nameAlg in the |pubArea|. Note that the hash algorithm is also included within the attested `name`
-	field of the TPMS_CERTIFY_INFO structure and will also match nameAlg in |pubArea| when returned by the TPM.
+        section 16 using the nameAlg in the |pubArea|.
+
+        Note: that the hash algorithm is also included within the attested `name`
+        field of the TPMS_CERTIFY_INFO structure and will also match nameAlg in |pubArea| when returned by the TPM.
     - Verify that |x5c| is present.
-    - Note that the remaining fields in the "Standard Attestation Structure" [[!TPMv2-Part1]]
+
+        Note: that the remaining fields in the "Standard Attestation Structure" [[!TPMv2-Part1]]
         section 31.2, i.e., `qualifiedSigner`, `clockInfo` and `firmwareVersion` are ignored.
         These fields MAY be used as an input to risk engines.
 

--- a/index.bs
+++ b/index.bs
@@ -6564,14 +6564,15 @@ engine.
         as computed using the procedure specified in [[!TPMv2-Part1]]
         section 16 using the nameAlg in the |pubArea|.
 
-        Note: that the hash algorithm is also included within the attested `name`
+        Note: The hash algorithm is also included within the attested `name`
         field of the TPMS_CERTIFY_INFO structure and will also match nameAlg in |pubArea| when returned by the TPM.
-    - Verify that |x5c| is present.
 
-        Note: that the remaining fields in the "Standard Attestation Structure" [[!TPMv2-Part1]]
+        Note: The remaining fields in the "Standard Attestation Structure" [[!TPMv2-Part1]]
         section 31.2, i.e., `qualifiedSigner`, `clockInfo` and `firmwareVersion` are ignored.
-        These fields MAY be used as an input to risk engines.
+        Depending on the properties of the |aikCert| key used, these fields may be obfuscated.
+        If valid, these MAY be used as an input to risk engines.
 
+    - Verify that |x5c| is present.
     - Verify the |sig| is a valid signature over |certInfo| using the attestation public key in |aikCert| with the
         algorithm specified in |alg|.
     - Verify that |aikCert| meets the requirements in [[#sctn-tpm-cert-requirements]].

--- a/index.bs
+++ b/index.bs
@@ -6554,6 +6554,14 @@ engine.
 
     Concatenate |authenticatorData| and |clientDataHash| to form |attToBeSigned|.
 
+    Verify integrity of |certInfo|
+    - Verify that |x5c| is present.
+    - Verify that |aikCert| meets the requirements in [[#sctn-tpm-cert-requirements]].
+    - If |aikCert| contains an extension with OID `1.3.6.1.4.1.45724.1.1.4` (`id-fido-gen-ce-aaguid`) verify that the value of this
+        extension matches the <code>[=authData/attestedCredentialData/aaguid=]</code> in |authenticatorData|.
+    - Verify the |sig| is a valid signature over |certInfo| using the attestation public key in |aikCert| with the
+        algorithm specified in |alg|.
+
     Validate that |certInfo| is valid:
     Note: |certInfo| is a TPMS_ATTEST structure.
     - Verify that `magic` is set to `TPM_GENERATED_VALUE`.
@@ -6572,12 +6580,6 @@ engine.
         Depending on the properties of the |aikCert| key used, these fields may be obfuscated.
         If valid, these MAY be used as an input to risk engines.
 
-    - Verify that |x5c| is present.
-    - Verify the |sig| is a valid signature over |certInfo| using the attestation public key in |aikCert| with the
-        algorithm specified in |alg|.
-    - Verify that |aikCert| meets the requirements in [[#sctn-tpm-cert-requirements]].
-    - If |aikCert| contains an extension with OID `1.3.6.1.4.1.45724.1.1.4` (`id-fido-gen-ce-aaguid`) verify that the value of this
-        extension matches the <code>[=authData/attestedCredentialData/aaguid=]</code> in |authenticatorData|.
     - If successful, return implementation-specific values representing [=attestation type=] [=AttCA=] and [=attestation trust
         path=] |x5c|.
 


### PR DESCRIPTION
Closes #1925 

Addressed potential implementation errors in TPM Attestation

Implementation commitment:

Addressed potential implementation errors in TPM Attestation
Addressed potential privacy issues


Documentation and checks

- [x] Affects privacy
- [ ] Affects security
- [ ] Updated explainer ([link](https://github.com/w3c/webauthn/wiki)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mwiseman-byid/webauthn/pull/2193.html" title="Last updated on Nov 13, 2024, 3:45 PM UTC (9618b97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2193/406ec42...mwiseman-byid:9618b97.html" title="Last updated on Nov 13, 2024, 3:45 PM UTC (9618b97)">Diff</a>