### PR TITLE
Bump build-validate-publish workflow image

### DIFF
--- a/.github/workflows/build-validate-publish.yml
+++ b/.github/workflows/build-validate-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: w3c/spec-prod@v2
+      - uses: w3c/spec-prod@v2.12.2
         with:
           GH_PAGES_BRANCH: gh-pages
           BUILD_FAIL_ON: nothing


### PR DESCRIPTION
This should fix build issues like the following:

    **Setup toolchain**

    $ pipx --version
      1.8.0
    $ pipx install bikeshed --quiet
      creating virtual environment...
      installing bikeshed...
      done! ✨ 🌟 ✨
        installed package bikeshed 6.1.1, installed using Python 3.10.12
        These apps are now globally available
          - bikeshed $ bikeshed update Bikeshed now requires Python 3.12 or higher; you are on 3.10.12. For instructions on how to set up a pyenv with 3.12, see: https://speced.github.io/bikeshed/#installing Command `bikeshed update` failed with exit code: 1. Error: Process completed with exit code 1.

The `ubuntu-24.04` runner image includes Python 3.12.3.

Closes #2370.