### PR TITLE
Address cross-origin create() in §5.10

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4535,7 +4535,12 @@ Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual pe
 ## Using Web Authentication within <code>iframe</code> elements ## {#sctn-iframe-guidance}
 
 The [=Web Authentication API=] is disabled by default in cross-origin <{iframe}>s.
-To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=]'s {{PublicKeyCredential/[DISCOVER-METHOD]}} method, specify the <{iframe/allow}> attribute on the <{iframe}> element and include the <code>[=publickey-credentials-get-feature|publickey-credentials-get=]</code> feature-identifier token in the <{iframe/allow}> attribute's value.
+To override this default policy and indicate that a cross-origin <{iframe}> is allowed to invoke the [=Web Authentication API=]'s
+{{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} methods,
+specify the <{iframe/allow}> attribute on the <{iframe}> element and include the
+<code>[=publickey-credentials-create-feature|publickey-credentials-create=]</code> or
+<code>[=publickey-credentials-get-feature|publickey-credentials-get=]</code>
+feature-identifier token, respectively, in the <{iframe/allow}> attribute's value.
 
 [=[RPS]=] utilizing the WebAuthn API in an embedded context should review [[#sctn-seccons-visibility]] regarding [=UI redressing=] and its possible mitigations.
 


### PR DESCRIPTION
As mentioned in https://github.com/w3c/webauthn/pull/2224#discussion_r1915219323 and issue #2229, this section needs to be updated to address cross-origin `create()` too.

Closes #2229.
