### PR TITLE
chore: Fix issue template contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,9 @@
 
 blank_issues_enabled: false
 contact_links:
-  - name: Developer-related questions for implementing passkeys
+  - name: Passkeys Developer Discussions
     url: https://passkeys.dev/discuss
+	about: A discussion forum for developer-related questions around implementing passkeys
   - name: FIDO2 Deployment or Implementation Question
     url: https://groups.google.com/a/fidoalliance.org/g/fido-dev
     about: Please use the FIDO-DEV list/group to ask questions about FIDO2 deployment and implementations


### PR DESCRIPTION
Previous update didn't seem to apply (passkeys discussion item doesn't appear in the list)