### PR TITLE
Add .well-known/webauthn registration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8489,8 +8489,7 @@ This section registers the below-listed [=extension identifier=] values, newly d
 ## Well-Known URI Registration
 
 This section registers the following well-known URI in the
-IANA "Well-Known URIs" registry [[!IANA-Well-Known-URIs]]
-established by [[RFC5785]].
+IANA "Well-Known URIs" registry [[!IANA-Well-Known-URIs]].
 
 - URI Suffix: <code>webauthn</code>
 - Reference: Section [[#sctn-validating-relation-origin]] of this specification


### PR DESCRIPTION
Registers `.well-known/webauthn`, addressing the comment https://github.com/w3c/transitions/issues/753#issuecomment-3719811000


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2376.html" title="Last updated on Jan 7, 2026, 10:00 PM UTC (ddde943)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2376/b668301...ddde943.html" title="Last updated on Jan 7, 2026, 10:00 PM UTC (ddde943)">Diff</a>