### PR TITLE
chore: removing type attribute for HTML validation during spec generation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -81,7 +81,7 @@ Markup Shorthands: css off, markdown on, macros-in-autolinks yes
 Implementation Report: https://www.w3.org/2020/12/webauthn-report.html
 </pre>
 
-<style type="text/css">
+<style>
 body {
     counter-reset: table;
 }


### PR DESCRIPTION
if we have it, we fail HTML validation


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 15, 2026, 10:59 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebauthn%2F95da78dc1ebb19fc26e1da3af75fd719ad7c7f62%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "2063:21",
        "messageType": "fatal",
        "text": "Tried to auto-close a <li>, but there were unclosed elements remaining before the nearest matching start tag (at 1919:5).\nOpen tags: <div> at 1697:1, <li> at 1919:5, <dl> at 1922:9"
    },
    {
        "lineNum": "8673",
        "messageType": "warning",
        "text": "The heading 'Well-Known URI Registration' needs a manually-specified ID."
    },
    {
        "lineNum": "8493:5",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"8493:5\" data-dfn-type=\"dfn\" id=\"set-user-verified-parameters\" data-lt=\"Set User Verified Parameters\" data-noexport=\"by-default\" class=\"dfn-paneled\">Set User Verified Parameters</dfn>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/webauthn%232429.)._

</details>
