### PR TITLE
Link "Object" to WebDriver instead of File API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -269,6 +269,7 @@ spec: SP800-800-63r3; urlPrefix: https://pages.nist.gov/800-63-3/sp800-63-3.html
 
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
+        text: Object; url: dfn-object
         text: WebDriver error; url: dfn-error
         text: WebDriver error code; url: dfn-error-code
         text: endpoint node; url: dfn-endpoint-node


### PR DESCRIPTION
Fixes #2212. As an additional correctness check, "FileAPI" no longer appears in the [links index](https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2218.html#index-defined-elsewhere) after this change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2218.html" title="Last updated on Dec 2, 2024, 3:33 PM UTC (8982a97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2218/3bba180...8982a97.html" title="Last updated on Dec 2, 2024, 3:33 PM UTC (8982a97)">Diff</a>