### PR TITLE
Fix CDDL inconsistencies in attStmtType and compound format

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5736,7 +5736,7 @@ template:
 
 - <strong>Syntax:</strong>
     The syntax of an [=attestation statement=] produced in this format, defined using CDDL [[!RFC8610]] for the extension point
-    `$attStmtFormat` defined in [[#sctn-generating-an-attestation-object]].
+    `$$attStmtType` defined in [[#sctn-generating-an-attestation-object]].
 
 - <dfn>Signing procedure</dfn>:
     The [=signing procedure=] for computing an [=attestation statement=] in this [=attestation statement format|format=] given

--- a/index.bs
+++ b/index.bs
@@ -5832,17 +5832,17 @@ the [=authenticator=] MUST:
 
     ```
     attObj = {
-                authData: bytes,
-                $$attStmtType
-             }
+        authData: bytes,
 
-    attStmtTemplate = (
-                          fmt: text,
-                          attStmt: { * tstr => any } ; Map is filled in by each concrete attStmtType
-                      )
+        ; Each choice in $$attStmtType defines the fmt value and attStmt structure
+        $$attStmtType
+    } .within attStmtTemplate
 
-    ; Every attestation statement format must have the above fields
-    attStmtTemplate .within $$attStmtType
+    attStmtTemplate = {
+        authData: bytes,
+        fmt: text,
+        attStmt: { * tstr => any } ; Map is filled in by each concrete attStmtType
+    }
     ```
 
 ### Signature Formats for Packed Attestation, FIDO U2F Attestation, and Assertion Signatures ### {#sctn-signature-attestation-types}

--- a/index.bs
+++ b/index.bs
@@ -5841,7 +5841,11 @@ the [=authenticator=] MUST:
     attStmtTemplate = {
         authData: bytes,
         fmt: text,
-        attStmt: { * tstr => any } ; Map is filled in by each concrete attStmtType
+        attStmt: (
+          { * tstr => any } ; Map is filled in by each concrete attStmtType
+          //
+          [ * any ]         ; attStmt may also be an array
+        )
     }
     ```
 

--- a/index.bs
+++ b/index.bs
@@ -6933,7 +6933,7 @@ The "compound" attestation statement format is used to pass multiple, self-conta
                           attStmt: [2* nonCompoundAttStmt]
                       )
 
-    nonCompoundAttStmt = { $$attStmtType } .within { fmt: text .ne "compound" }
+    nonCompoundAttStmt = { $$attStmtType } .within { fmt: text .ne "compound", * any => any }
     ```
 
 : Signing procedure


### PR DESCRIPTION
Closes #2210. Also fixes a couple of other issues I noticed while working on this:

- [§6.5.2. Attestation Statement Formats](https://w3c.github.io/webauthn/#sctn-attestation-formats) refers to a CDDL extension point `$attStmtFormat` that (no longer?) exists, it should be `$$attStmtType`.
- The `.within { fmt: text .ne "compound" }` control on `nonCompoundAttStmt` inadvertently makes `nonCompoundAttStmt` unable to match anything, because maps are matched exhaustively (see [CDDL](https://datatracker.ietf.org/doc/html/rfc8610#section-2.1), so the right-hand-side of `.within` forbids additional fields beyond `fmt`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2216.html" title="Last updated on Nov 27, 2024, 12:37 PM UTC (8b29bec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2216/3bba180...8b29bec.html" title="Last updated on Nov 27, 2024, 12:37 PM UTC (8b29bec)">Diff</a>