### PR TITLE
Add JSON object properties table to Set User Verified virtual authenticator endpoint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8344,7 +8344,11 @@ It contains the following |key| and |value| pairs:
         <tbody>
             <tr>
                 <td>|isUserVerified|</td>
-                <td>Determines the [=authData/flags/UV|UV flag=] in [=authenticator data=] in the [=Virtual Authenticator|Virtual Authenticator's=] response.</td>
+                <td>
+                    Determines the result of [=User Verification=] performed on the
+                    [=Virtual Authenticator=]. If set to [TRUE], [=User Verification=] will always
+                    succeed. If set to [FALSE], it will fail.
+                </td>
                 <td>boolean</td>
             </tr>
         </tbody>

--- a/index.bs
+++ b/index.bs
@@ -8329,6 +8329,28 @@ is defined as follows:
     </table>
 </figure>
 
+The <dfn>Set User Verified Parameters</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|.
+It contains the following |key| and |value| pairs:
+
+<figure id="table-setCredentialPropertiesParameters" class="table">
+    <table class="data">
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Description</th>
+                <th>Value Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>|isUserVerified|</td>
+                <td>Determines the [=authData/flags/UV|UV flag=] in [=authenticator data=] in the [=authenticator|authenticator's=] response.</td>
+                <td>boolean</td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
+
 The [=remote end steps=] are:
 
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]

--- a/index.bs
+++ b/index.bs
@@ -8344,7 +8344,7 @@ It contains the following |key| and |value| pairs:
         <tbody>
             <tr>
                 <td>|isUserVerified|</td>
-                <td>Determines the [=authData/flags/UV|UV flag=] in [=authenticator data=] in the [=authenticator|authenticator's=] response.</td>
+                <td>Determines the [=authData/flags/UV|UV flag=] in [=authenticator data=] in the [=Virtual Authenticator|Virtual Authenticator's=] response.</td>
                 <td>boolean</td>
             </tr>
         </tbody>

--- a/index.bs
+++ b/index.bs
@@ -8332,7 +8332,7 @@ is defined as follows:
 The <dfn>Set User Verified Parameters</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|.
 It contains the following |key| and |value| pairs:
 
-<figure id="table-setCredentialPropertiesParameters" class="table">
+<figure id="table-setUserVerifiedParameters" class="table">
     <table class="data">
         <thead>
             <tr>


### PR DESCRIPTION
This editorial PR adds a table describing the JSON object that must be `POST`'d to the **Set User Verified** virtual authenticator endpoint:

<img width="869" height="610" alt="Screenshot 2026-01-26 at 3 43 16 PM" src="https://github.com/user-attachments/assets/10c6a452-52e7-4386-960b-41a8d05be345" />

No normative behavior changes are included in this PR. This simply aims to update this endpoint's description to be in line with other endpoints like **Add Virtual Authenticator**, **Add Credential**, and **Set Credential Properties** that describe the shape of their JSON object parameters.