### PR TITLE
Bikeshed lint: Set section ID for "Well-Known URI Registration"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8492,7 +8492,8 @@ This section registers the below-listed [=extension identifier=] values, newly d
 - Description: This [=client extension|client=] [=registration extension=] and [=authentication extension=] allows a [=[RP]=] to store opaque data associated with a credential.
 - Specification Document: Section [[#sctn-large-blob-extension]] of this specification
 
-## Well-Known URI Registration
+
+## Well-Known URI Registration # {#sctn-well-known-uri-reg}
 
 This section registers the following well-known URI in the
 IANA "Well-Known URIs" registry [[!IANA-Well-Known-URIs]].

--- a/index.bs
+++ b/index.bs
@@ -8493,7 +8493,7 @@ This section registers the below-listed [=extension identifier=] values, newly d
 - Specification Document: Section [[#sctn-large-blob-extension]] of this specification
 
 
-## Well-Known URI Registration # {#sctn-well-known-uri-reg}
+## Well-Known URI Registration ## {#sctn-well-known-uri-reg}
 
 This section registers the following well-known URI in the
 IANA "Well-Known URIs" registry [[!IANA-Well-Known-URIs]].


### PR DESCRIPTION
Fixes the following Bikeshed lint:

```
LINE 8492: The heading 'Well-Known URI Registration' needs a manually-specified ID.
```

This will break any existing references to the current `#well-known-uri-registration` anchor in the editor's draft, which is also the anchor in CR-webauthn-3-20260113.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 23, 2026, 1:42 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebauthn%2F06c478273e09539d72fa128744ba198574ec8544%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "2060:21",
        "messageType": "fatal",
        "text": "Tried to auto-close a <li>, but there were unclosed elements remaining before the nearest matching start tag (at 1916:5).\nOpen tags: <div> at 1698:1, <li> at 1916:5, <dl> at 1919:9"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/webauthn%232420.)._

</details>
