### PR TITLE
Add JSON partial dictionaries for extensions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7204,6 +7204,9 @@ but the currently used [=RP ID=] might be "example.com".
     partial dictionary AuthenticationExtensionsClientInputs {
       DOMString appid;
     };
+    partial dictionary AuthenticationExtensionsClientInputsJSON {
+      DOMString appid;
+    };
     </xmp>
 
 : Client extension processing
@@ -7237,6 +7240,9 @@ Instead, in step three, the comparison on the host is relaxed to accept hosts on
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean appid;
     };
+    partial dictionary AuthenticationExtensionsClientOutputsJSON {
+      boolean appid;
+    };
     </xmp>
 
 : Authenticator extension input
@@ -7265,6 +7271,9 @@ During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a popu
 :: A single DOMString specifying a FIDO |AppID|.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientInputs {
+      DOMString appidExclude;
+    };
+    partial dictionary AuthenticationExtensionsClientInputsJSON {
       DOMString appidExclude;
     };
     </xmp>
@@ -7323,6 +7332,9 @@ During a transition from the FIDO U2F JavaScript API, a [=[RP]=] may have a popu
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean appidExclude;
     };
+    partial dictionary AuthenticationExtensionsClientOutputsJSON {
+      boolean appidExclude;
+    };
     </xmp>
 
 : Authenticator extension input
@@ -7354,6 +7366,9 @@ At this time, one [=credential property=] is defined: the [=client-side discover
     partial dictionary AuthenticationExtensionsClientInputs {
         boolean credProps;
     };
+    partial dictionary AuthenticationExtensionsClientInputsJSON {
+        boolean credProps;
+    };
     </xmp>
 
 : Client extension processing
@@ -7370,6 +7385,9 @@ At this time, one [=credential property=] is defined: the [=client-side discover
     };
 
     partial dictionary AuthenticationExtensionsClientOutputs {
+        CredentialPropertiesOutput credProps;
+    };
+    partial dictionary AuthenticationExtensionsClientOutputsJSON {
         CredentialPropertiesOutput credProps;
     };
     </xmp>
@@ -7421,14 +7439,25 @@ Note: This extension may be implemented for [=authenticators=] that do not use [
         required BufferSource first;
         BufferSource second;
     };
+    dictionary AuthenticationExtensionsPRFValuesJSON {
+        required Base64URLString first;
+        Base64URLString second;
+    };
 
     dictionary AuthenticationExtensionsPRFInputs {
         AuthenticationExtensionsPRFValues eval;
         record<DOMString, AuthenticationExtensionsPRFValues> evalByCredential;
     };
+    dictionary AuthenticationExtensionsPRFInputsJSON {
+        AuthenticationExtensionsPRFValuesJSON eval;
+        record<DOMString, AuthenticationExtensionsPRFValuesJSON> evalByCredential;
+    };
 
     partial dictionary AuthenticationExtensionsClientInputs {
         AuthenticationExtensionsPRFInputs prf;
+    };
+    partial dictionary AuthenticationExtensionsClientInputsJSON {
+        AuthenticationExtensionsPRFInputsJSON prf;
     };
     </xmp>
 
@@ -7473,9 +7502,16 @@ Note: This extension may be implemented for [=authenticators=] that do not use [
         boolean enabled;
         AuthenticationExtensionsPRFValues results;
     };
+    dictionary AuthenticationExtensionsPRFOutputsJSON {
+        boolean enabled;
+        AuthenticationExtensionsPRFValuesJSON results;
+    };
 
     partial dictionary AuthenticationExtensionsClientOutputs {
         AuthenticationExtensionsPRFOutputs prf;
+    };
+    partial dictionary AuthenticationExtensionsClientOutputsJSON {
+        AuthenticationExtensionsPRFOutputsJSON prf;
     };
     </xmp>
 
@@ -7526,6 +7562,9 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
     partial dictionary AuthenticationExtensionsClientInputs {
         AuthenticationExtensionsLargeBlobInputs largeBlob;
     };
+    partial dictionary AuthenticationExtensionsClientInputsJSON {
+        AuthenticationExtensionsLargeBlobInputsJSON largeBlob;
+    };
 
     enum LargeBlobSupport {
       "required",
@@ -7536,6 +7575,11 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
         DOMString support;
         boolean read;
         BufferSource write;
+    };
+    dictionary AuthenticationExtensionsLargeBlobInputsJSON {
+        DOMString support;
+        boolean read;
+        Base64URLString write;
     };
     </xmp>
 
@@ -7591,10 +7635,18 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
     partial dictionary AuthenticationExtensionsClientOutputs {
         AuthenticationExtensionsLargeBlobOutputs largeBlob;
     };
+    partial dictionary AuthenticationExtensionsClientOutputsJSON {
+        AuthenticationExtensionsLargeBlobOutputsJSON largeBlob;
+    };
 
     dictionary AuthenticationExtensionsLargeBlobOutputs {
         boolean supported;
         ArrayBuffer blob;
+        boolean written;
+    };
+    dictionary AuthenticationExtensionsLargeBlobOutputsJSON {
+        boolean supported;
+        Base64URLString blob;
         boolean written;
     };
     </xmp>


### PR DESCRIPTION
Fixes #1968.

<!-- Remove the following for non-normative changes -->

The following tasks have been completed:

- [x] (Already covered) Modified Web platform tests:
  - [`public-key-credential-creation-options-from-json.https.window.js`](https://github.com/web-platform-tests/wpt/blob/5d324f76a978e2902906a29e32c5089f725ac5b2/webauthn/public-key-credential-creation-options-from-json.https.window.js#L103)
  - [`public-key-credential-request-options-from-json.https.window.js`](https://github.com/web-platform-tests/wpt/blob/5d324f76a978e2902906a29e32c5089f725ac5b2/webauthn/public-key-credential-request-options-from-json.https.window.js#L48)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2284.html" title="Last updated on Apr 25, 2025, 2:56 PM UTC (43972a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2284/43b55de...43972a4.html" title="Last updated on Apr 25, 2025, 2:56 PM UTC (43972a4)">Diff</a>