### PR TITLE
Restore inadvertently overwritten change to '[=RP ID=]'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9051,7 +9051,7 @@ provide clear context to the user by displaying both:
 - The caller's origin: The [=origin=] of the [=fully active=] document that is invoking `navigator.credentials`
 - The Relying Party ID: The [=RP ID=] for which the credential was originally created or will be created
 
-For example, given the Relying Party ID `exampleA.com` with a calling origin of `https://otherExampleB.com`,
+For example, given the [=RP ID=] `exampleA.com` with a calling origin of `https://otherExampleB.com`,
 a [=WebAuthn client=] and/or [=client platform=] could show the user:
 "Sign in to otherExampleB.com with your passkey for exampleA.com?"
 


### PR DESCRIPTION
This change in dc655cd0a199deae17cea9eedf4617823192664d was inadvertently overwritten in fabee8ee0290c01280090d8e4d77afe507d1c937.
