### PR TITLE
Fix indentation of step to invoke authenticatorMakeCredential

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2058,19 +2058,19 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                     1. Otherwise, [=list/Append=] |C| to |excludeCredentialDescriptorList|.
 
-                    1. <span id="CreateCred-InvokeAuthnrMakeCred">
-                        <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
-                        Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
-                            |clientDataHash|,
-                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
-                            <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
-                            |requireResidentKey|,
-                            |userVerification|,
-                            |credTypesAndPubKeyAlgs|,
-                            |excludeCredentialDescriptorList|,
-                            |enterpriseAttestationPossible|,
-                            |attestationFormats|,
-                            and |authenticatorExtensions| as parameters.</span>
+                1. <span id="CreateCred-InvokeAuthnrMakeCred">
+                    <!-- @@EDITOR-ANCHOR-01: KEEP THIS LIST SYNC'D WITH OTHER LOCATIONS WITH THIS TAG -->
+                    Invoke the [=authenticatorMakeCredential=] operation on |authenticator| with
+                        |clientDataHash|,
+                        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/rp}}</code>,
+                        <code>|pkOptions|.{{PublicKeyCredentialCreationOptions/user}}</code>,
+                        |requireResidentKey|,
+                        |userVerification|,
+                        |credTypesAndPubKeyAlgs|,
+                        |excludeCredentialDescriptorList|,
+                        |enterpriseAttestationPossible|,
+                        |attestationFormats|,
+                        and |authenticatorExtensions| as parameters.</span>
 
                 1. [=set/Append=] |authenticator| to |issuedRequests|.
 


### PR DESCRIPTION
Fixes #2444.

This re-applies commit e239ee557e71232c034ff8e034582f1e231cf31f (PR #2027). It's unclear what re-broke this after that commit, but it may be a rendering difference between Bikeshed 5.4.2 and 7.x.

Tagging as both editorial and technical since this is technically a substantive change to the procedure definition, but it's mostly editorial since the current indentation is obviously incorrect (as identified in #2025 for example).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/pull/2470.html" title="Last updated on Aug 21, 2026, 8:25 AM UTC (cccacdc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webauthn/2470/146d0db...cccacdc.html" title="Last updated on Aug 21, 2026, 8:25 AM UTC (cccacdc)">Diff</a>