### PR TITLE
remoteClientDataJSON Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vagrant/
 index.html
 .DS_Store
+.vs/

--- a/index.bs
+++ b/index.bs
@@ -8779,6 +8779,9 @@ possible for [=[RPS]=] to trust any further [=attestation statements=] from the 
 
 See also the related security consideration for [=[RPS]=] in [[#sctn-revoked-attestation-certificates]].
 
+
+## Security considerations for [=clients=] ## {#sctn-security-considerations-client}
+
 ### The remoteClientDataJSON Extension ### {#sctn-remote-clientdatajson-security}
 
 The [=remoteClientDataJSON=] extension enables a [=Remote desktop web client=] to proxy

--- a/index.bs
+++ b/index.bs
@@ -1,4 +1,4 @@
-﻿<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
+<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
 Notes:
 * the h1 tag is spec title that is rendered within the document window. Wrapping
   may be controlled with break tags.  The spec 'Level' value is not appended.
@@ -1864,23 +1864,27 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
         1. [=map/Set=] |authenticatorExtensions|[|extensionId|] to the [=base64url encoding=] of |authenticatorExtensionInput|.
     </li>
 
-1. Let |collectedClientData| be a new {{CollectedClientData}} instance whose fields are:
-    : {{CollectedClientData/type}}
-    :: The string "webauthn.create".
-    : {{CollectedClientData/challenge}}
-    :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialCreationOptions/challenge}}.
-    : {{CollectedClientData/origin}}
-    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
-    : {{CollectedClientData/crossOrigin}}
-    :: The inverse of the value of the
-        {{PublicKeyCredential/[CREATE-METHOD]/sameOriginWithAncestors}}
-        argument passed to this [=internal method=].
-    : {{CollectedClientData/topOrigin}}
-    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
-        the {{PublicKeyCredential/[CREATE-METHOD]/sameOriginWithAncestors}}
-        argument passed to this [=internal method=] is [FALSE], else `undefined`.
+    <li id="CreateCred-ConstructCollectedClientData">
+        Let |collectedClientData| be a new {{CollectedClientData}} instance whose fields are:
+            : {{CollectedClientData/type}}
+            :: The string "webauthn.create".
+            : {{CollectedClientData/challenge}}
+            :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialCreationOptions/challenge}}.
+            : {{CollectedClientData/origin}}
+            :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
+            : {{CollectedClientData/crossOrigin}}
+            :: The inverse of the value of the
+                {{PublicKeyCredential/[CREATE-METHOD]/sameOriginWithAncestors}}
+                argument passed to this [=internal method=].
+            : {{CollectedClientData/topOrigin}}
+            :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
+                the {{PublicKeyCredential/[CREATE-METHOD]/sameOriginWithAncestors}}
+                argument passed to this [=internal method=] is [FALSE], else `undefined`.
+    </li>
 
-1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
+    <li id="CreateCred-SerializeClientDataJSON">
+        Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
+    </li>
 
 1. Let |clientDataHash| be the [=hash of the serialized client data=] represented by |clientDataJSON|.
 
@@ -2408,23 +2412,27 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
     1. [=map/Set=] |authenticatorExtensions|[|extensionId|] to the [=base64url encoding=] of |authenticatorExtensionInput|.
 
-1. Let |collectedClientData| be a new {{CollectedClientData}} instance whose fields are:
-    : {{CollectedClientData/type}}
-    :: The string "webauthn.get".
-    : {{CollectedClientData/challenge}}
-    :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialRequestOptions/challenge}}
-    : {{CollectedClientData/origin}}
-    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
-    : {{CollectedClientData/crossOrigin}}
-    :: The inverse of the value of the
-        {{PublicKeyCredential/[DISCOVER-METHOD]/sameOriginWithAncestors}}
-        argument passed to this [=internal method=].
-    : {{CollectedClientData/topOrigin}}
-    :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
-        the {{PublicKeyCredential/[DISCOVER-METHOD]/sameOriginWithAncestors}}
-        argument passed to this [=internal method=] is [FALSE], else `undefined`.
+    <li id="GetAssn-ConstructCollectedClientData">
+        Let |collectedClientData| be a new {{CollectedClientData}} instance whose fields are:
+            : {{CollectedClientData/type}}
+            :: The string "webauthn.get".
+            : {{CollectedClientData/challenge}}
+            :: The [=base64url encoding=] of |pkOptions|.{{PublicKeyCredentialRequestOptions/challenge}}
+            : {{CollectedClientData/origin}}
+            :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|.
+            : {{CollectedClientData/crossOrigin}}
+            :: The inverse of the value of the
+                {{PublicKeyCredential/[DISCOVER-METHOD]/sameOriginWithAncestors}}
+                argument passed to this [=internal method=].
+            : {{CollectedClientData/topOrigin}}
+            :: The [=ascii serialization of an origin|serialization of=] |callerOrigin|'s [=top-level origin=] if
+                the {{PublicKeyCredential/[DISCOVER-METHOD]/sameOriginWithAncestors}}
+                argument passed to this [=internal method=] is [FALSE], else `undefined`.
+    </li>
 
-1. Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
+    <li id="GetAssn-SerializeClientDataJSON">
+        Let |clientDataJSON| be the [=JSON-compatible serialization of client data=] constructed from |collectedClientData|.
+    </li>
 
 1. Let |clientDataHash| be the [=hash of the serialized client data=] represented by |clientDataJSON|.
 
@@ -4476,7 +4484,7 @@ Note: The {{PublicKeyCredentialHint}} enumeration is deliberately not referenced
 
 ## Permissions Policy integration ## {#sctn-permissions-policy}
 
-This specification defines three [=policy-controlled features=]. [[!Permissions-Policy]]
+This specification defines three [=policy-controlled features=] [[!Permissions-Policy]].
 
 Two features are identified by the feature-identifier tokens "<code><dfn data-lt="publickey-credentials-create-feature" export>publickey-credentials-create</dfn></code>"
 and "<code><dfn data-lt="publickey-credentials-get-feature" export>publickey-credentials-get</dfn></code>".
@@ -7814,7 +7822,7 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
 :: When [[#sctn-createCredential|creating a new credential]], this extension injects the following
     steps at labeled points in that algorithm:
 
-    1. Just before [establishing the RP ID](#CreateCred-DetermineRpId):
+    1. Replace [establishing the RP ID](#CreateCred-DetermineRpId) with following procedure
         1. If the result of [=getting the current permission state=] for
             `"publickey-credentials-remote-client-data-json"` and the [=current settings object=]
             is not `"granted"`.
@@ -7826,49 +7834,58 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
             given |remoteClientDataJSON|.
             1. If above parsing step fails, throw a "{{NotSupportedError}}" {{DOMException}}.
         1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
-
-    1. In [establishing the RP ID](#CreateCred-DetermineRpId):
         1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
-            [=is not a registrable domain suffix of and is not equal to=] |effectiveDomain|,
-            instead of running the [$related origins validation procedure$],
-            verify that <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
-            [=is a registrable domain suffix of or is equal to=] |remoteOrigin|.
-            1. If this check fails, throw a "{{SecurityError}}" {{DOMException}}.
+            [=is not a registrable domain suffix of and is not equal to=] |remoteOrigin|, and if the client
+            1. does not support [[#sctn-related-origins|related origin requests]]
+                1. Throw a "{{SecurityError}}" {{DOMException}}.
+            1. supports [[#sctn-related-origins|related origin requests]]
+                1. Skip [$related origins validation procedure$] for this operation.
 
-    1. In the step that constructs |clientDataJSON| from |collectedClientData|,
+    1. Skip [constructing collectedClientData](#CreateCred-ConstructCollectedClientData) step.
+        1. |collectedClientData| has been parsed from given |remoteClientDataJSON| in [establishing the RP ID](#CreateCred-DetermineRpId).
+        1. The [=user agent=] MUST NOT add, remove, or modify any contents of |collectedClientData|,
+            as doing so would invalidate the remote machine's calculated |clientDataJSON|,
+            resulting in a signature mismatch at the [=[RP]=].
+
+    1. In [serializing client data](#CreateCred-SerializeClientDataJSON) step,
         set |clientDataJSON| to |remoteClientDataJSON| instead.
         1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON|,
-            as doing so would invalidate the remote machine's calculated |clientDataJSON|,
+            to construct |clientDataJSON| here as doing so would invalidate the remote machine's calculated |clientDataJSON|,
             resulting in a signature mismatch at the [=[RP]=].
 
 : Client extension processing ([=authentication extension|authentication=])
 :: When [[#sctn-getAssertion|generating an authentication assertion]], this extension injects the
     following steps at labeled points in that algorithm:
 
-    1. Just before [establishing the RP ID](#GetAssn-DetermineRpId):
-        1. If the result of [=getting the current permission state=] [[!Permissions]] for
+    1. Replace [establishing the RP ID](#GetAssn-DetermineRpId) with following procedure:
+        1. If the result of [=getting the current permission state=] for
             `"publickey-credentials-remote-client-data-json"` and the [=current settings object=]
-            is not `"granted"`
-            1. Throw a "{{NotAllowedError}}" {{DOMException}}
-        1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
-            is not present, throw a "{{NotAllowedError}}" {{DOMException}}.
+            is not `"granted"`.
+            1. Throw a "{{NotAllowedError}}" {{DOMException}}.
+        1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+            is not present
+            1. Throw a "{{NotAllowedError}}" {{DOMException}}.
         1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=]
-            given |remoteClientDataJSON|. [[!infra]]
-            If this throws, throw a "{{NotSupportedError}}" {{DOMException}}.
+            given |remoteClientDataJSON|.
+            1. If above parsing step fails, throw a "{{NotSupportedError}}" {{DOMException}}.
         1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
+        1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+            [=is not a registrable domain suffix of and is not equal to=] |remoteOrigin|, and if the client
+            1. does not support [[#sctn-related-origins|related origin requests]]
+                1. Throw a "{{SecurityError}}" {{DOMException}}.
+            1. supports [[#sctn-related-origins|related origin requests]]
+                1. Skip [$related origins validation procedure$] for this operation.
 
-    1. In [establishing the RP ID](#GetAssn-DetermineRpId):
-        1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
-            [=is not a registrable domain suffix of and is not equal to=] |effectiveDomain|,
-            instead of running the [$related origins validation procedure$],
-            verify that <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
-            [=is a registrable domain suffix of or is equal to=] |remoteOrigin|.
-            1. If this check fails, throw a "{{SecurityError}}" {{DOMException}}.
+    1. Skip [constructing collectedClientData](#GetAssn-ConstructCollectedClientData) step.
+        1. |collectedClientData| has been parsed from given |remoteClientDataJSON| in [establishing the RP ID](#GetAssn-DetermineRpId).
+        1. The [=user agent=] MUST NOT add, remove, or modify any contents of |collectedClientData|,
+            as doing so would invalidate the remote machine's calculated |clientDataJSON|,
+            resulting in a signature mismatch at the [=[RP]=].
 
-    1. In the step that constructs |clientDataJSON| from |collectedClientData|,
+    1. In [serializing client data](#GetAssn-SerializeClientDataJSON) step,
         set |clientDataJSON| to |remoteClientDataJSON| instead.
         1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON|,
-            as doing so would invalidate the remote machine's calculated |clientDataJSON|,
+            to construct |clientDataJSON| here as doing so would invalidate the remote machine's calculated |clientDataJSON|,
             resulting in a signature mismatch at the [=[RP]=].
 
 : Authenticator extension input
@@ -7881,7 +7898,7 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
 :: None
 
 : Client extension output
-:: Returns the boolean to indicate whether that the extension rules were checked and validated.
+:: Returns the boolean to indicate whether parsing all the extension steps resulted in a success or failure.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean remoteClientDataJson;
@@ -8764,8 +8781,6 @@ possible for [=[RPS]=] to trust any further [=attestation statements=] from the 
 
 See also the related security consideration for [=[RPS]=] in [[#sctn-revoked-attestation-certificates]].
 
-## Security considerations for [=clients=] ## {#sctn-security-considerations-client}
-
 ### The remoteClientDataJSON Extension ### {#sctn-remote-clientdatajson-security}
 
 The [=remoteClientDataJSON=] extension enables a [=Remote desktop web client=] to proxy
@@ -8789,6 +8804,11 @@ alters the trust model of the [=Web Authentication API=] in the following ways:
 [=User agents=] that grant this extension SHOULD clearly communicate to users when a
 remote-desktop-proxied WebAuthn operation is in progress, so that users understand
 that their authenticator is being used on behalf of a remotely hosted application.
+
+<!-- no sec cons for clients enumerated at this time
+## Security considerations for [=clients=] ## {#sctn-security-considerations-client}
+-->
+
 
 ## Security considerations for [=[RPS]=] ## {#sctn-security-considerations-rp}
 

--- a/index.bs
+++ b/index.bs
@@ -7771,7 +7771,7 @@ in [=Remote desktop web client=].
 This allows web-based remote desktop web clients to execute remote WebAuthn requests locally. Here the [=Remote desktop web client=] is calling WebAuthn request on behalf of
 RP present on the remote machine and have different origin than the calling RP in the remote machine.
 
-Note: This extension is a [=powerful feature=] that requires explicit per-origin permission before use.
+This extension is a [=powerful feature=] that requires explicit per-origin permission before use.
 [=User agents=] SHOULD NOT prompt the user for this permission at request time;
 instead, the grant is administered through device management policy (e.g., managed browser profiles, managed browser instances, or
 managed devices that enumerate specific [=Remote desktop web client=] origins) or
@@ -7785,8 +7785,6 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
     The [=default permission state=] for this feature is `"denied"`,
     meaning the extension is not available by default and must be explicitly enabled.
     Since no additional aspects are defined, the [=permission descriptor type=] defaults to {{PermissionDescriptor}}.
-
-    The [=permission descriptor type=] for this feature is:
 
     <div class="example" id="example-publickey-credentials-remote-client-data-json-permission-query">
     A [=Remote desktop web client=] may check whether the [=user agent=] has been configured
@@ -7898,7 +7896,7 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
 :: None
 
 : Client extension output
-:: Returns the boolean to indicate whether parsing all the extension steps resulted in a success or failure.
+:: Returns the value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
       boolean remoteClientDataJson;
@@ -8789,8 +8787,8 @@ alters the trust model of the [=Web Authentication API=] in the following ways:
 
 - **Origin substitution:** The [=user agent=] accepts a {{CollectedClientData/origin}} supplied by the calling
     [=Remote desktop web client=] rather than deriving it from the current execution context.
-    Any [=user agent=] granting this permission must therefore trust that the caller
-    accurately supplies the origin of the remote [=[RP]=].
+    Any [=user agent=] granting this permission MUST therefore trust that the caller
+    accurately and honestly supplies the origin of the remote [=[RP]=].
 
 - **RP ID validation:** The [=RP ID=] is validated against the origin present in |remoteClientDataJSON|
     rather than the [=effective domain=] of the local [=client=]'s origin.
@@ -8804,10 +8802,6 @@ alters the trust model of the [=Web Authentication API=] in the following ways:
 [=User agents=] that grant this extension SHOULD clearly communicate to users when a
 remote-desktop-proxied WebAuthn operation is in progress, so that users understand
 that their authenticator is being used on behalf of a remotely hosted application.
-
-<!-- no sec cons for clients enumerated at this time
-## Security considerations for [=clients=] ## {#sctn-security-considerations-client}
--->
 
 
 ## Security considerations for [=[RPS]=] ## {#sctn-security-considerations-rp}

--- a/index.bs
+++ b/index.bs
@@ -1,4 +1,4 @@
-﻿<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
+<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
 Notes:
 * the h1 tag is spec title that is rendered within the document window. Wrapping
   may be controlled with break tags.  The spec 'Level' value is not appended.

--- a/index.bs
+++ b/index.bs
@@ -7832,14 +7832,10 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
             given |remoteClientDataJSON|.
             1. If above parsing step fails, throw a "{{EncodingError}}" {{DOMException}}.
         1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
-        1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
-            [=is not a registrable domain suffix of and is not equal to=] |remoteOrigin|, and if the client
-            1. does not support [[#sctn-related-origins|related origin requests]]
-                1. Throw a "{{SecurityError}}" {{DOMException}}.
-            1. supports [[#sctn-related-origins|related origin requests]]
-                1. Skip [$related origins validation procedure$] for this operation.
-                
-                    Note: This means the local client is delegating the [$related origins validation procedure$] to the remote client.
+        1. Skip checking whether <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+            [=is a registrable domain suffix of or is equal to=] |remoteOrigin| or not.
+
+            Note: This means the local client is delegating all the [=RP ID=] related origin checks to the remote client.
 
     1. Skip [constructing collectedClientData](#CreateCred-ConstructCollectedClientData) step.
         1. |collectedClientData| has been parsed from given |remoteClientDataJSON| in [establishing the RP ID](#CreateCred-DetermineRpId).
@@ -7869,12 +7865,10 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
             given |remoteClientDataJSON|.
             1. If above parsing step fails, throw a "{{NotSupportedError}}" {{DOMException}}.
         1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
-        1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
-            [=is not a registrable domain suffix of and is not equal to=] |remoteOrigin|, and if the client
-            1. does not support [[#sctn-related-origins|related origin requests]]
-                1. Throw a "{{SecurityError}}" {{DOMException}}.
-            1. supports [[#sctn-related-origins|related origin requests]]
-                1. Skip [$related origins validation procedure$] for this operation.
+        1. Skip checking whether <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+            [=is a registrable domain suffix of or is equal to=] |remoteOrigin| or not.
+
+            Note: This means the local client is delegating all the [=RP ID=] related origin checks to the remote client.
 
     1. Skip [constructing collectedClientData](#GetAssn-ConstructCollectedClientData) step.
         1. |collectedClientData| has been parsed from given |remoteClientDataJSON| in [establishing the RP ID](#GetAssn-DetermineRpId).
@@ -8795,10 +8789,10 @@ alters the trust model of the [=Web Authentication API=] in the following ways:
     Any [=user agent=] granting this permission MUST therefore trust that the caller
     accurately and honestly supplies the origin of the remote [=[RP]=].
 
-- **RP ID validation:** The [=RP ID=] is validated against the origin present in |remoteClientDataJSON|
-    rather than the [=effective domain=] of the local [=client=]'s origin.
-    If content running in the [=Remote desktop web client=] origin can influence the
-    |remoteClientDataJSON| value, it could cause assertions valid for an unintended [=[RP]=] to be produced.
+- **RP ID validation:** The [=RP ID=] validatation is delegated to the remote client as remote client
+    has all the necessary context of validating the origin to account for related origins and platform specific app deployment models.
+    Any [=user agent=] granting this permission MUST therefore trust that the remote client has
+    accurately and honestly validated [=RP ID=] against all the origin checks.
 
 - **Per-origin configuration mechanism required:** As this extension's permissions are per origin,
     [=user agents=] MUST only provide configuration mechanisms which are per-origin basis

--- a/index.bs
+++ b/index.bs
@@ -1,4 +1,4 @@
-<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
+﻿<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
 Notes:
 * the h1 tag is spec title that is rendered within the document window. Wrapping
   may be controlled with break tags.  The spec 'Level' value is not appended.
@@ -252,6 +252,7 @@ spec:html; type:dfn; for:environment settings object; text:global object
 spec:html; type:dfn; for:/; text:same site
 spec:infra; type:dfn; for:/; text:set
 spec:infra; type:dfn; text:list
+spec:infra; type:dfn; text:user agent
 spec:url; type:dfn; text:domain
 spec:url; type:dfn; for:url; text:host
 spec:url; type:dfn; text:valid domain;
@@ -4475,10 +4476,14 @@ Note: The {{PublicKeyCredentialHint}} enumeration is deliberately not referenced
 
 ## Permissions Policy integration ## {#sctn-permissions-policy}
 
-This specification defines two [=policy-controlled features=] identified by
-the feature-identifier tokens "<code><dfn data-lt="publickey-credentials-create-feature" export>publickey-credentials-create</dfn></code>"
+This specification defines three [=policy-controlled features=]. [[!Permissions-Policy]]
+
+Two features are identified by the feature-identifier tokens "<code><dfn data-lt="publickey-credentials-create-feature" export>publickey-credentials-create</dfn></code>"
 and "<code><dfn data-lt="publickey-credentials-get-feature" export>publickey-credentials-get</dfn></code>".
-Their [=default allowlists=] are both '<code>self</code>'. [[!Permissions-Policy]]
+Their [=default allowlists=] are both '<code>self</code>'.
+
+A third feature is identified by the feature-identifier token "<code><dfn data-lt="publickey-credentials-remote-client-data-json-feature" export>publickey-credentials-remote-client-data-json</dfn></code>".
+Its [=default allowlist=] is '<code>none</code>', meaning it is disabled for all origins by default. This feature is also a [=powerful feature=] ([[!Permissions]]) identified by the name <code>"publickey-credentials-remote-client-data-json"</code>, with [=default permission state=] `"denied"`.
 
 A {{Document}}'s [=Document/permissions policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
 [=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via <code><a idl for="CredentialsContainer" lt="create()">navigator.credentials.create({publicKey:..., ...})</a></code> or
@@ -7747,6 +7752,118 @@ However, [=authenticators=] that do not utilize [[!FIDO-CTAP]] do not necessaril
 : Authenticator extension processing
 :: [=largeblob|This extension=] directs the user-agent to cause the large blob to be stored on, or retrieved from, the authenticator. It thus does not specify any direct authenticator interaction for [=[RPS]=].
 
+### Remote Client Data JSON extension (<dfn>remoteClientDataJSON</dfn>) ### {#sctn-remote-client-data-json-extension}
+
+<dfn>Remote desktop web client</dfn> let users interact with the (native) desktop environment of a remote host from a local client (web) application.
+
+[=remoteClientDataJSON|This=] [=registration extension=] and [=authentication extension=] allows user to use a
+WebAuthn authenticator connected to the local [=client platform=] in order to sign into a website in a browser, or an app running on a remote host
+in [=Remote desktop web client=].
+
+This allows web-based remote desktop web clients to execute remote WebAuthn requests locally. Here the [=Remote desktop web client=] is calling WebAuthn request on behalf of
+RP present on the remote machine and have different origin than the calling RP in the remote machine.
+
+Note: This extension is a [=powerful feature=] that requires explicit per-origin permission before use.
+[=User agents=] SHOULD NOT prompt the user for this permission at request time;
+instead, the grant is administered through device management policy (e.g., managed browser profiles, managed browser instances, or
+managed devices that enumerate specific [=Remote desktop web client=] origins) or
+through explicit per-origin user opt-in in [=WebAuthn Client=] settings.
+This permission MUST be configured per-origin and MUST NOT offer the capability to permit all origins.
+
+: Permissions
+:: This extension defines a [=powerful feature=] ([[!Permissions]]) and a [=policy-controlled feature=] ([[!Permissions-Policy]]),
+    both identified by the name <code>"publickey-credentials-remote-client-data-json"</code>.
+    The [=default allowlist=] for this [=policy-controlled feature=] is `'none'`.
+    The [=default permission state=] for this feature is `"denied"`,
+    meaning the extension is not available by default and must be explicitly enabled.
+    Since no additional aspects are defined, the [=permission descriptor type=] defaults to {{PermissionDescriptor}}.
+
+    The [=permission descriptor type=] for this feature is:
+
+    <div class="example" id="example-publickey-credentials-remote-client-data-json-permission-query">
+    A [=Remote desktop web client=] may check whether the [=user agent=] has been configured
+    to permit this extension for the current origin via the {{Permissions}} API:
+
+    <xmp highlight="javascript">
+    const status = await navigator.permissions.query({
+        name: "publickey-credentials-remote-client-data-json"
+    });
+    if (status.state === "granted") {
+        // The client is configured to allow the remoteClientDataJSON extension; proceed with the remote desktop flow.
+    }
+    </xmp>
+    </div>
+
+: Extension identifier
+:: `remoteClientDataJSON`
+
+: Operation applicability
+:: [=registration extension|Registration=] and [=authentication extension|Authentication=]
+
+: Client extension input
+::  <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientInputs {
+        DOMString remoteClientDataJSON;
+    };
+    partial dictionary AuthenticationExtensionsClientInputsJSON {
+        DOMString remoteClientDataJSON;
+    };
+    </xmp>
+
+: Client extension processing ([=registration extension|registration=])
+::
+    1. If the result of [=getting the current permission state=] [[!Permissions]] for `"publickey-credentials-remote-client-data-json"` and the [=current settings object=] is not `"granted"`:
+         1. Throw a "{{NotAllowedError}}" {{DOMException}}
+    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> is not present
+         1. Throw a "{{NotAllowedError}}" {{DOMException}}
+    1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=] [[!INFRA]] given |remoteClientDataJSON|.
+         1. If this throws, throw a "{{NotSupportedError}}" {{DOMException}}.
+    1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
+    1. Verify that <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+          [=is a registrable domain suffix of or is equal to=] |remoteOrigin|, substituting |remoteOrigin| for |effectiveDomain| in that check.
+         1. If this check fails, throw a "{{NotAllowedError}}" {{DOMException}}.
+    1. Skip the [$related origins validation procedure$] for |effectiveDomain|.
+    1. Let |clientDataJSON| be equal to |remoteClientDataJSON|.
+         1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON| when constructing |clientDataJSON|,
+               as doing so would invalidate the remote machine's calculated |clientDataJSON|, resulting in a signature mismatch at the [=[RP]=].
+
+: Client extension processing ([=authentication extension|authentication=])
+::
+    1. If the result of [=getting the current permission state=] for `"publickey-credentials-remote-client-data-json"` and the [=current settings object=] is not `"granted"`: [[!Permissions]]
+         1. Throw a "{{NotAllowedError}}" {{DOMException}}
+    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> is not present
+         1. Throw a "{{NotAllowedError}}" {{DOMException}}
+    1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=] [[!INFRA]] given |remoteClientDataJSON|.
+         1. If this throws, return a {{DOMException}} whose name is "{{NotSupportedError}}".
+    1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
+    1. Verify that <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
+          [=is a registrable domain suffix of or is equal to=] |remoteOrigin|, substituting |remoteOrigin| for |effectiveDomain| in that check.
+         1. If this check fails, throw a "{{NotAllowedError}}" {{DOMException}}.
+    1. Skip the [$related origins validation procedure$] for |effectiveDomain|.
+    1. Let |clientDataJSON| be equal to |remoteClientDataJSON|.
+         1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON| when constructing |clientDataJSON|,
+               as doing so would invalidate the remote machine's calculated |clientDataJSON|, resulting in a signature mismatch at the [=[RP]=].
+
+
+: Authenticator extension input
+:: None
+
+: Authenticator extension processing
+:: None
+
+: Authenticator extension output
+:: None
+
+: Client extension output
+:: Returns the boolean to indicate whether that the extension rules were checked and validated.
+    <xmp class="idl">
+    partial dictionary AuthenticationExtensionsClientOutputs {
+      boolean remoteClientDataJson;
+    };
+    partial dictionary AuthenticationExtensionsClientOutputsJSON {
+      boolean remoteClientDataJson;
+    };
+    </xmp>
 
 ## Authenticator Extensions ## {#sctn-defined-authenticator-extensions}
 
@@ -8589,7 +8706,6 @@ or where [=client=] and [=authenticator=] do not communicate directly,
 designers SHOULD consider how this affects the enforcement of [=scope=] restrictions
 and the strength of the [=authenticator=] as a [=something you have=] authentication factor.
 
-
 ## Security considerations for [=authenticators=] <span id="sctn-attestation-security-considerations"></span> ## {#sctn-security-considerations-authenticator}
 <!-- Note: the above <span> is there to preserve the #sctn-attestation-security-considerations anchor although the section it was
 tied to has been removed. The section had no text of its own and served only to group the following two subsections together. -->
@@ -8621,9 +8737,31 @@ possible for [=[RPS]=] to trust any further [=attestation statements=] from the 
 
 See also the related security consideration for [=[RPS]=] in [[#sctn-revoked-attestation-certificates]].
 
-<!-- no sec cons for clients enumerated at this time
 ## Security considerations for [=clients=] ## {#sctn-security-considerations-client}
--->
+
+### The remoteClientDataJSON Extension ### {#sctn-remote-clientdatajson-security}
+
+The [=remoteClientDataJSON=] extension enables a [=Remote desktop web client=] to proxy
+[=Web Authentication API=] requests on behalf of a remote [=[RP]=]. This fundamentally
+alters the trust model of the [=Web Authentication API=] in the following ways:
+
+- **Origin substitution:** The [=user agent=] accepts a {{CollectedClientData/origin}} supplied by the calling
+    [=Remote desktop web client=] rather than deriving it from the current execution context.
+    Any [=user agent=] granting this permission must therefore trust that the caller
+    accurately supplies the origin of the remote [=[RP]=].
+
+- **RP ID validation:** The [=RP ID=] is validated against the origin present in |remoteClientDataJSON|
+    rather than the [=effective domain=] of the local [=client=]'s origin.
+    If content running in the [=Remote desktop web client=] origin can influence the
+    |remoteClientDataJSON| value, it could cause assertions valid for an unintended [=[RP]=] to be produced.
+
+- **Per-origin grant required:** For the above reasons, [=user agents=] MUST NOT grant this
+    permission globally to all origins. The permission MUST be restricted on a per-origin basis
+    via [=user agent=] policy.
+
+[=User agents=] that grant this extension SHOULD clearly communicate to users when a
+remote-desktop-proxied WebAuthn operation is in progress, so that users understand
+that their authenticator is being used on behalf of a remotely hosted application.
 
 ## Security considerations for [=[RPS]=] ## {#sctn-security-considerations-rp}
 

--- a/index.bs
+++ b/index.bs
@@ -7838,6 +7838,8 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
                 1. Throw a "{{SecurityError}}" {{DOMException}}.
             1. supports [[#sctn-related-origins|related origin requests]]
                 1. Skip [$related origins validation procedure$] for this operation.
+                
+                    Note: This means the local client is delegating the [$related origins validation procedure$] to the remote client.
 
     1. Skip [constructing collectedClientData](#CreateCred-ConstructCollectedClientData) step.
         1. |collectedClientData| has been parsed from given |remoteClientDataJSON| in [establishing the RP ID](#CreateCred-DetermineRpId).

--- a/index.bs
+++ b/index.bs
@@ -7811,39 +7811,65 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
     </xmp>
 
 : Client extension processing ([=registration extension|registration=])
-::
-    1. If the result of [=getting the current permission state=] [[!Permissions]] for `"publickey-credentials-remote-client-data-json"` and the [=current settings object=] is not `"granted"`:
-         1. Throw a "{{NotAllowedError}}" {{DOMException}}
-    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> is not present
-         1. Throw a "{{NotAllowedError}}" {{DOMException}}
-    1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=] [[!INFRA]] given |remoteClientDataJSON|.
-         1. If this throws, throw a "{{NotSupportedError}}" {{DOMException}}.
-    1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
-    1. Verify that <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
-          [=is a registrable domain suffix of or is equal to=] |remoteOrigin|, substituting |remoteOrigin| for |effectiveDomain| in that check.
-         1. If this check fails, throw a "{{NotAllowedError}}" {{DOMException}}.
-    1. Skip the [$related origins validation procedure$] for |effectiveDomain|.
-    1. Let |clientDataJSON| be equal to |remoteClientDataJSON|.
-         1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON| when constructing |clientDataJSON|,
-               as doing so would invalidate the remote machine's calculated |clientDataJSON|, resulting in a signature mismatch at the [=[RP]=].
+:: When [[#sctn-createCredential|creating a new credential]], this extension injects the following
+    steps at labeled points in that algorithm:
+
+    1. Just before [establishing the RP ID](#CreateCred-DetermineRpId):
+        1. If the result of [=getting the current permission state=] for
+            `"publickey-credentials-remote-client-data-json"` and the [=current settings object=]
+            is not `"granted"`.
+            1. Throw a "{{NotAllowedError}}" {{DOMException}}.
+        1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+            is not present
+            1. Throw a "{{NotAllowedError}}" {{DOMException}}.
+        1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=]
+            given |remoteClientDataJSON|.
+            1. If above parsing step fails, throw a "{{NotSupportedError}}" {{DOMException}}.
+        1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
+
+    1. In [establishing the RP ID](#CreateCred-DetermineRpId):
+        1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+            [=is not a registrable domain suffix of and is not equal to=] |effectiveDomain|,
+            instead of running the [$related origins validation procedure$],
+            verify that <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
+            [=is a registrable domain suffix of or is equal to=] |remoteOrigin|.
+            1. If this check fails, throw a "{{SecurityError}}" {{DOMException}}.
+
+    1. In the step that constructs |clientDataJSON| from |collectedClientData|,
+        set |clientDataJSON| to |remoteClientDataJSON| instead.
+        1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON|,
+            as doing so would invalidate the remote machine's calculated |clientDataJSON|,
+            resulting in a signature mismatch at the [=[RP]=].
 
 : Client extension processing ([=authentication extension|authentication=])
-::
-    1. If the result of [=getting the current permission state=] for `"publickey-credentials-remote-client-data-json"` and the [=current settings object=] is not `"granted"`: [[!Permissions]]
-         1. Throw a "{{NotAllowedError}}" {{DOMException}}
-    1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code> is not present
-         1. Throw a "{{NotAllowedError}}" {{DOMException}}
-    1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=] [[!INFRA]] given |remoteClientDataJSON|.
-         1. If this throws, return a {{DOMException}} whose name is "{{NotSupportedError}}".
-    1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
-    1. Verify that <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
-          [=is a registrable domain suffix of or is equal to=] |remoteOrigin|, substituting |remoteOrigin| for |effectiveDomain| in that check.
-         1. If this check fails, throw a "{{NotAllowedError}}" {{DOMException}}.
-    1. Skip the [$related origins validation procedure$] for |effectiveDomain|.
-    1. Let |clientDataJSON| be equal to |remoteClientDataJSON|.
-         1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON| when constructing |clientDataJSON|,
-               as doing so would invalidate the remote machine's calculated |clientDataJSON|, resulting in a signature mismatch at the [=[RP]=].
+:: When [[#sctn-getAssertion|generating an authentication assertion]], this extension injects the
+    following steps at labeled points in that algorithm:
 
+    1. Just before [establishing the RP ID](#GetAssn-DetermineRpId):
+        1. If the result of [=getting the current permission state=] [[!Permissions]] for
+            `"publickey-credentials-remote-client-data-json"` and the [=current settings object=]
+            is not `"granted"`
+            1. Throw a "{{NotAllowedError}}" {{DOMException}}
+        1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
+            is not present, throw a "{{NotAllowedError}}" {{DOMException}}.
+        1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=]
+            given |remoteClientDataJSON|. [[!infra]]
+            If this throws, throw a "{{NotSupportedError}}" {{DOMException}}.
+        1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
+
+    1. In [establishing the RP ID](#GetAssn-DetermineRpId):
+        1. If <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
+            [=is not a registrable domain suffix of and is not equal to=] |effectiveDomain|,
+            instead of running the [$related origins validation procedure$],
+            verify that <code>|pkOptions|.{{PublicKeyCredentialRequestOptions/rpId}}</code>
+            [=is a registrable domain suffix of or is equal to=] |remoteOrigin|.
+            1. If this check fails, throw a "{{SecurityError}}" {{DOMException}}.
+
+    1. In the step that constructs |clientDataJSON| from |collectedClientData|,
+        set |clientDataJSON| to |remoteClientDataJSON| instead.
+        1. The [=user agent=] MUST NOT add, remove, or modify any contents of |remoteClientDataJSON|,
+            as doing so would invalidate the remote machine's calculated |clientDataJSON|,
+            resulting in a signature mismatch at the [=[RP]=].
 
 : Authenticator extension input
 :: None
@@ -8705,6 +8731,7 @@ If designing a solution where the [=authenticator=] does not need to be physical
 or where [=client=] and [=authenticator=] do not communicate directly,
 designers SHOULD consider how this affects the enforcement of [=scope=] restrictions
 and the strength of the [=authenticator=] as a [=something you have=] authentication factor.
+
 
 ## Security considerations for [=authenticators=] <span id="sctn-attestation-security-considerations"></span> ## {#sctn-security-considerations-authenticator}
 <!-- Note: the above <span> is there to preserve the #sctn-attestation-security-considerations anchor although the section it was

--- a/index.bs
+++ b/index.bs
@@ -1,4 +1,4 @@
-<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
+﻿<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
 Notes:
 * the h1 tag is spec title that is rendered within the document window. Wrapping
   may be controlled with break tags.  The spec 'Level' value is not appended.
@@ -8800,9 +8800,9 @@ alters the trust model of the [=Web Authentication API=] in the following ways:
     If content running in the [=Remote desktop web client=] origin can influence the
     |remoteClientDataJSON| value, it could cause assertions valid for an unintended [=[RP]=] to be produced.
 
-- **Per-origin grant required:** For the above reasons, [=user agents=] MUST NOT grant this
-    permission globally to all origins. The permission MUST be restricted on a per-origin basis
-    via [=user agent=] policy.
+- **Per-origin configuration mechanism required:** As this extension's permissions are per origin,
+    [=user agents=] MUST only provide configuration mechanisms which are per-origin basis
+    via [=user agent=] policy (e.g. UA settings or enterprise policy).
 
 [=User agents=] that grant this extension SHOULD clearly communicate to users when a
 remote-desktop-proxied WebAuthn operation is in progress, so that users understand

--- a/index.bs
+++ b/index.bs
@@ -1,4 +1,4 @@
-<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
+﻿<!--   ***********  Web Authentication - Level 3 - Spec source file ***********
 Notes:
 * the h1 tag is spec title that is rendered within the document window. Wrapping
   may be controlled with break tags.  The spec 'Level' value is not appended.
@@ -7835,7 +7835,7 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
         1. Skip checking whether <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
             [=is a registrable domain suffix of or is equal to=] |remoteOrigin| or not.
 
-            Note: This means the local client is delegating all the [=RP ID=] related origin checks to the remote client.
+            Note: This means that the local client is delegating all the [=RP ID=] related origin checks to the remote client.
 
     1. Skip [constructing collectedClientData](#CreateCred-ConstructCollectedClientData) step.
         1. |collectedClientData| has been parsed from given |remoteClientDataJSON| in [establishing the RP ID](#CreateCred-DetermineRpId).
@@ -7868,7 +7868,7 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
         1. Skip checking whether <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
             [=is a registrable domain suffix of or is equal to=] |remoteOrigin| or not.
 
-            Note: This means the local client is delegating all the [=RP ID=] related origin checks to the remote client.
+            Note: This means that the local client is delegating all the [=RP ID=] related origin checks to the remote client.
 
     1. Skip [constructing collectedClientData](#GetAssn-ConstructCollectedClientData) step.
         1. |collectedClientData| has been parsed from given |remoteClientDataJSON| in [establishing the RP ID](#GetAssn-DetermineRpId).

--- a/index.bs
+++ b/index.bs
@@ -7830,7 +7830,7 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
             1. Throw a "{{NotAllowedError}}" {{DOMException}}.
         1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=]
             given |remoteClientDataJSON|.
-            1. If above parsing step fails, throw a "{{NotSupportedError}}" {{DOMException}}.
+            1. If above parsing step fails, throw a "{{EncodingError}}" {{DOMException}}.
         1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
         1. If <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
             [=is not a registrable domain suffix of and is not equal to=] |remoteOrigin|, and if the client


### PR DESCRIPTION
Closes #1577

Use Case:
Remote desktop web applications let users interact with the (native) desktop environment of a remote host from a local client (web) application.

A user may want to use a WebAuthn authenticator connected to their local client in order to sign into a website in a browser running on a remote host.

This is based on https://github.com/w3c/webauthn/wiki/Explainer:-Remote-Desktop-Support which is already present in some form in chromium code base. 

Based on feedback and use case scenario, this proposal solves the double clientData calculation issue and returns remoteDesktopClientOrigin to the RP as part of client/Authenticator extension.

<!-- Remove the following for non-normative changes -->

The following tasks have been completed:

- [ ] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/))

Implementation commitment:

- [ ] WebKit ([link to issue](https://bugs.webkit.org/))
- [ ] Chromium ([link to issue](https://issues.chromium.org/issues/new?component=1456855&template=0))
- [ ] Gecko ([link to issue](https://bugzilla.mozilla.org/home))

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Explainer ([link](https://github.com/w3c/webauthn/wiki/Explainer:-Remote-Desktop-Support))


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 24, 2026, 3:59 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebauthn%2F52a5b1156bba3012711d9b1cf2d59e784033fe43%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "2063:21",
        "messageType": "fatal",
        "text": "Tried to auto-close a <li>, but there were unclosed elements remaining before the nearest matching start tag (at 1919:5).\nOpen tags: <div> at 1697:1, <li> at 1919:5, <dl> at 1922:9"
    },
    {
        "lineNum": "8673",
        "messageType": "warning",
        "text": "The heading 'Well-Known URI Registration' needs a manually-specified ID."
    },
    {
        "lineNum": "8493:5",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"8493:5\" data-dfn-type=\"dfn\" id=\"set-user-verified-parameters\" data-lt=\"Set User Verified Parameters\" data-noexport=\"by-default\" class=\"dfn-paneled\">Set User Verified Parameters</dfn>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/webauthn%232375.)._

</details>
