### PR TITLE
Remove outdated notes about permissions policy on `isUVPAA()` and `getCC()`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2840,7 +2840,6 @@ This method has no arguments and returns a Boolean value.
     };
 </xmp>
 
-Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=permissions policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-permissions-policy]].
 
 </div>
 
@@ -2874,8 +2873,6 @@ The set of [=map/keys=] SHOULD also contain a key for each [extension](#sctn-ext
 
 Note that even if an extension is mapped to [TRUE], the authenticator used for any given operation may not support that extension,
 so [=[RPS]=] MUST NOT assume that the authenticator processing steps for that extension will be performed on that basis.
-
-Note: Invoking this method from a [=browsing context=] where the [=Web Authentication API=] is "disabled" according to the [=allowed to use=] algorithm&mdash;i.e., by a [=permissions policy=]&mdash;will result in the promise being rejected with a {{DOMException}} whose name is "{{NotAllowedError}}". See also [[#sctn-permissions-policy]].
 
 </div>
 


### PR DESCRIPTION
Closes #2251.

This PR removes outdated notes about the potential for permissions policy to cause the following methods to become unavailable and raise specific errors accordingly:

- `isUserVerifyingPlatformAuthenticator()`
- `getClientCapabilities()`

This PR can be considered editorial for L3 because 1) no browser currently imposes such restrictions on the use of `isUVPAA()`, and 2) `getCC()` is being introduced in L3 and has not had any such restrictions imposed on its use.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2267.html" title="Last updated on Feb 26, 2025, 8:06 PM UTC (425cfab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2267/e461bfa...425cfab.html" title="Last updated on Feb 26, 2025, 8:06 PM UTC (425cfab)">Diff</a>