### PR TITLE
add `cable` to `AuthenticatorTransport`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4278,7 +4278,8 @@ and mirrors some fields of the {{PublicKeyCredential}} object returned by
         "ble",
         "smart-card",
         "hybrid",
-        "internal"
+        "internal",
+        "cable"
     };
 </xmp>
 


### PR DESCRIPTION
Fixes #2286.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zacknewman/webauthn/pull/2287.html" title="Last updated on Apr 27, 2025, 9:54 PM UTC (258e3f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2287/43b55de...zacknewman:258e3f2.html" title="Last updated on Apr 27, 2025, 9:54 PM UTC (258e3f2)">Diff</a>