### PR TITLE
Consistently refer to COSE IDs as "int (name)" instead of "name (int)"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3488,10 +3488,10 @@ optionally evidence of [=user consent=] to a specific transaction.
         The following {{COSEAlgorithmIdentifier}} values are NOT RECOMMENDED
         in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}}:
 
-        * -9 (ESP256); use ES256 (-7) instead or in addition.
-        * -51 (ESP384); use ES384 (-35) instead or in addition.
-        * -52 (ESP512); use ES512 (-36) instead or in addition.
-        * -19 (Ed25519); use EdDSA (-8) instead or in addition.
+        * -9 (ESP256); use -7 (ES256) instead or in addition.
+        * -51 (ESP384); use -35 (ES384) instead or in addition.
+        * -52 (ESP512); use -36 (ES512) instead or in addition.
+        * -19 (Ed25519); use -8 (EdDSA) instead or in addition.
 
         Note: Within WebAuthn, the values -9 (ESP256), -51 (ESP384), -52 (ESP512) and -19 (Ed25519)
         represent the same thing respectively as -7 (ES256), -35 (ES384), -36 (ES512) and -8 (EdDSA)
@@ -4341,13 +4341,13 @@ Note: The {{AuthenticatorTransport}} enumeration is deliberately not referenced,
     for instance, <code>-7</code> for "ES256" and <code>-257</code> for "RS256".
 
     The COSE algorithms registry leaves degrees of freedom to be specified by other parameters in a [=COSE key=]. In order to promote interoperability, this specification makes the following additional guarantees of [=credential public keys=]:
-        1. Keys with algorithm ES256 (-7) MUST specify P-256 (1) as the [=crv=] parameter and MUST NOT use the compressed point form.
-        1. Keys with algorithm ESP256 (-9) MUST NOT use the compressed point form.
-        1. Keys with algorithm ES384 (-35) MUST specify P-384 (2) as the [=crv=] parameter and MUST NOT use the compressed point form.
-        1. Keys with algorithm ESP384 (-51) MUST NOT use the compressed point form.
-        1. Keys with algorithm ES512 (-36) MUST specify P-521 (3) as the [=crv=] parameter and MUST NOT use the compressed point form.
-        1. Keys with algorithm ESP512 (-52) MUST NOT use the compressed point form.
-        1. Keys with algorithm EdDSA (-8) MUST specify Ed25519 (6) as the [=crv=] parameter. (These always use a compressed form in COSE.)
+        1. Keys with algorithm -7 (ES256) MUST specify 1 (P-256) as the [=crv=] parameter and MUST NOT use the compressed point form.
+        1. Keys with algorithm -9 (ESP256) MUST NOT use the compressed point form.
+        1. Keys with algorithm -35 (ES384) MUST specify 2 (P-384) as the [=crv=] parameter and MUST NOT use the compressed point form.
+        1. Keys with algorithm -51 (ESP384) MUST NOT use the compressed point form.
+        1. Keys with algorithm -36 (ES512) MUST specify 3 (P-521) as the [=crv=] parameter and MUST NOT use the compressed point form.
+        1. Keys with algorithm -52 (ESP512) MUST NOT use the compressed point form.
+        1. Keys with algorithm -8 (EdDSA) MUST specify 6 (Ed25519) as the [=crv=] parameter. (These always use a compressed form in COSE.)
 
     These restrictions align with the recommendation in [=Section 2.1=] of [[!RFC9053]].
 </div>


### PR DESCRIPTION
Currently there's a mix of referring to the number or the name first. Since WebAuthn is COSE centric, this PR changes to consistently referring to the number first.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2305.html" title="Last updated on Jun 16, 2025, 10:23 AM UTC (c8490b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2305/3e3cfc3...c8490b1.html" title="Last updated on Jun 16, 2025, 10:23 AM UTC (c8490b1)">Diff</a>