### PR TITLE
Fix AuthenticationExtensionsAuthenticatorInputs/Outputs CDDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4013,7 +4013,7 @@ This is a dictionary containing the [=client extension output=] values for zero 
 
 ```
 AuthenticationExtensionsAuthenticatorInputs = {
-  * $$extensionInput .within ( tstr => any )
+  * $$extensionInput .within { tstr => any }
 }
 ```
 
@@ -4028,7 +4028,7 @@ This type is not exposed to the [=[RP]=], but is used by the [=client=] and [=au
 
 ```
 AuthenticationExtensionsAuthenticatorOutputs = {
-  * $$extensionOutput .within ( tstr => any )
+  * $$extensionOutput .within { tstr => any }
 }
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -4013,8 +4013,8 @@ This is a dictionary containing the [=client extension output=] values for zero 
 
 ```
 AuthenticationExtensionsAuthenticatorInputs = {
-  * $$extensionInput .within { tstr => any }
-}
+  * $$extensionInput
+} .within { * tstr => any }
 ```
 
 The [=CDDL=] type `AuthenticationExtensionsAuthenticatorInputs` defines a [=CBOR=] map
@@ -4028,8 +4028,8 @@ This type is not exposed to the [=[RP]=], but is used by the [=client=] and [=au
 
 ```
 AuthenticationExtensionsAuthenticatorOutputs = {
-  * $$extensionOutput .within { tstr => any }
-}
+  * $$extensionOutput
+} .within { * tstr => any }
 ```
 
 The [=CDDL=] type `AuthenticationExtensionsAuthenticatorOutputs` defines a [=CBOR=] map


### PR DESCRIPTION
This is the combination of PR #2219 and the changes proposed in https://github.com/tidoust/webauthn/pull/1 . Merging this PR would effectively merge #2219 as well, and means we don't need to wait for @tidoust to review https://github.com/tidoust/webauthn/pull/1.

The issue is similar to the "proposed change 1" of #2210. I [recently had clarified on the CDDL mail list](https://mailarchive.ietf.org/arch/msg/cbor/lz2snfZHg0oGie8n04fcbCzkNFo/) that control operators only apply to types, not groups. @tidoust's PR #2219 fixes the right-hand side, but not the left-hand side. This PR completes the fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2221.html" title="Last updated on Dec 18, 2024, 3:30 PM UTC (5d855e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2221/3bba180...5d855e7.html" title="Last updated on Dec 18, 2024, 3:30 PM UTC (5d855e7)">Diff</a>