### PR TITLE
Fix COSEAlgorithmIdentifier in section 5.4

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3479,7 +3479,7 @@ optionally evidence of [=user consent=] to a specific transaction.
 
         [=[RPS]=] that wish to support a wide range of [=authenticators=] SHOULD include at least the following {{COSEAlgorithmIdentifier}} values:
 
-        * -8 (Ed25519)
+        * -8 (EdDSA)
         * -7 (ES256)
         * -257 (RS256)
 


### PR DESCRIPTION
This PR fixes the description for `pubKeyCredParams` in section 5.4. The number `-8` does not identify the `Ed25519` algorithm but `EdDSA` (see the [IANA document](https://www.iana.org/assignments/cose/cose.xhtml#algorithms)).
`Ed25519` has number -19.