### PR TITLE
Fix single quote misinterpreted as possessive/contraction apostrophe

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9197,7 +9197,7 @@ may contain additional, usually constant, data not mentioned explicitly in the p
 
 All random values are deterministically generated using HKDF-SHA-256 [[RFC5869]]
 from the base input key material denoted in CDDL as `'WebAuthn test vectors'`,
-or equivalently as `h'576562417574686e207465737420766563746f7273'`.
+or equivalently as <code>h&apos;576562417574686e207465737420766563746f7273'</code>.
 ECDSA signatures use a deterministic nonce [[RFC6979]].
 The RSA key in the examples is constructed from the two smallest Mersenne primes 2<sup>p</sup> - 1 such that p &ge; 1024.
 


### PR DESCRIPTION
Before:

<img width="116" height="70" alt="image" src="https://github.com/user-attachments/assets/4aa22bf3-0c5b-454f-bd3b-e66c23f12fa9" />

After:
<img width="113" height="71" alt="image" src="https://github.com/user-attachments/assets/02d3548e-c0b8-4e37-a654-5bbc2fb75e22" />


