### PR TITLE
Add more to L3 revision history

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9893,6 +9893,7 @@ This section contains the substantive changes that have been made to this specif
 - Conditional mediation for create: [[#sctn-createCredential]]
 - Conditional mediation for get: [[#sctn-getAssertion]]
 - [[#sctn-getClientCapabilities]]
+    - [[#sctn-disclosing-client-capabilities]]
 - [[#sctn-signal-methods]]
 - New [=client data=] attribute {{CollectedClientData/topOrigin}}: [[#dictionary-client-data]]
 - [[#enum-hints]]

--- a/index.bs
+++ b/index.bs
@@ -9883,6 +9883,28 @@ This section contains the substantive changes that have been made to this specif
 
 ## Changes since Web Authentication Level 2 [[webauthn-2-20210408]] ## {#changes-since-l2}
 
+### Substantive Changes ### {#changes-l3-substantive}
+
+The following changes were made to the [=Web Authentication API=] and the way it operates.
+
+Changes:
+
+- Updated timeout guidance: [[#sctn-timeout-recommended-range]]
+- `uvm` extension no longer included; see instead L2 [[webauthn-2-20210408]]
+- [=authData/attestedCredentialData/aaguid=] in [=attested credential data=] is no longer zeroed
+    when {{PublicKeyCredentialCreationOptions/attestation}} preference is {{AttestationConveyancePreference/none}}: [[#sctn-createCredential]]
+
+
+Deprecations:
+
+- Registration parameter
+    <code>{{CredentialCreationOptions/publicKey}}.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialEntity/name}}</code>:
+    [[#dictionary-pkcredentialentity]]
+- [[#sctn-android-safetynet-attestation]]
+
+
+New features:
+
 - New JSON (de)serialization methods:
     - {{PublicKeyCredential/toJSON()}} method in [[#iface-pkcredential]]
     - [[#sctn-parseCreationOptionsFromJSON]]
@@ -9894,6 +9916,7 @@ This section contains the substantive changes that have been made to this specif
 - Conditional mediation for get: [[#sctn-getAssertion]]
 - [[#sctn-getClientCapabilities]]
     - [[#sctn-disclosing-client-capabilities]]
+- New enum value {{AuthenticatorTransport/hybrid}} in [[#enum-transport]].
 - [[#sctn-signal-methods]]
 - New [=client data=] attribute {{CollectedClientData/topOrigin}}: [[#dictionary-client-data]]
 - [[#enum-hints]]
@@ -9904,7 +9927,23 @@ This section contains the substantive changes that have been made to this specif
     - [[#sctn-automation-set-credential-properties]]
 - [[#sctn-compound-attestation]]
 - [[#prf-extension]]
-- Updated timeout guidance: [[#sctn-timeout-recommended-range]]
+
+
+### Editorial Changes ### {#changes-l3-editorial}
+
+The following changes were made to improve clarity, readability, navigability and similar aspects of the document.
+
+- Updated [[#sctn-use-cases]] to reflect developments in deployment landscape.
+- Introduced [=credential record=] concept to formalize what data [=[RPS]=] need to store
+    and how it relates between [=registration ceremony|registration=] and [=authentication ceremonies=].
+- Clarified error conditions:
+    - [[#sctn-create-request-exceptions]]
+    - [[#sctn-get-request-exceptions]]
+- [[#sctn-strings]] split into subsections [[#sctn-strings-truncation-client]] and [[#sctn-strings-truncation-authenticator]]
+    to clarify division of responsibilities.
+- Added [[#sctn-test-vectors]].
+- Moved normative language outside of "note" blocks.
+
 
 <pre class=biblio>
 {


### PR DESCRIPTION
(This is a meta-PR that would merge into PR #2224, not into main)

Adds some more of the changes made in L3. So far this is just from my recent memory and I've not yet gone through this exhaustively - for example there was a bunch of types changed from `USVString` to `DOMString` that I haven't yet taken the time to go through and add.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2232.html" title="Last updated on Jan 15, 2025, 1:59 PM UTC (de3d11a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2232/2c138b5...de3d11a.html" title="Last updated on Jan 15, 2025, 1:59 PM UTC (de3d11a)">Diff</a>