### PR TITLE
Add change history since Level 3 Working Draft 2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9999,7 +9999,7 @@ The following changes were made to the [=Web Authentication API=] and the way it
 Changes:
 
 - Updated timeout guidance: [[#sctn-timeout-recommended-range]]
-- `uvm` extension no longer included; see instead L2 [[webauthn-2-20210408]]
+- `uvm` extension no longer included; see instead L2 [[webauthn-2-20210408]].
 - [=authData/attestedCredentialData/aaguid=] in [=attested credential data=] is no longer zeroed
     when {{PublicKeyCredentialCreationOptions/attestation}} preference is {{AttestationConveyancePreference/none}}: [[#sctn-createCredential]]
 


### PR DESCRIPTION
This might be helpful since [Working Draft 2](https://www.w3.org/TR/2025/WD-webauthn-3-20250127/) is the version currently out for wide review (as far as I understand). Feel free to close if this is a bad idea.

If this is merged before #2298 or #2280, then those PRs should be updated to add to this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2301.html" title="Last updated on Jun 12, 2025, 9:25 AM UTC (17d5b9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2301/3bcf9d5...17d5b9f.html" title="Last updated on Jun 12, 2025, 9:25 AM UTC (17d5b9f)">Diff</a>