### PR TITLE
Clarify behaviour of duplicate pubKeyCredParams and attestationFormats

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3554,7 +3554,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     :   <dfn>attestationFormats</dfn>
     ::  The [=[RP]=] MAY use this OPTIONAL member to specify a preference regarding the [=attestation=] statement format used by the [=authenticator=].
         Values SHOULD be taken from the IANA "WebAuthn Attestation Statement Format Identifiers" registry [[!IANA-WebAuthn-Registries]] established by [[!RFC8809]].
-        Values are ordered from most preferable to least preferable.
+        Values are ordered from most preferred to least preferred.
         Duplicates are allowed but effectively ignored.
         This parameter is advisory and the [=authenticator=] MAY use an attestation statement not enumerated in this parameter.
 

--- a/index.bs
+++ b/index.bs
@@ -3512,6 +3512,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     :   <dfn>pubKeyCredParams</dfn>
     ::  This member lists the key types and signature algorithms the [=[RP]=] supports,
         ordered from most preferred to least preferred.
+        Duplicates are allowed but effectively ignored.
         The [=client=] and [=authenticator=] make a best-effort to create a credential of the most preferred type possible.
         If none of the listed types can be created, the {{CredentialsContainer/create()}} operation fails.
 
@@ -3554,6 +3555,7 @@ optionally evidence of [=user consent=] to a specific transaction.
     ::  The [=[RP]=] MAY use this OPTIONAL member to specify a preference regarding the [=attestation=] statement format used by the [=authenticator=].
         Values SHOULD be taken from the IANA "WebAuthn Attestation Statement Format Identifiers" registry [[!IANA-WebAuthn-Registries]] established by [[!RFC8809]].
         Values are ordered from most preferable to least preferable.
+        Duplicates are allowed but effectively ignored.
         This parameter is advisory and the [=authenticator=] MAY use an attestation statement not enumerated in this parameter.
 
         The default value is the empty list, which indicates no preference.


### PR DESCRIPTION
Closes #2202.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2214.html" title="Last updated on Nov 27, 2024, 10:45 AM UTC (eb13ee1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2214/3bba180...eb13ee1.html" title="Last updated on Nov 27, 2024, 10:45 AM UTC (eb13ee1)">Diff</a>