### PR TITLE
Add a new optional `rpId` to Credential Record

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6042,6 +6042,9 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
             :   [$credential record/attestationClientDataJSON$]
             ::  <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code>.
+
+            :   [$credential record/rpId$]
+            ::  <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
         </dl>
 
         The [=[RP]=] MAY also include any additional [=struct/items=] as necessary.

--- a/index.bs
+++ b/index.bs
@@ -1127,6 +1127,12 @@ BCP 14 [[!RFC2119]] [[!RFC8174]] when, and only when, they appear in all capital
             when the [=public key credential source=] was [=registration|registered=].
             Storing this in combination with the above [$credential record/attestationObject$] [=struct/item=]
             enables the [=[RP]=] to re-verify the [=attestation signature=] at a later time.
+        
+        :   <dfn>rpId</dfn>
+        ::  The value of the <code>{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code> parameter
+            specified in the {{CredentialsContainer/create()}} operation during credential registration.
+            Storing this enables the [=[RP]=] to use the credential across different domains later
+            via [[#sctn-related-origins|Related Origins]].
     </dl>
 
     [=WebAuthn extensions=] MAY define additional [=struct/items=] needed to process the extension.


### PR DESCRIPTION
Closes #2257

This PR adds `rpId` to Credential Record. This optional field is defined to try and help guide RPs, that wish to use Related Origins, to store values that will streamline adoption of the feature.