### PR TITLE
Forbid authenticator data from containing cleartext PRF outputs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7538,7 +7538,14 @@ but also cannot be deleted by the client since the [=authenticator data=] is sig
 : Authenticator extension input / output
 :: [=prf|This extension=] is abstract over the authenticator implementation,
     using either the [[FIDO-CTAP]] `hmac-secret` extension or an unspecified interface for communication between the client and authenticator.
-    It thus does not specify a CBOR interface for inputs and outputs.
+    It thus does not specify a CBOR interface for inputs and outputs, except for the following requirement:
+
+    - [=Authenticator extension outputs=] MUST NOT contain cleartext PRF outputs.
+
+        Note: This is because the [=authenticator data=] is signed,
+        so authenticator extension outputs cannot be omitted in case the {{PublicKeyCredential}} needs to be sent to the [=[RP]=] server.
+        This is important for use cases where PRF outputs should remain private to the client side,
+        such as using PRF outputs to derive encryption keys.
 
 : Authenticator extension processing
 :: [=Authenticators=] that support the [[FIDO-CTAP]] `hmac-secret` extension implement authenticator processing as defined in that extension.


### PR DESCRIPTION
Closes #2359.

<!-- Remove the following for non-normative changes -->

The following tasks have been completed:

- ~~[ ] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/))~~ N/A - abstract requirement

Implementation commitment:

- ~~[ ] WebKit ([link to issue](https://bugs.webkit.org/))~~ N/A - abstract requirement
- ~~[ ] Chromium ([link to issue](https://issues.chromium.org/issues/new?component=1456855&template=0))~~ N/A - abstract requirement
- ~~[ ] Gecko ([link to issue](https://bugzilla.mozilla.org/home))~~ N/A - abstract requirement

Documentation and checks

- [x] Affects privacy
- [x] Affects security
- ~~[ ] Updated explainer ([link](https://github.com/w3c/webauthn/wiki))~~ N/A - abstract requirement


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2372.html" title="Last updated on Dec 10, 2025, 8:52 PM UTC (5481e3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2372/33f5b27...5481e3b.html" title="Last updated on Dec 10, 2025, 8:52 PM UTC (5481e3b)">Diff</a>