### PR TITLE
Fold changes since L3WD2 into changes since L2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10015,36 +10015,6 @@ for their contributions as our W3C Team Contacts.
 
 This section summarizes the significant changes that have been made to this specification over time.
 
-## Changes since Web Authentication Level 3 Working draft 2 [[webauthn-3-20250127]] ## {#changes-since-l3-wd2}
-
-*These changes will be merged into the next section when finalizing Level 3.
-Changes to content that was not yet present in Level 2 are listed with a leading "(\*)" mark
-and will then be deleted from the merged change history.*
-
-Normative changes:
-
-- (*) Added dictionary extensions to {{AuthenticationExtensionsClientInputsJSON}}
-    and {{AuthenticationExtensionsClientOutputsJSON}} in definitions of extensions.
-- Added recommendation against using {{COSEAlgorithmIdentifier}} values -9, -51, -52 and -19
-    in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}}.
-- Added requirement for ESP256 (-9), ESP384 (-51) and ESP512 (-52) public keys to use uncompressed form: [[#sctn-alg-identifier]]
-
-Editorial changes:
-
-- (*) Fixed section heading levels of test vectors subsections: [[webauthn-3-20250127#sctn-test-vectors]]
-- Removed outdated notes about permissions policy in [[webauthn-3-20250127#sctn-isUserVerifyingPlatformAuthenticatorAvailable]]
-    and [[webauthn-3-20250127#sctn-getClientCapabilities]].
-- Added algorithm -8 (EdDSA) to example code in [[webauthn-3-20250127#sctn-sample-registration]].
-- (*) Clarified meaning of `prf` extension output `enabled`: [[webauthn-3-20250127#dom-authenticationextensionsprfoutputs-enabled]]
-- (*) Fixed mistake in how test vectors were generated in [[webauthn-3-20250127#test-vectors-extensions-prf-ctap]].
-- (*) Changed Ed25519 test vectors to be generated from the seed `'packed.EdDSA'` instead of `'packed.Ed25519'`: [[#sctn-test-vectors-packed-eddsa]]
-- (*) Added Ed448 test vectors: [[#sctn-test-vectors-packed-ed448]]
-- Changed DER example in [[#sctn-signature-attestation-types]] to include INTEGER components of differing lengths.
-- (*) Added base64url encoding of `extra_client_data` in test vectors.
-- (*) Regenerated test vectors to omit padding from base64url encoded data in `clientDataJSON` values.
-- (*) Renamed variable extra_client_data to extraData_random in test vectors.
-
-
 ## Changes since Web Authentication Level 2 [[webauthn-2-20210408]] ## {#changes-since-l2}
 
 ### Substantive Changes ### {#changes-l3-substantive}
@@ -10057,6 +10027,7 @@ Changes:
 - `uvm` extension no longer included; see instead L2 [[webauthn-2-20210408]].
 - [=authData/attestedCredentialData/aaguid=] in [=attested credential data=] is no longer zeroed
     when {{PublicKeyCredentialCreationOptions/attestation}} preference is {{AttestationConveyancePreference/none}}: [[#sctn-createCredential]]
+- Added requirement for ESP256 (-9), ESP384 (-51) and ESP512 (-52) public keys to use uncompressed form: [[#sctn-alg-identifier]]
 
 
 Deprecations:
@@ -10071,6 +10042,8 @@ Deprecations:
       - <code>{{CredentialCreationOptions/publicKey}}.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialEntity/name}}</code>
       - <code>{{CredentialCreationOptions/publicKey}}.{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialEntity/name}}</code>
       - <code>{{CredentialCreationOptions/publicKey}}.{{PublicKeyCredentialCreationOptions/user}}.{{PublicKeyCredentialUserEntity/displayName}}</code>
+- Added recommendation against using {{COSEAlgorithmIdentifier}} values -9, -51, -52 and -19
+    in {{PublicKeyCredentialCreationOptions/pubKeyCredParams}}.
 
 
 New features:
@@ -10116,6 +10089,9 @@ The following changes were made to improve clarity, readability, navigability an
     to clarify division of responsibilities.
 - Added [[#sctn-test-vectors]].
 - Moved normative language outside of "note" blocks.
+- Removed outdated notes about permissions policy in [[webauthn-3-20250127#sctn-isUserVerifyingPlatformAuthenticatorAvailable]]
+    and [[webauthn-3-20250127#sctn-getClientCapabilities]].
+- Added algorithm -8 (EdDSA) to example code in [[webauthn-3-20250127#sctn-sample-registration]].
 
 
 <pre class=biblio>


### PR DESCRIPTION
Closes #2302.

This branches from PR #2346 in order to cover the changelog changes from there too, so this PR currently targets that as the base in order to not inflate the diff.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2356.html" title="Last updated on Oct 29, 2025, 7:27 PM UTC (d392f23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2356/0dbeb20...d392f23.html" title="Last updated on Oct 29, 2025, 7:27 PM UTC (d392f23)">Diff</a>