### PR TITLE
Generalize PRF extension processing to non-CTAP authenticators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7518,8 +7518,8 @@ but also cannot be deleted by the client since the [=authenticator data=] is sig
        1. If the authenticator does not support the CTAP2 `hmac-secret` extension [[FIDO-CTAP]],
             but does support some other implementation compatible with the abstract authenticator processing defined below:
           1. Set {{AuthenticationExtensionsPRFOutputs/enabled}} to [TRUE].
-          1. If {{AuthenticationExtensionsPRFInputs/eval}} is present,
-              use some unspecified mechanism to convey {{AuthenticationExtensionsPRFInputs/eval}} to the authenticator as the inputs to evaluate the PRF on.
+          1. If |salt1| is defined, use some unspecified mechanism to convey |salt1| and,
+              if defined, |salt2| to the authenticator as PRF inputs, in that order.
           1. Use some unspecified mechanism to receive the PRF outputs from the authenticator.
               Set <code>{{AuthenticationExtensionsPRFOutputs/results}}</code> to the evaluation results, if any.
 


### PR DESCRIPTION
Fixes #2285.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2298.html" title="Last updated on Jun 13, 2025, 1:30 PM UTC (e75c208)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2298/3bcf9d5...e75c208.html" title="Last updated on Jun 13, 2025, 1:30 PM UTC (e75c208)">Diff</a>