### PR TITLE
remoteClientDataJSONCorrection Typos/Inconsistencies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7863,7 +7863,7 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
             1. Throw a "{{NotAllowedError}}" {{DOMException}}.
         1. Let |collectedClientData| be the result of [=parse a JSON string to an Infra value=]
             given |remoteClientDataJSON|.
-            1. If above parsing step fails, throw a "{{NotSupportedError}}" {{DOMException}}.
+            1. If above parsing step fails, throw a "{{EncodingError}}" {{DOMException}}.
         1. Let |remoteOrigin| be the value of the `"origin"` key of |collectedClientData|.
         1. Skip checking whether <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}.{{PublicKeyCredentialRpEntity/id}}</code>
             [=is a registrable domain suffix of or is equal to=] |remoteOrigin| or not.
@@ -7895,10 +7895,10 @@ This permission MUST be configured per-origin and MUST NOT offer the capability 
 :: Returns the value [TRUE] to indicate to the [=[RP]=] that the extension was acted upon.
     <xmp class="idl">
     partial dictionary AuthenticationExtensionsClientOutputs {
-      boolean remoteClientDataJson;
+      boolean remoteClientDataJSON;
     };
     partial dictionary AuthenticationExtensionsClientOutputsJSON {
-      boolean remoteClientDataJson;
+      boolean remoteClientDataJSON;
     };
     </xmp>
 


### PR DESCRIPTION
Closes #2423 

### Fix 1: Be Consistent in casing of extension variable. 

### Fix 2: Be Consistent in JSON failure error between create() and Get(). Now both returns EncodingError


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 4, 2026, 4:10 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebauthn%2F2d45c892e7d41bd7cc8b0a54ad4b45be1cf22019%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "2063:21",
        "messageType": "fatal",
        "text": "Tried to auto-close a <li>, but there were unclosed elements remaining before the nearest matching start tag (at 1919:5).\nOpen tags: <div> at 1697:1, <li> at 1919:5, <dl> at 1922:9"
    },
    {
        "lineNum": "8673",
        "messageType": "warning",
        "text": "The heading 'Well-Known URI Registration' needs a manually-specified ID."
    },
    {
        "lineNum": "8493:5",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"8493:5\" data-dfn-type=\"dfn\" id=\"set-user-verified-parameters\" data-lt=\"Set User Verified Parameters\" data-noexport=\"by-default\" class=\"dfn-paneled\">Set User Verified Parameters</dfn>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/webauthn%232424.)._

</details>
