### PR TITLE
Clarify that credentialId in Virtual Authenticator URLs is base64url encoded

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8426,6 +8426,8 @@ The [=Remove Credential=] WebDriver [=extension command=] removes a [=Public Key
     </table>
 </figure>
 
+Note: The `{credentialId}` in the URI Template is base64url encoded.
+
 The [=remote end steps=] are:
 
  1. If |authenticatorId| does not match any [=Virtual Authenticator=] stored in the [=Virtual Authenticator
@@ -8548,6 +8550,8 @@ a [=Virtual Authenticator=]'s [=public key credential source=]. It is defined as
         </tbody>
     </table>
 </figure>
+
+Note: The `{credentialId}` in the URI Template is base64url encoded.
 
 The <dfn>Set Credential Properties Parameters</dfn> is a JSON [=Object=] passed to the [=remote end steps=] as |parameters|.
 It contains the following |key| and |value| pairs:


### PR DESCRIPTION
This PR clarifies that the `{credentialId}` parameter in the URI Template for the Virtual Authenticator "Remove Credential" and "Set Credential Properties" extension commands is base64url encoded. 

This resolves the ambiguity for implementers parsing the URL path.

Fixes #2450


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/homayounmmdy/webauthn/pull/2451.html" title="Last updated on Jul 26, 2026, 5:26 PM UTC (4ae2026)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2451/e89aa62...homayounmmdy:4ae2026.html" title="Last updated on Jul 26, 2026, 5:26 PM UTC (4ae2026)">Diff</a>