### PR TITLE
Upgrade to Bikeshed 7

### DIFF
--- a/.github/workflows/build-validate-publish.yml
+++ b/.github/workflows/build-validate-publish.yml
@@ -9,8 +9,8 @@ jobs:
     name: Build, Validate, and Publish
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: w3c/spec-prod@v2.12.2
+      - uses: actions/checkout@v7
+      - uses: w3c/spec-prod@v2.13.2
         with:
           GH_PAGES_BRANCH: gh-pages
           BUILD_FAIL_ON: nothing

--- a/index.bs
+++ b/index.bs
@@ -2058,19 +2058,19 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                     1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
 
-                1. <span id="CreateCred-InvokeAuthnrMakeCred">
-                    <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
-                    Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
-                        |clientDataHash|,
-                        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
-                        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
-                        |requireResidentKey|,
-                        |userVerification|,
-                        |credTypesAndPubKeyAlgs|,
-                        |excludeCredentialDescriptorList|,
-                        |enterpriseAttestationPossible|,
-                        |attestationFormats|,
-                        and |authenticatorExtensions| as parameters.</span>
+                    1. <span id="CreateCred-InvokeAuthnrMakeCred">
+                        <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
+                        Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
+                            |clientDataHash|,
+                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
+                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
+                            |requireResidentKey|,
+                            |userVerification|,
+                            |credTypesAndPubKeyAlgs|,
+                            |excludeCredentialDescriptorList|,
+                            |enterpriseAttestationPossible|,
+                            |attestationFormats|,
+                            and |authenticatorExtensions| as parameters.</span>
 
                 1. [=set/Append=] |authenticator| to |issuedRequests|.
 

--- a/index.bs
+++ b/index.bs
@@ -2059,6 +2059,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                     1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
 
                 1. <span id="CreateCred-InvokeAuthnrMakeCred">
+                    <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
                     Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
                         |clientDataHash|,
                         <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,

--- a/index.bs
+++ b/index.bs
@@ -258,6 +258,7 @@ spec:url; type:dfn; for:url; text:host
 spec:url; type:dfn; text:valid domain;
 spec:webidl; type:dfn; text:DOMString
 spec:webidl; type:interface; text:Promise
+spec:fido-client-to-authenticator-protocol-v2.1; type:dfn; text:ctap2 canonical cbor encoding form
 </pre>
 
 
@@ -2057,23 +2058,18 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                     1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
 
-                <!-- Note: this next step is actually a step on the same level as the above, but bikeshed wanted it indented this much
-                in order to render it as a numbered step. If outdented, it (today) is rendered either as a bullet in the midst
-                of a numbered list or is mis-numbered -->
-                    <li id='CreateCred-InvokeAuthnrMakeCred'>
-                        <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
-                        Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
-                            |clientDataHash|,
-                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
-                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
-                            |requireResidentKey|,
-                            |userVerification|,
-                            |credTypesAndPubKeyAlgs|,
-                            |excludeCredentialDescriptorList|,
-                            |enterpriseAttestationPossible|,
-                            |attestationFormats|,
-                            and |authenticatorExtensions| as parameters.
-                    </li>
+                1. <span id="CreateCred-InvokeAuthnrMakeCred">
+                    Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
+                        |clientDataHash|,
+                        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
+                        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
+                        |requireResidentKey|,
+                        |userVerification|,
+                        |credTypesAndPubKeyAlgs|,
+                        |excludeCredentialDescriptorList|,
+                        |enterpriseAttestationPossible|,
+                        |attestationFormats|,
+                        and |authenticatorExtensions| as parameters.</span>
 
                 1. [=set/Append=] |authenticator| to |issuedRequests|.
 
@@ -8520,6 +8516,8 @@ The [=remote end steps=] are:
 
  1. If |parameters| is not a JSON [=Object=], return a [=WebDriver error=] with [=WebDriver error code=]
      [=invalid argument=].
+    
+     Note: |parameters| is a [=Set User Verified Parameters=] object.
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
      Database=], return a [=WebDriver error=] with [=WebDriver error code=] [=invalid argument=].
  1. If |isUserVerified| is not a defined property of |parameters|, return a [=WebDriver error=] with [=WebDriver error code=]
@@ -8673,7 +8671,7 @@ This section registers the below-listed [=extension identifier=] values, newly d
 - Description: This [=client extension|client=] [=registration extension=] and [=authentication extension=] allows a [=[RP]=] to store opaque data associated with a credential.
 - Specification Document: Section [[#sctn-large-blob-extension]] of this specification
 
-## Well-Known URI Registration
+## Well-Known URI Registration ## {#sctn-well-known-uri-registration}
 
 This section registers the following well-known URI in the
 IANA "Well-Known URIs" registry [[!IANA-Well-Known-URIs]].


### PR DESCRIPTION
About a month ago `bikeshed==5.4.2`, which we've been currently stuck on, stopped being able to build the spec. After digging into this, I found out it's because a recent change to https://github.com/speced/bikeshed-data on June 9th [significantly changed the structure of metadata](https://github.com/speced/bikeshed-data/commit/9bca02f0da0074c26035edb16b2fc8d44111f973) that Bikeshed relied on, so Bikeshed 5 didn't know how to find any of the .include files it needs to build.

This seemed like as good a time as any to try and unblock our migration to the latest Bikeshed. This PR contains changes that finally allow us to use Bikeshed 7 (and hopefully beyond.)

BTW, Bikeshed told me I could refer to CTAP 2.1 or 2.2 for "ctap2 canonical cbor encoding form" links. I picked 2.1 because I figured CBOR encoding hasn't really changed all that much between 2.1 and 2.2. **Maybe we refer to CTAP 2.2 instead?**


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2442.html" title="Last updated on Jul 9, 2026, 1:01 PM UTC (89661cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2442/207cf99...89661cd.html" title="Last updated on Jul 9, 2026, 1:01 PM UTC (89661cd)">Diff</a>