### PR TITLE
Fix AuthenticationExtensionsAuthenticatorInputs/Outputs CDDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4013,7 +4013,7 @@ This is a dictionary containing the [=client extension output=] values for zero 
 
 ```
 AuthenticationExtensionsAuthenticatorInputs = {
-  * $$extensionInput .within ( tstr => any )
+  * $$extensionInput .within { tstr => any }
 }
 ```
 
@@ -4028,7 +4028,7 @@ This type is not exposed to the [=[RP]=], but is used by the [=client=] and [=au
 
 ```
 AuthenticationExtensionsAuthenticatorOutputs = {
-  * $$extensionOutput .within ( tstr => any )
+  * $$extensionOutput .within { tstr => any }
 }
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -4013,8 +4013,8 @@ This is a dictionary containing the [=client extension output=] values for zero 
 
 ```
 AuthenticationExtensionsAuthenticatorInputs = {
-  * $$extensionInput .within { tstr => any }
-}
+  * $$extensionInput
+} .within { * tstr => any }
 ```
 
 The [=CDDL=] type `AuthenticationExtensionsAuthenticatorInputs` defines a [=CBOR=] map
@@ -4028,8 +4028,8 @@ This type is not exposed to the [=[RP]=], but is used by the [=client=] and [=au
 
 ```
 AuthenticationExtensionsAuthenticatorOutputs = {
-  * $$extensionOutput .within { tstr => any }
-}
+  * $$extensionOutput
+} .within { * tstr => any }
 ```
 
 The [=CDDL=] type `AuthenticationExtensionsAuthenticatorOutputs` defines a [=CBOR=] map


### PR DESCRIPTION
According to the [CDDL grammar](https://datatracker.ietf.org/doc/html/rfc8610#appendix-B), after a control operator (called `ctlop` in the grammar), there can only be a `type2` production. In a `type2` production, wrapping parentheses can only be used to wrap a `type` production. `tstr => any` is a `group` production. As such, unless I missed something, it cannot be wrapped in parentheses to produce a `type2` production. It rather needs to be wrapped in curly braces or brackets.

In other words, from a CDDL grammar perspective, this is an invalid type:
```cddl
foo .within ( tstr => any )
```

This is a valid type:
```cddl
foo .within { tstr => any }
```

This update fixes the CDDL type definitions that used the `.within` operator with an invalid type2.

I don't believe the change introduces any semantic change (so more an editorial update than anything else) but note I'm no CDDL expert, I just happened to have been playing with the CDDL grammar recently... If the semantics change, well, the problem still stands: the current definition is not valid CDDL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webauthn/pull/2219.html" title="Last updated on Dec 18, 2024, 5:30 PM UTC (a9b57fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2219/3bba180...tidoust:a9b57fa.html" title="Last updated on Dec 18, 2024, 5:30 PM UTC (a9b57fa)">Diff</a>