### PR TITLE
Handle Bikeshed 5.0.3

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -77,7 +77,7 @@ Abstract: This specification defines an API enabling the creation and use of str
  specification also describes the functional model for WebAuthn conformant [=authenticators=], including their signature and
  [=attestation=] functionality.
 Boilerplate: omit conformance, omit feedback-header, omit abstract-header
-Markup Shorthands: css off, markdown on
+Markup Shorthands: css off, markdown on, macros-in-autolinks yes
 Implementation Report: https://www.w3.org/2020/12/webauthn-report.html
 </pre>
 


### PR DESCRIPTION
Using macros inside of autolinks previously worked only accidentally; I made it work *explicitly* in Bikeshed 5.0. I've since walked back that decision, and put it behind a pref in 5.0.3.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tabatkins/webauthn/pull/2254.html" title="Last updated on Feb 4, 2025, 5:19 PM UTC (89ba883)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2254/315d68c...tabatkins:89ba883.html" title="Last updated on Feb 4, 2025, 5:19 PM UTC (89ba883)">Diff</a>