### PR TITLE
Fix PublicKeyCredentialDescriptor attribute name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2484,7 +2484,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
                     1. Set <code>|publicKeyOptions|.{{PublicKeyCredentialRequestOptions/allowCredentials}}</code> to be a [=list=] containing a
                         single {{PublicKeyCredentialDescriptor}} [=list/item=] whose {{PublicKeyCredentialDescriptor/id}}'s value is set to
-                        |credentialMetadata|'s [=DiscoverableCredentialMetadata/id=]'s value and whose{{PublicKeyCredentialDescriptor/id}}
+                        |credentialMetadata|'s [=DiscoverableCredentialMetadata/id=]'s value and whose {{PublicKeyCredentialDescriptor/type}}
                         value is set to |credentialMetadata|'s [=DiscoverableCredentialMetadata/type=].
 
                     1. Execute the [=issuing a credential request to an authenticator=] algorithm with |authenticator|, |savedCredentialIds|,


### PR DESCRIPTION
Fixes the PublicKeyCredentialDescriptor attribute name to read `type` instead of `id`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/joostd/webauthn/pull/2273.html" title="Last updated on Mar 11, 2025, 1:09 PM UTC (7ad6614)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2273/e461bfa...joostd:7ad6614.html" title="Last updated on Mar 11, 2025, 1:09 PM UTC (7ad6614)">Diff</a>