### PR TITLE
Backup preference 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4428,6 +4428,8 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
         "security-key",
         "client-device",
         "hybrid",
+        "backed-up",
+        "non-backed-up",
     };
 </xmp>
 
@@ -4453,6 +4455,12 @@ Note: The {{PublicKeyCredentialHint}} enumeration is deliberately not referenced
     ::  Indicates that the [=[RP]=] believes that users will satisfy this request with general-purpose [=authenticators=] such as smartphones. For example, a consumer [=[RP]=] may believe that only a small fraction of their customers possesses dedicated security keys. This option also implies that the local [=platform authenticator=] should not be promoted in the UI.
 
         For compatibility with older user agents, when this hint is used in {{PublicKeyCredentialCreationOptions}}, the {{AuthenticatorSelectionCriteria/authenticatorAttachment}} SHOULD be set to {{AuthenticatorAttachment/cross-platform}}.
+
+    :   <dfn>backed-up</dfn>
+    ::  Indicates that the [=[RP]=] prefers a [=backed up=] credential.
+
+    :   <dfn>non-backed-up</dfn>
+    ::  Indicates that the [=[RP]=] prefers a non [=backed up=] credential.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -4457,10 +4457,10 @@ Note: The {{PublicKeyCredentialHint}} enumeration is deliberately not referenced
         For compatibility with older user agents, when this hint is used in {{PublicKeyCredentialCreationOptions}}, the {{AuthenticatorSelectionCriteria/authenticatorAttachment}} SHOULD be set to {{AuthenticatorAttachment/cross-platform}}.
 
     :   <dfn>backed-up-cred</dfn>
-    ::  Indicates that the [=[RP]=] prefers a [=backed up=] credential.
+    ::  Indicates that the [=[RP]=] prefers a [=backed up=] credential during [=Registration=].
 
     :   <dfn>non-backed-up-cred</dfn>
-    ::  Indicates that the [=[RP]=] prefers a non [=backed up=] credential.
+    ::  Indicates that the [=[RP]=] prefers a non [=backed up=] credential during [=Registration=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -4428,8 +4428,8 @@ Note: The {{ClientCapability}} enumeration is deliberately not referenced, see [
         "security-key",
         "client-device",
         "hybrid",
-        "backed-up",
-        "non-backed-up",
+        "backed-up-cred,
+        "non-backed-up-cred",
     };
 </xmp>
 
@@ -4456,10 +4456,10 @@ Note: The {{PublicKeyCredentialHint}} enumeration is deliberately not referenced
 
         For compatibility with older user agents, when this hint is used in {{PublicKeyCredentialCreationOptions}}, the {{AuthenticatorSelectionCriteria/authenticatorAttachment}} SHOULD be set to {{AuthenticatorAttachment/cross-platform}}.
 
-    :   <dfn>backed-up</dfn>
+    :   <dfn>backed-up-cred</dfn>
     ::  Indicates that the [=[RP]=] prefers a [=backed up=] credential.
 
-    :   <dfn>non-backed-up</dfn>
+    :   <dfn>non-backed-up-cred</dfn>
     ::  Indicates that the [=[RP]=] prefers a non [=backed up=] credential.
 
 </div>


### PR DESCRIPTION
Closes #2252 

This PR provides a way for an RP to indicate their backup preference regarding the credential being created at registration time via PublicKeyCredentialHint.

Note: Given the nature of different options provided by the providers/authenticators, their capabilities, user choices etc., RP must expect both backed-up and non-backed-up credentials in the registration responses.