### PR TITLE
WebAuthn Clients should NOT zero out AAGUIDs from security keys when attestation is none 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2171,7 +2171,6 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                                   1. If the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] is 16 zero bytes, <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> is "packed", and "x5c" is absent from <code>|credentialCreationData|.[=attestationObjectResult=]</code>, then [=self attestation=] is being used and no further action is needed.
                                   1. Otherwise:
                                       1. Set the value of <code>|credentialCreationData|.[=attestationObjectResult=].fmt</code> to "none", and set the value of <code>|credentialCreationData|.[=attestationObjectResult=].attStmt</code> to be an empty [=CBOR=] map. (See [[#sctn-none-attestation]] and [[#sctn-generating-an-attestation-object]]).
-                                      1. If |authenticator| is not a [=platform authenticator=] then replace the [=authData/attestedCredentialData/aaguid=] in the [=attested credential data=] with 16 zero bytes.
 
                             :   {{AttestationConveyancePreference/indirect}}
                             ::  The client MAY replace the [=authData/attestedCredentialData/aaguid=] and [=attestation statement=] with a more privacy-friendly


### PR DESCRIPTION
Allow the passing of the aaguid for all Authenticators, not just the platform ones.

Closes #2198 

<!-- Remove the following for non-normative changes -->

The following tasks have been completed:

- [ ] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/))

Implementation commitment:

- [ ] WebKit ([link to issue](https://bugs.webkit.org/))
- [ ] Chromium ([link to issue](https://issues.chromium.org/issues/new?component=1456855&template=0))
- [ ] Gecko ([link to issue](https://bugzilla.mozilla.org/home))

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Updated explainer ([link](https://github.com/w3c/webauthn/wiki)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2199.html" title="Last updated on Nov 13, 2024, 9:13 PM UTC (5d74429)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2199/814e03a...5d74429.html" title="Last updated on Nov 13, 2024, 9:13 PM UTC (5d74429)">Diff</a>