### PR TITLE
Backup Preference Option for providers who support both backed-up and non-backed up credential

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2001,6 +2001,10 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                         </dl>
 
+                1. If Authenticator supports creating both [=backup eligible=] and non [=backup eligible=] credentials and
+                     if <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/backupPreference}}</code> is present, present user
+                     with a choice of whether it wants to create a [=backup eligible=] credential or not appropriately.
+
                 1. Let |enterpriseAttestationPossible| be a Boolean value, as follows. If
                     <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/attestation}}</code>
 
@@ -2919,6 +2923,7 @@ value and terminate the operation.
         DOMString                                               attestation = "none";
         sequence<DOMString>                                     attestationFormats = [];
         AuthenticationExtensionsClientInputsJSON                extensions;
+        DOMString                                               backupPreference = "preferred";
     };
 
     dictionary PublicKeyCredentialUserEntityJSON {
@@ -3829,6 +3834,31 @@ Note: The {{AttestationConveyancePreference}} enumeration is deliberately not re
         If permitted, the user agent SHOULD signal to the authenticator (at [invocation time](#CreateCred-InvokeAuthnrMakeCred)) that enterprise attestation is requested, and convey the resulting [=/AAGUID=] and [=attestation statement=], unaltered, to the [=[RP]=].
 </div>
 
+### <dfn>Backup Preference</dfn> Preference Enumeration (enum <dfn enum>BackupPreference</dfn>) ### {#enum-backup-preference}
+
+[=[WRPS]=] may use {{BackupPreference}} to specify their preference regarding [=Backup Eligibility=]
+during credential generation.
+
+<xmp class="idl">
+    enum BackupPreference {
+        "discouraged",
+        "preferred"
+    };
+</xmp>
+
+Note: The {{BackupPreference}} enumeration is deliberately not referenced, see [[#sct-domstring-backwards-compatibility]].
+
+<div dfn-type="enum-value" dfn-for="BackupPreference">
+    :   <dfn>discouraged</dfn>
+    ::  The [=[RP]=] prefers creating a non [=backup eligible=] credential, but will accept a
+        [=backup eligible=] credential.
+
+    :   <dfn>preferred</dfn>
+    ::  The [=[RP]=] prefers creating a [=backup eligible=] credential, but will accept a non
+        [=backup eligible=] credential.
+
+        This is the default, and unknown values fall back to the behavior of this value.
+</div>
 
 ## Options for Assertion Generation (dictionary <dfn dictionary>PublicKeyCredentialRequestOptions</dfn>) ## {#dictionary-assertion-options}
 


### PR DESCRIPTION
Closes #2252 

This PR provides a way for an RP to indicate their backup preference regarding the credential being created at registration time.

Note: Given the nature of different options provided by the providers/authenticators, their capabilities, user choices etc., RP must expect both backed-up and non-backed-up credentials in the registration responses.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/akshayku/webauthn/pull/2259.html" title="Last updated on Feb 12, 2025, 1:35 PM UTC (3e6c782)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2259/34d93ac...akshayku:3e6c782.html" title="Last updated on Feb 12, 2025, 1:35 PM UTC (3e6c782)">Diff</a>