### PR TITLE
Drop outdated "Issue 1" from spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3991,10 +3991,6 @@ should continue. When the {{Window}} object associated with the [=Document=] los
 {{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} operations
 SHOULD be aborted.
 
-    Issue: The WHATWG HTML WG is discussing whether to provide a hook when a browsing context gains or
-    loses focuses. If a hook is provided, the above paragraph will be updated to include the hook.
-    See [WHATWG HTML WG Issue #2711](https://github.com/whatwg/html/issues/2711) for more details.
-
 
 ## WebAuthn Extensions Inputs and Outputs ## {#sctn-extensions-inputs-outputs}
 


### PR DESCRIPTION
This issue was originally added in commit
931b46eece69f5d780ce4b317e3a377a3a67f85c in 2017. The referenced discussion seems to have stalled shortly thereafter, so this issue is most likely no longer relevant.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2195.html" title="Last updated on Nov 13, 2024, 3:05 PM UTC (e2923ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2195/92e1015...e2923ba.html" title="Last updated on Nov 13, 2024, 3:05 PM UTC (e2923ba)">Diff</a>