### PR TITLE
Editorial tweaks to PR #2377

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7931,7 +7931,7 @@ A <dfn>CMTG Key Record</dfn> is a [=struct=] with the following [=struct/items=]
 
 <dl dfn-for="CMTG Key Record" dfn-type="abstract-op">
     : <dfn>publicKey</dfn>
-    :: The [=Credential Manager Trust Group public key|CMTG public key=]
+    :: The [=Credential Manager Trust Group public key|CMTG public key=].
 
     : <dfn>lastUsed</dfn>
     :: A timestamp representing the last time this specific key was verified by the [=Relying Party=].
@@ -8024,7 +8024,7 @@ A <dfn>CMTG Key Record</dfn> is a [=struct=] with the following [=struct/items=]
     1. Let |cmtgKeySig| be the result of signing the [=assertion signature=] [input](#fig-signature) with |cmtgPrivateKey|,
         using the same signature algorithm as that used by the [=user credential=]'s [=credential key pair=].
 
-         Note: the [=assertion signature=] [input](#fig-signature) and |cmtgKeySig| covers the [=[RP]=]'s {{PublicKeyCredentialCreationOptions/challenge}}
+         Note: The [=assertion signature=] [input](#fig-signature) and |cmtgKeySig| covers the [=[RP]=]'s {{PublicKeyCredentialCreationOptions/challenge}}
           because it includes the [=hash of the serialized client data=]. Thus the [=[RP]=] knows that |cmtgKeySig| is a fresh signature.
 
     1. Output |cmtgPublicKey| as the [=authenticator extension output=].
@@ -8050,9 +8050,9 @@ using these variables established therein: |credential|, |clientExtensionResults
 1. Let |extensionOutput| be the value of the {{AuthenticationExtensionsClientOutputs/cmtgKey}} member of |clientExtensionResults|.
 
 1. If |extensionOutput| does not contain the required members of {{AuthenticationExtensionsCmtgKeyOutputs}},
-    Terminate this `cmtgKey` validation algorithm.
+    terminate this `cmtgKey` validation algorithm.
 
-    NOTE: [=[RP]=]s MUST ignore any keys in |extensionOutput| that are not defined in the {{AuthenticationExtensionsCmtgKeyOutputs}} dictionary.
+    NOTE: [=[RPS]=] MUST ignore any keys in |extensionOutput| that are not defined in the {{AuthenticationExtensionsCmtgKeyOutputs}} dictionary.
 
 1. Let |signature| be |extensionOutput|.{{AuthenticationExtensionsCmtgKeyOutputs/signature}}.
     Verify that |signature| is a valid ArrayBuffer.
@@ -8064,13 +8064,13 @@ using these variables established therein: |credential|, |clientExtensionResults
     within the [=attestedCredentialData=] of |authData|.
 
 1. Verify that |signature| is a valid signature over the [=assertion signature=] [input](#fig-signature)
-    (i.e. `authData` and `hash`) by the [=Credential Manager Trust Group Key=] |cmtgKey|.
+    (i.e. |authData| and |hash|) by the [=Credential Manager Trust Group Key=] |cmtgKey|.
 
 1. If the remaining steps of [[#sctn-registering-a-new-credential]] are successful:
     
     1. Let |newEntry| be a new [=CMTG Key Record=] where its [$CMTG Key Record/publicKey$] is |cmtgKey|
         and its [$CMTG Key Record/lastUsed$] is the [=[RP]=]'s current time.
-    1. Append |newEntry| to |credentialRecord|.[$credential record/cmtgKeyRecords$]
+    1. Append |newEntry| to |credentialRecord|.[$credential record/cmtgKeyRecords$].
 
 See also [[#sctn-cmtg-key-extension-usage]] for further details.
 
@@ -8079,19 +8079,19 @@ See also [[#sctn-cmtg-key-extension-usage]] for further details.
 If the `cmtgKey` extension was included on a {{CredentialsContainer/get()|navigator.credentials.get()}} call,
 then the below verification steps are performed in the context of <a href=#authn-ceremony-verify-extension-outputs>this step</a> of [[#sctn-verifying-assertion]]
 using these variables established therein: |credential|, |clientExtensionResults|, |authData|, and |hash|. 
-[=[RP]=] policy may specify whether a response without a `cmtgKey` is acceptable.
+[=[RP]=] policy may specify whether a response without a {{AuthenticationExtensionsClientOutputs/cmtgKey}} is acceptable.
 
 1. Let |credentialRecord| be the [=credential record=] for the [=credential=].
 
 1. Let |extensionOutput| be the value of the {{AuthenticationExtensionsClientOutputs/cmtgKey}} member of |clientExtensionResults|.
 
-1. If |extensionOutput| is not present or does not contain the required members of {{AuthenticationExtensionsCmtgKeyOutputs}}
+1. If |extensionOutput| is not present or does not contain the required members of {{AuthenticationExtensionsCmtgKeyOutputs}}:
 
     1. Optionally, perform additional policy checks.
 
     1. Terminate this `cmtgKey` validation algorithm.
 
-    NOTE: [=[RP]=]s MUST ignore any keys in |extensionOutput| that are not defined in the {{AuthenticationExtensionsCmtgKeyOutputs}} dictionary.
+    NOTE: [=[RPS]=] MUST ignore any keys in |extensionOutput| that are not defined in the {{AuthenticationExtensionsCmtgKeyOutputs}} dictionary.
 
 1. Let |signature| be |extensionOutput|.{{AuthenticationExtensionsCmtgKeyOutputs/signature}}.
     Verify that |signature| is a valid ArrayBuffer.

--- a/index.bs
+++ b/index.bs
@@ -7929,7 +7929,7 @@ the [=credential record=] structure SHOULD be augmented with the following field
 
 A <dfn>CMTG Key Record</dfn> is a [=struct=] with the following [=struct/items=]:
 
-<dl dfn-for="CMTG Key Record">
+<dl dfn-for="CMTG Key Record" dfn-type="abstract-op">
     : <dfn>publicKey</dfn>
     :: The [=Credential Manager Trust Group public key|CMTG public key=]
 
@@ -8068,8 +8068,8 @@ using these variables established therein: |credential|, |clientExtensionResults
 
 1. If the remaining steps of [[#sctn-registering-a-new-credential]] are successful:
     
-    1. Let |newEntry| be a new [=CMTG Key Record=] where its [=CMTG Key Record/publicKey=] is |cmtgKey|
-        and its [=CMTG Key Record/lastUsed=] is the [=[RP]=]'s current time.
+    1. Let |newEntry| be a new [=CMTG Key Record=] where its [$CMTG Key Record/publicKey$] is |cmtgKey|
+        and its [$CMTG Key Record/lastUsed$] is the [=[RP]=]'s current time.
     1. Append |newEntry| to |credentialRecord|.[$credential record/cmtgKeyRecords$]
 
 See also [[#sctn-cmtg-key-extension-usage]] for further details.
@@ -8107,11 +8107,11 @@ using these variables established therein: |credential|, |clientExtensionResults
     (The signature algorithm is the same as for the [=user credential=].)
 
 1. If |credentialRecord|.[$credential record/cmtgKeyRecords$] contains an entry |e|
-    where |e|.[=CMTG Key Record/publicKey=] matches |cmtgKey|:
+    where |e|.[$CMTG Key Record/publicKey$] matches |cmtgKey|:
 
     The [=authenticator=]/[=credential manager=] is part of a previously seen trust group.
 
-    1. Update |e|.[=CMTG Key Record/lastUsed=] to the current time.
+    1. Update |e|.[$CMTG Key Record/lastUsed$] to the current time.
 
 1. Otherwise:
 
@@ -8119,8 +8119,8 @@ using these variables established therein: |credential|, |clientExtensionResults
 
     1. Optionally, perform additional policy checks.
     
-    1. Let |newEntry| be a new [=CMTG Key Record=] where its [=CMTG Key Record/publicKey=] is |cmtgKey|
-        and its [=CMTG Key Record/lastUsed=] is the current time.
+    1. Let |newEntry| be a new [=CMTG Key Record=] where its [$CMTG Key Record/publicKey$] is |cmtgKey|
+        and its [$CMTG Key Record/lastUsed$] is the current time.
 
     1. Append |newEntry| to |credentialRecord|.[$credential record/cmtgKeyRecords$].
 

--- a/index.bs
+++ b/index.bs
@@ -7996,7 +7996,7 @@ A <dfn>CMTG Key Record</dfn> is a [=struct=] with the following [=struct/items=]
 
     ```
     $$extensionOutput //= (
-        cmtgKey: bstr,
+        cmtgKey: bstr .cbor COSE_Key,
     )
     ```
 

--- a/index.bs
+++ b/index.bs
@@ -7927,13 +7927,13 @@ the [=credential record=] structure SHOULD be augmented with the following field
     ::  A [=list=] of [=CMTG Key Records=], initially empty.
 </dl>
 
-A <dfn id="cmtgKeyRecord">CMTG Key Record</dfn> is a [=struct=] with the following [=struct/items=]:
+A <dfn>CMTG Key Record</dfn> is a [=struct=] with the following [=struct/items=]:
 
 <dl dfn-for="CMTG Key Record">
-    : <dfn id="cmtgKeyRecordPublicKey">publicKey</dfn>
+    : <dfn>publicKey</dfn>
     :: The [=Credential Manager Trust Group public key|CMTG public key=]
 
-    : <dfn id="cmtgKeyRecordLastUsed">lastUsed</dfn>
+    : <dfn>lastUsed</dfn>
     :: A timestamp representing the last time this specific key was verified by the [=Relying Party=].
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -7775,7 +7775,7 @@ in the [=authenticator=], if such a key pair needs to be created for the
 and returning one of the [=Credential Manager Trust Group public keys=]
 along with a signature by the [=Credential Manager Trust Group private key=] to the [=[RP]=].
 
-This is done each time this [=cmtgKey=] extension is included with either a 
+This is done each time this [=cmtgKey=] extension is requested in either a
 {{CredentialsContainer/create()|navigator.credentials.create()}} or {{CredentialsContainer/get()|navigator.credentials.get()}} call.
 
 #### Relying Party Usage #### {#sctn-cmtg-key-extension-usage}
@@ -8040,14 +8040,13 @@ Verifying the <code>[=cmtgKey=]</code> extension output is performed by the [=[R
 
 ##### Registration (`create()`) ##### {#sctn-cmtg-key-extension-verification-create}
 
-If the `cmtgKey` extension was included on a {{CredentialsContainer/create()|navigator.credentials.create()}} call
-and a [=Credential Manager Trust Group Key=] is returned by an [=authenticator=],
+If a {{AuthenticationExtensionsClientOutputs/cmtgKey}} extension output is present in a {{CredentialsContainer/create()|navigator.credentials.create()}} call,
 the below verification steps are performed in the context of <a href=#reg-ceremony-verify-extension-outputs>this step</a> of [[#sctn-registering-a-new-credential]]
 using these variables established therein: |credential|, |clientExtensionResults|, |authData|, and |hash|. 
 
-1. Let |credentialRecord| be the [=credential record=] for the [=credential=].
+1. Let |credentialRecord| be the [=credential record=] for |credential|.
 
-1. Let |extensionOutput| be the value of the {{AuthenticationExtensionsClientOutputs/cmtgKey}} member of |clientExtensionResults|.
+1. Let |extensionOutput| be the value of <code>|clientExtensionResults|.{{AuthenticationExtensionsClientOutputs/cmtgKey}}</code>.
 
 1. If |extensionOutput| does not contain the required members of {{AuthenticationExtensionsCmtgKeyOutputs}},
     terminate this `cmtgKey` validation algorithm.
@@ -8076,14 +8075,14 @@ See also [[#sctn-cmtg-key-extension-usage]] for further details.
 
 ##### Authentication (`get()`) ##### {#sctn-cmtg-key-extension-verification-get}
 
-If the `cmtgKey` extension was included on a {{CredentialsContainer/get()|navigator.credentials.get()}} call,
+If a {{AuthenticationExtensionsClientOutputs/cmtgKey}} extension output is present in a {{CredentialsContainer/get()|navigator.credentials.get()}} call,
 then the below verification steps are performed in the context of <a href=#authn-ceremony-verify-extension-outputs>this step</a> of [[#sctn-verifying-assertion]]
 using these variables established therein: |credential|, |clientExtensionResults|, |authData|, and |hash|. 
 [=[RP]=] policy may specify whether a response without a {{AuthenticationExtensionsClientOutputs/cmtgKey}} is acceptable.
 
-1. Let |credentialRecord| be the [=credential record=] for the [=credential=].
+1. Let |credentialRecord| be the [=credential record=] for |credential|.
 
-1. Let |extensionOutput| be the value of the {{AuthenticationExtensionsClientOutputs/cmtgKey}} member of |clientExtensionResults|.
+1. Let |extensionOutput| be the value of <code>|clientExtensionResults|.{{AuthenticationExtensionsClientOutputs/cmtgKey}}</code>.
 
 1. If |extensionOutput| is not present or does not contain the required members of {{AuthenticationExtensionsCmtgKeyOutputs}}:
 


### PR DESCRIPTION
This is a meta-PR that would merge into #2377, not directly to main.

I propose some fairly straightforward editorial tweaks:

- I don't think we need the `id` attributes for these `<dfn>`s, so we can delete them.
- "credential record" uses `dfn-type="abstract-op"`, so let's use the same `dfn-type` for the extensions to "credential record".
- Various tweaks to punctuation, capitalization etc.
- We can use the [`.cbor` control operator](https://datatracker.ietf.org/doc/html/rfc8610#section-3.8.4) to indicate that the `cmtgKey` output should contain CBOR matching the COSE_Key type.
- A couple of phrasing tweaks to make the text a bit more concise and precise.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 13, 2026, 2:22 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebauthn%2F3238904ba7186bf82876f9163a941b48a391b1dc%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "2074:21",
        "messageType": "fatal",
        "text": "Tried to auto-close a <li>, but there were unclosed elements remaining before the nearest matching start tag (at 1930:5).\nOpen tags: <div> at 1712:1, <li> at 1930:5, <dl> at 1933:9"
    },
    {
        "lineNum": "8863",
        "messageType": "warning",
        "text": "The heading 'Well-Known URI Registration' needs a manually-specified ID."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/webauthn%232426.)._

</details>
