### PR TITLE
Add `attestationFormats` to the list of new features since L2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9953,6 +9953,8 @@ New features:
     - [[#sctn-automation-set-credential-properties]]
 - [[#sctn-compound-attestation]]
 - [[#prf-extension]]
+- New {{PublicKeyCredentialCreationOptions/attestationFormats}} option to request specific
+  attestation statement formats during a [=registration ceremony=]
 
 
 ### Editorial Changes ### {#changes-l3-editorial}

--- a/index.bs
+++ b/index.bs
@@ -9953,8 +9953,9 @@ New features:
     - [[#sctn-automation-set-credential-properties]]
 - [[#sctn-compound-attestation]]
 - [[#prf-extension]]
-- New {{PublicKeyCredentialCreationOptions/attestationFormats}} option to request specific
-  attestation statement formats during a [=registration ceremony=]
+- Registration parameter
+    <code>{{CredentialCreationOptions/publicKey}}.{{PublicKeyCredentialCreationOptions/attestationFormats}}</code>:
+    [[#dictionary-makecredentialoptions]]
 
 
 ### Editorial Changes ### {#changes-l3-editorial}


### PR DESCRIPTION
This PR adds `attestationFormats` to the list of changes since L2.

Closes #2268.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2292.html" title="Last updated on May 7, 2025, 6:13 PM UTC (9037c73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2292/06dfbc8...9037c73.html" title="Last updated on May 7, 2025, 6:13 PM UTC (9037c73)">Diff</a>