### PR TITLE
Fix test vectors heading levels

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9085,7 +9085,7 @@ attestation_ca_cert = h'30820207308201ada003020102021100ed7f905d8bd0b414d1784913
 </xmp>
 
 
-### ES256 Credential with No Attestation ### {#sctn-test-vectors-none-es256}
+## ES256 Credential with No Attestation ## {#sctn-test-vectors-none-es256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9119,7 +9119,7 @@ signature = h'3046022100f50a4e2e4409249c4a853ba361282f09841df4dd4547a13a87780218
 </xmp>
 
 
-### ES256 Credential with Self Attestation ### {#sctn-test-vectors-packed-self-es256}
+## ES256 Credential with Self Attestation ## {#sctn-test-vectors-packed-self-es256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9154,7 +9154,7 @@ signature = h'3044022076691be76a8618976d9803c4cdc9b97d34a7af37e3bdc894a2bf54f040
 </xmp>
 
 
-### ES256 Credential with "crossOrigin": true in clientDataJSON ### {#sctn-test-vectors-none-es256-crossOrigin}
+## ES256 Credential with "crossOrigin": true in clientDataJSON ## {#sctn-test-vectors-none-es256-crossOrigin}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9189,7 +9189,7 @@ signature = h'304402204396b14b216ed47920dc359e46aa0a1d4a912cf9d50f25a58ec236a11d
 </xmp>
 
 
-### ES256 Credential with "topOrigin" in clientDataJSON ### {#sctn-test-vectors-none-es256-topOrigin}
+## ES256 Credential with "topOrigin" in clientDataJSON ## {#sctn-test-vectors-none-es256-topOrigin}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9223,7 +9223,7 @@ signature = h'304402206a19613fa8cfacfc8027272aec5dae3555fea9f983d841581466678d71
 </xmp>
 
 
-### ES256 Credential with very long credential ID ### {#sctn-test-vectors-none-es256-long-credential-id}
+## ES256 Credential with very long credential ID ## {#sctn-test-vectors-none-es256-long-credential-id}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9256,7 +9256,7 @@ signature = h'304502203ecef83fb12a0cae7841055f9f87103a99fd14b424194bbf06c4623d3e
 </xmp>
 
 
-### Packed Attestation with ES256 Credential ### {#sctn-test-vectors-packed-es256}
+## Packed Attestation with ES256 Credential ## {#sctn-test-vectors-packed-es256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9293,7 +9293,7 @@ signature = h'30460221009d8d54895393894d37b9fa7bdfbcff05403de3cf0d6443ffb394fa23
 </xmp>
 
 
-### Packed Attestation with ES384 Credential ### {#sctn-test-vectors-packed-es384}
+## Packed Attestation with ES384 Credential ## {#sctn-test-vectors-packed-es384}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9328,7 +9328,7 @@ signature = h'3065023100e4efbb46745ed00e67c4d51ab2bacab2af62ffa8b7c5fecec6d7d9bf
 </xmp>
 
 
-### Packed Attestation with ES512 Credential ### {#sctn-test-vectors-packed-es512}
+## Packed Attestation with ES512 Credential ## {#sctn-test-vectors-packed-es512}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9364,7 +9364,7 @@ signature = h'3081870242009bda02fe384e77bcb9fb42b07c395b7a53ec9d9616dd0308ab8495
 </xmp>
 
 
-### Packed Attestation with RS256 Credential ### {#sctn-test-vectors-packed-rs256}
+## Packed Attestation with RS256 Credential ## {#sctn-test-vectors-packed-rs256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9401,7 +9401,7 @@ signature = h'01063d52d7c39b4d432fc7063c5d93e582bdcb16889cd71f888d67d880ea730a42
 </xmp>
 
 
-### Packed Attestation with Ed25519 Credential ### {#sctn-test-vectors-packed-ed25519}
+## Packed Attestation with Ed25519 Credential ## {#sctn-test-vectors-packed-ed25519}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9437,7 +9437,7 @@ signature = h'4c873571377ac019f257d6bf07249f63ac2487483c51bc511ce0f0e3266c840cb0
 </xmp>
 
 
-### TPM Attestation with ES256 Credential ### {#sctn-test-vectors-tpm-es256}
+## TPM Attestation with ES256 Credential ## {#sctn-test-vectors-tpm-es256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9472,7 +9472,7 @@ signature = h'3045022060dc76b1607ec716c6e5eba8d056695ed6bc47b2e3d7a729c34e759e3a
 </xmp>
 
 
-### Android Key Attestation with ES256 Credential ### {#sctn-test-vectors-android-key-es256}
+## Android Key Attestation with ES256 Credential ## {#sctn-test-vectors-android-key-es256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9508,7 +9508,7 @@ signature = h'304502202060107d953b286aa1bf35e3e8c78b383fddab5591b2db17ffb23ed83f
 </xmp>
 
 
-### Apple Anonymous Attestation with ES256 Credential ### {#sctn-test-vectors-apple-es256}
+## Apple Anonymous Attestation with ES256 Credential ## {#sctn-test-vectors-apple-es256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">
@@ -9543,7 +9543,7 @@ signature = h'3046022100ee35db795ce28044e1f8231d68b3d79a9882f7415aa35c1b5ac74d24
 </xmp>
 
 
-### FIDO U2F Attestation with ES256 Credential ### {#sctn-test-vectors-fido-u2f-es256}
+## FIDO U2F Attestation with ES256 Credential ## {#sctn-test-vectors-fido-u2f-es256}
 
 [=registration ceremony|Registration=]:
 <xmp class="example" highlight="cddl">


### PR DESCRIPTION
These were subsections of "Attestation trust root certificate", which does not seem appropriate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2261.html" title="Last updated on Feb 20, 2025, 3:57 PM UTC (559de50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2261/f616b28...559de50.html" title="Last updated on Feb 20, 2025, 3:57 PM UTC (559de50)">Diff</a>