### PR TITLE
Fix number of PRFs in AuthenticationExtensionsPRFOutputs.enabled description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7480,7 +7480,7 @@ Note: This extension may be implemented for [=authenticators=] that do not use [
 
     <div dfn-type="dict-member" dfn-for="AuthenticationExtensionsPRFOutputs">
         :   <dfn>enabled</dfn>
-        ::  [TRUE] if, and only if, the one or two PRFs are available for use with the created credential. This is only reported during [=registration=] and is not present in the case of [=authentication=].
+        ::  [TRUE] if, and only if, the PRF is available for use with the created credential. This is only reported during [=registration=] and is not present in the case of [=authentication=].
 
         :   <dfn>results</dfn>
         ::  The results of evaluating the PRF for the inputs given in {{AuthenticationExtensionsPRFInputs/eval}} or {{AuthenticationExtensionsPRFInputs/evalByCredential}}. Outputs may not be available during [=registration=]; see comments in {{AuthenticationExtensionsPRFInputs/eval}}.


### PR DESCRIPTION
The description of [`AuthenticationExtensionsPRFOutputs.enabled`](https://w3c.github.io/webauthn/#dom-authenticationextensionsprfoutputs-enabled) incorrectly reads "one or two PRFs":

>**_enabled_, of type [boolean](https://webidl.spec.whatwg.org/#idl-boolean)**
>`true` if, and only if, the one or two PRFs are available for use with the created credential. This is only reported during [registration](https://w3c.github.io/webauthn/#registration) and is not present in the case of [authentication](https://w3c.github.io/webauthn/#authentication).

This is likely a forgotten remnant from before PR #1836.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2277.html" title="Last updated on Mar 31, 2025, 9:40 AM UTC (cddb53a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2277/ea670c3...cddb53a.html" title="Last updated on Mar 31, 2025, 9:40 AM UTC (cddb53a)">Diff</a>