### PR TITLE
Clarify that DER lengths vary with INTEGER magnitude and curve size

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5847,13 +5847,14 @@ the [=authenticator=] MUST:
         ```
         Example:
         Note: Encoding lengths vary with INTEGER magnitude and curve size.
-        30 44                                ; SEQUENCE (68 Bytes)
+        30 45                                ; SEQUENCE (69 Bytes)
             02 20                            ; INTEGER (32 Bytes)
-            |  3d 46 28 7b 8c 6e 8c 8c  26 1c 1b 88 f2 73 b0 9a
-            |  32 a6 cf 28 09 fd 6e 30  d5 a7 9f 26 37 00 8f 54
-            02 20                            ; INTEGER (32 Bytes)
-            |  4e 72 23 6e a3 90 a9 a1  7b cf 5f 7a 09 d6 3a b2
-            |  17 6c 92 bb 8e 36 c0 41  98 a2 7b 90 9b 6e 8f 13
+            | 3e ce f8 3f b1 2a 0c ae 78 41 05 5f 9f 87 10 3a
+            | 99 fd 14 b4 24 19 4b bf 06 c4 62 3d 3e e6 e3 fd
+            02 21                            ; INTEGER (33 Bytes)
+            | 00 d2 ac e3 46 db 26 2b 13 74 a6 b7 0f aa 51 f5
+            | 18 a4 2d dc a1 3a 41 25 ce 6f 50 52 a7 5b ac 9f
+            | b6
         ```
 
         Note: As CTAP1/U2F [=authenticators=] are already producing signatures values in this format, CTAP2
@@ -10047,6 +10048,7 @@ Editorial changes:
 - (*) Fixed mistake in how test vectors were generated in [[webauthn-3-20250127#test-vectors-extensions-prf-ctap]].
 - (*) Changed Ed25519 test vectors to be generated from the seed `'packed.EdDSA'` instead of `'packed.Ed25519'`: [[#sctn-test-vectors-packed-eddsa]]
 - (*) Added Ed448 test vectors: [[#sctn-test-vectors-packed-ed448]]
+- Changed DER example in [[#sctn-signature-attestation-types]] to include INTEGER components of differing lengths.
 
 
 ## Changes since Web Authentication Level 2 [[webauthn-2-20210408]] ## {#changes-since-l2}

--- a/index.bs
+++ b/index.bs
@@ -5844,17 +5844,18 @@ the [=authenticator=] MUST:
     - For COSEAlgorithmIdentifier -7 (ES256),  and other ECDSA-based algorithms, the
         `sig` value MUST be encoded as an ASN.1 DER Ecdsa-Sig-Value, as defined in [[RFC3279]] section 2.2.3.
 
+        <!-- Example generated using https://github.com/w3c/webauthn/blob/96cc62b627f0b17114931e1bbc546f376f372c5d/test-vectors/webauthn-test-vectors.py#L1004-L1010 with seed 'none.ES256.442295' (442295 is the lowest value that generates a 33+30-byte signature, 2524 is the lowest that generates a 33+31-byte signature) -->
         ```
         Example:
         Note: Encoding lengths vary with INTEGER magnitude and curve size.
-        30 45                                ; SEQUENCE (69 Bytes)
-            02 20                            ; INTEGER (32 Bytes)
-            | 3e ce f8 3f b1 2a 0c ae 78 41 05 5f 9f 87 10 3a
-            | 99 fd 14 b4 24 19 4b bf 06 c4 62 3d 3e e6 e3 fd
+        30 43                                ; SEQUENCE (67 Bytes)
             02 21                            ; INTEGER (33 Bytes)
-            | 00 d2 ac e3 46 db 26 2b 13 74 a6 b7 0f aa 51 f5
-            | 18 a4 2d dc a1 3a 41 25 ce 6f 50 52 a7 5b ac 9f
-            | b6
+            | 00 89 90 95 04 e1 4f 1e 29 db a8 15 8f a7 c3 87
+            | e8 88 ff be 07 d8 24 bb 21 43 20 55 06 ab 15 9c
+            | 3e
+            02 1e                            ; INTEGER (30 Bytes)
+            | 56 55 4f b5 81 9b 12 84 5e 85 be 2f 78 37 1c f3
+            | cb 95 e3 87 f4 51 cb 36 2b 94 78 d1 83 d2
         ```
 
         Note: As CTAP1/U2F [=authenticators=] are already producing signatures values in this format, CTAP2

--- a/index.bs
+++ b/index.bs
@@ -5846,6 +5846,7 @@ the [=authenticator=] MUST:
 
         ```
         Example:
+        Note: Encoding lengths vary with INTEGER magnitude and curve size.
         30 44                                ; SEQUENCE (68 Bytes)
             02 20                            ; INTEGER (32 Bytes)
             |  3d 46 28 7b 8c 6e 8c 8c  26 1c 1b 88 f2 73 b0 9a


### PR DESCRIPTION
Closes #2314.

The new example is copied from the ["ES256 Credential with very long credential ID" test vector](https://w3c.github.io/webauthn/#sctn-test-vectors-none-es256-long-credential-id) whose [signature](https://github.com/w3c/webauthn/blob/96cc62b627f0b17114931e1bbc546f376f372c5d/index.bs#L9387) happens to have components of different lengths.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2315.html" title="Last updated on Jul 15, 2025, 4:54 PM UTC (81514c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2315/96cc62b...81514c7.html" title="Last updated on Jul 15, 2025, 4:54 PM UTC (81514c7)">Diff</a>