### PR TITLE
Adds mise to local tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 index.html
 .DS_Store
 .vs/
+.venv/

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,33 @@
+[tools]
+python = "3.13"
+
+[tasks."setup"]
+description = "Install dependencies into a local virtual environment"
+run = """
+python -m venv .venv
+./.venv/bin/pip install --upgrade pip
+./.venv/bin/pip install "bikeshed>=7.1.1" "pip>=26.1.2"
+touch .venv/.mise-setup-done
+"""
+sources = ["pyproject.toml"]
+outputs = [".venv/.mise-setup-done"]
+
+[tasks."update"]
+description = "Update bikeshed"
+depends = ["setup"]
+run = "./.venv/bin/python -m bikeshed update"
+
+[tasks."build"]
+description = "Build the formatted HTML specification"
+depends = ["setup"]
+run = "./.venv/bin/python -m bikeshed spec"
+
+[tasks."watch"]
+description = "Watch for changes and automatically regenerate the document"
+depends = ["setup"]
+run = "./.venv/bin/python -m bikeshed watch"
+
+[tasks."serve"]
+description = "Serve the rendered document locally at http://127.0.0.1:8000"
+depends = ["setup"]
+run = "./.venv/bin/python -m http.server -b 127.0.0.1"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To materially contribute to this specification, you must meet the requirements o
 
 # Building the Draft
 
+(see the next section if you use `mise`)
+
 The following are required before continuing:
 
 - Python 3.13
@@ -47,6 +49,26 @@ Running the following command from the root of this repo will let you view the r
 ```
 uv run -m http.server -b 127.0.0.1
 ```
+
+## Using mise
+
+If you use [mise](https://mise.jdx.dev/), run the following commands to set up your local development environment to work on these specifications:
+
+`mise run setup`
+
+`mise run update`
+
+Formatted HTML for the draft can then be built with the following command:
+
+`mise run build`
+
+You can use the `watch` functionality to automatically regenerate the rendered document as you make changes locally:
+
+`mise run watch`
+
+Running the following command from the root of this repo will let you view the rendered document at http://127.0.0.1:8000:
+
+`mise run serve`
 
 # Continuous Integration & Branches
 


### PR DESCRIPTION
Adds [mise](https://mise.jdx.dev/) to the local tooling options (in addition to `uv`).

Targeted to #2441 