### PR TITLE
Delete inaccurate recommendation to abort on unfocus

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3946,12 +3946,6 @@ See [[dom#abortcontroller-api-integration]] section for detailed instructions.
     during [=authenticator sessions=]. The same goes for
     {{PublicKeyCredential/[DISCOVER-METHOD]}}.
 
-The [=visibility states|visibility=] and [=focus=] state of the {{Window}} object determines whether the
-{{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} operations
-should continue. When the {{Window}} object associated with the [=Document=] loses focus,
-{{PublicKeyCredential/[CREATE-METHOD]}} and {{PublicKeyCredential/[DISCOVER-METHOD]}} operations
-SHOULD be aborted.
-
 
 ## WebAuthn Extensions Inputs and Outputs ## {#sctn-extensions-inputs-outputs}
 
@@ -10029,6 +10023,7 @@ Changes:
 - [=authData/attestedCredentialData/aaguid=] in [=attested credential data=] is no longer zeroed
     when {{PublicKeyCredentialCreationOptions/attestation}} preference is {{AttestationConveyancePreference/none}}: [[#sctn-createCredential]]
 - Added requirement for ESP256 (-9), ESP384 (-51) and ESP512 (-52) public keys to use uncompressed form: [[#sctn-alg-identifier]]
+- Removed recommendation in [[#sctn-abortoperation]] to abort when document loses focus.
 
 
 Deprecations:


### PR DESCRIPTION
Per discussion in https://github.com/w3c/webauthn/issues/2278.

Closes #2278.

<!-- Remove the following for non-normative changes -->

The following tasks have been completed:

- ~~[ ] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/))~~ N/A

Implementation commitment:

- [ ] WebKit ([link to issue](https://bugs.webkit.org/))
- [ ] Chromium ([link to issue](https://issues.chromium.org/issues/new?component=1456855&template=0))
- [ ] Gecko ([link to issue](https://bugzilla.mozilla.org/home))

Documentation and checks

- ~~[ ] Affects privacy~~
- ~~[ ] Affects security~~
- ~~[ ] Updated explainer ([link](https://github.com/w3c/webauthn/wiki))~~ N/A


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2367.html" title="Last updated on Dec 4, 2025, 10:40 AM UTC (2a6d11c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2367/3acdcc3...2a6d11c.html" title="Last updated on Dec 4, 2025, 10:40 AM UTC (2a6d11c)">Diff</a>