### PR TITLE
Fix Bikeshed lint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -247,6 +247,7 @@ spec: RFC8610; urlPrefix: https://tools.ietf.org/html/rfc8610
 <pre class="link-defaults">
 spec:credential-management; type:dfn; text:credentials
 spec:dom; type:dfn; for:/; text:document
+spec:html; type:dfn; text:allowed to use
 spec:html; type:dfn; for:environment settings object; text:global object
 spec:html; type:dfn; for:/; text:same site
 spec:infra; type:dfn; for:/; text:set

--- a/index.bs
+++ b/index.bs
@@ -2255,7 +2255,7 @@ decline the entire interaction even if a [=public key credential source=] is pre
 [=credential=].
 
 The {{CredentialsContainer/get()|navigator.credentials.get()}} implementation [[!CREDENTIAL-MANAGEMENT-1]] calls
-<code>PublicKeyCredential.{{PublicKeyCredential/[[CollectFromCredentialStore]]()}}</code> to collect any [=credentials=] that
+<code>PublicKeyCredential.{{Credential/[[CollectFromCredentialStore]]()}}</code> to collect any [=credentials=] that
 should be available without [=user mediation=] (roughly, this specification's [=authorization gesture=]), and if it does not find
 exactly one of those, it then calls <code>PublicKeyCredential.{{PublicKeyCredential/[DISCOVER-METHOD]}}</code> to have
 the user select a [=public key credential source=].


### PR DESCRIPTION
Fixes these Bikeshed lints:

- ```
  LINE 4469:1: Multiple possible 'allowed to use' dfn refs.
  Arbitrarily chose https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use
  To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
  spec:html; type:dfn; text:allowed to use
  spec:private-aggregation-api; type:dfn; text:allowed to use
  [=allowed to use=]
  LINE 4471:65: Multiple possible 'allowed to use' dfn refs.
  Arbitrarily chose https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use
  To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
  spec:html; type:dfn; text:allowed to use
  spec:private-aggregation-api; type:dfn; text:allowed to use
  [=allowed to use=]
  ```
- ```
  LINE 2258:27: No 'idl' refs found for '[[CollectFromCredentialStore]]()' with for='['PublicKeyCredential']'.
  {{PublicKeyCredential/[[CollectFromCredentialStore]]()}}
  ```
  (This is because `PublicKeyCredential` doesn't define its own `CollectFromCredentialStore`, instead inheriting it from `Credential`.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2279.html" title="Last updated on Apr 3, 2025, 2:45 PM UTC (4655be0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2279/1745d5f...4655be0.html" title="Last updated on Apr 3, 2025, 2:45 PM UTC (4655be0)">Diff</a>